### PR TITLE
Configure popover to avoid iPad crash

### DIFF
--- a/packages/example/ios/IonicRunner/IonicRunner/Info.plist
+++ b/packages/example/ios/IonicRunner/IonicRunner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To Pick Photos from Library</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/packages/ios/Avocado/Avocado/Plugins/Camera.swift
+++ b/packages/ios/Avocado/Avocado/Plugins/Camera.swift
@@ -24,6 +24,7 @@ public class Camera : Plugin, UIImagePickerControllerDelegate, UINavigationContr
     imagePicker!.delegate = self
     imagePicker!.modalPresentationStyle = .popover
     imagePicker!.popoverPresentationController?.delegate = self
+    self.setPopover(self.imagePicker!)
     //imagePicker!.popoverPresentationController?.sourceView = view
     
     // Build the action sheet
@@ -31,7 +32,7 @@ public class Camera : Plugin, UIImagePickerControllerDelegate, UINavigationContr
     alert.addAction(UIAlertAction(title: "From Photos", style: .default, handler: { (action: UIAlertAction) in
       self.imagePicker!.sourceType = .photoLibrary
       self.imagePicker!.allowsEditing = allowEditing
-      
+
       self.bridge.viewController.present(self.imagePicker!, animated: true, completion: nil)
     }))
     
@@ -44,9 +45,10 @@ public class Camera : Plugin, UIImagePickerControllerDelegate, UINavigationContr
       }
       
       self.imagePicker!.sourceType = .camera
+
       self.bridge.viewController.present(self.imagePicker!, animated: true, completion: nil)
     }))
-    
+    setPopover(alert)
     self.bridge.viewController.present(alert, animated: true, completion: nil)
   }
   
@@ -108,6 +110,15 @@ public class Camera : Plugin, UIImagePickerControllerDelegate, UINavigationContr
     }
     
     return nil
+  }
+
+  /**
+   * Configure popover sourceRect, sourceView and permittedArrowDirections to show it centered
+   */
+  func setPopover (_ vc:UIViewController) {
+    vc.popoverPresentationController?.sourceRect = CGRect(x: self.bridge.viewController.view.center.x, y: self.bridge.viewController.view.center.y, width: 0, height: 0)
+    vc.popoverPresentationController?.sourceView = self.bridge.viewController.view
+    vc.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
   }
 }
 


### PR DESCRIPTION
Added `NSPhotoLibraryUsageDescription` entry
Configured the alert and imagePicker popovers so they appear centered and don't crash on iPad
