### PR TITLE
Added other usage descriptions for Camera usage

### DIFF
--- a/packages/ios/Avocado/Avocado/DocLinks.swift
+++ b/packages/ios/Avocado/Avocado/DocLinks.swift
@@ -10,5 +10,7 @@ import Foundation
 
 enum DocLinks: String {
   case NSPhotoLibraryAddUsageDescription = "https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW73"
+  case NSPhotoLibraryUsageDescription = "https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17"
+  case NSCameraUsageDescription = "https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24"
 }
 

--- a/packages/ios/Avocado/Avocado/Plugins/Camera.swift
+++ b/packages/ios/Avocado/Avocado/Plugins/Camera.swift
@@ -87,11 +87,23 @@ public class Camera : Plugin, UIImagePickerControllerDelegate, UINavigationContr
    */
   func checkUsageDescriptions() -> String? {
     if let dict = Bundle.main.infoDictionary {
-      let hasPhotoLibraryUsage = dict["NSPhotoLibraryAddUsageDescription"] != nil
-      if !hasPhotoLibraryUsage {
+      let hasPhotoLibraryAddUsage = dict["NSPhotoLibraryAddUsageDescription"] != nil
+      if !hasPhotoLibraryAddUsage {
         let docLink = DocLinks.NSPhotoLibraryAddUsageDescription
         return "You are missing NSPhotoLibraryAddUsageDescription in your Info.plist file." +
         " Camera will not function without it. Learn more: \(docLink.rawValue)"
+      }
+      let hasPhotoLibraryUsage = dict["NSPhotoLibraryUsageDescription"] != nil
+      if !hasPhotoLibraryUsage {
+          let docLink = DocLinks.NSPhotoLibraryUsageDescription
+          return "You are missing NSPhotoLibraryUsageDescription in your Info.plist file." +
+          " Camera will not function without it. Learn more: \(docLink.rawValue)"
+      }
+      let hasCameraUsage = dict["NSCameraUsageDescription"] != nil
+      if !hasCameraUsage {
+          let docLink = DocLinks.NSCameraUsageDescription
+          return "You are missing NSCameraUsageDescription in your Info.plist file." +
+          " Camera will not function without it. Learn more: \(docLink.rawValue)"
       }
     }
     


### PR DESCRIPTION
Camera also needs `NSPhotoLibraryUsageDescription`for accessing the photo gallery and `NSCameraUsageDescription` for using the camera. 