### PR TITLE
Add resources entry to podspec so it copies the avc.js to the project

### DIFF
--- a/ios/Avocado/Avocado.podspec
+++ b/ios/Avocado/Avocado.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/ionic-team/avocado.git', :tag => s.version }
   s.source_files = 'Avocado/*.{swift,h,m}', 'Avocado/Plugins/*.{swift,h,m}', 'Avocado/Plugins/**/*.{swift,h,m}'
   s.dependency 'AvocadoCordova', '1.0.0'
+  s.resources = "Avocado/Scripts/*"
 end


### PR DESCRIPTION
When installing Avocado from CocoaPods the avc.js file is not found.
Adding Avocado/Scripts/* as resources will copy everything in that folder and make it available on the app bundle.