### PR TITLE
Change the statusbar style on main thread

### DIFF
--- a/ios/Avocado/Avocado/Plugins/StatusBar.swift
+++ b/ios/Avocado/Avocado/Plugins/StatusBar.swift
@@ -10,10 +10,12 @@ public class StatusBar: AVCPlugin {
     let options = call.options!
 
     if let style = options["style"] as? String {
-      if style == "DARK" {
-        UIApplication.shared.statusBarStyle = .lightContent
-      } else if style == "LIGHT" {
-        UIApplication.shared.statusBarStyle = .default
+      DispatchQueue.main.async {
+        if style == "DARK" {
+          UIApplication.shared.statusBarStyle = .lightContent
+        } else if style == "LIGHT" {
+          UIApplication.shared.statusBarStyle = .default
+        }
       }
     }
     


### PR DESCRIPTION
While testing IonicRunner I noticed that changing the style was taking too long and this runtime warning was displayed "UIApplication.setStatusBarStyle(_:) must be used from main thread only".