### PR TITLE
Add setCenteredPopover method to AVCPlugin

### DIFF
--- a/ios/Avocado/Avocado/AVCBridge.swift
+++ b/ios/Avocado/Avocado/AVCBridge.swift
@@ -11,7 +11,7 @@ enum BridgeError: Error {
   public var AVC_SITE = "https://avocado.ionicframework.com"
   
   public var webView: WKWebView
-  public var viewController: UIViewController
+  @objc public var viewController: UIViewController
   
   public var lastPlugin: AVCPlugin?
   

--- a/ios/Avocado/Avocado/AVCPlugin.h
+++ b/ios/Avocado/Avocado/AVCPlugin.h
@@ -25,5 +25,6 @@
 -(void) load;
 -(NSString *)getId;
 -(BOOL)getBool:(AVCPluginCall*) call field:(NSString *)field defaultValue:(BOOL)defaultValue;
+-(void)setCenteredPopover:(UIViewController *) vc;
 
 @end

--- a/ios/Avocado/Avocado/AVCPlugin.m
+++ b/ios/Avocado/Avocado/AVCPlugin.m
@@ -93,6 +93,14 @@
  return TRUE;
  }*/
 
+/**
+ * Configure popover sourceRect, sourceView and permittedArrowDirections to show it centered
+ */
+-(void)setCenteredPopover:(UIViewController *) vc {
+  vc.popoverPresentationController.sourceRect = CGRectMake(self.bridge.viewController.view.center.x, self.bridge.viewController.view.center.y, 0, 0);
+  vc.popoverPresentationController.sourceView = self.bridge.viewController.view;
+  vc.popoverPresentationController.permittedArrowDirections = 0;
+}
 
 @end
 

--- a/ios/Avocado/Avocado/Plugins/Browser.swift
+++ b/ios/Avocado/Avocado/Plugins/Browser.swift
@@ -17,6 +17,7 @@ public class Browser : AVCPlugin, SFSafariViewControllerDelegate {
       self.vc = SFSafariViewController.init(url: url!)
       self.vc!.delegate = self
       self.vc!.modalPresentationStyle = .popover
+      self.setCenteredPopover(self.vc)
       self.bridge.viewController.present(self.vc!, animated: true, completion: {
         call.success()
       })

--- a/ios/Avocado/Avocado/Plugins/Camera.swift
+++ b/ios/Avocado/Avocado/Plugins/Camera.swift
@@ -24,7 +24,7 @@ public class Camera : AVCPlugin, UIImagePickerControllerDelegate, UINavigationCo
     imagePicker!.delegate = self
     imagePicker!.modalPresentationStyle = .popover
     imagePicker!.popoverPresentationController?.delegate = self
-    self.setPopover(self.imagePicker!)
+    self.setCenteredPopover(self.imagePicker!)
     //imagePicker!.popoverPresentationController?.sourceView = view
     
     // Build the action sheet
@@ -59,7 +59,7 @@ public class Camera : AVCPlugin, UIImagePickerControllerDelegate, UINavigationCo
       alert.dismiss(animated: true, completion: nil)
     }))
     
-    setPopover(alert)
+    self.setCenteredPopover(alert)
     self.bridge.viewController.present(alert, animated: true, completion: nil)
   }
   
@@ -123,12 +123,4 @@ public class Camera : AVCPlugin, UIImagePickerControllerDelegate, UINavigationCo
     return nil
   }
   
-  /**
-   * Configure popover sourceRect, sourceView and permittedArrowDirections to show it centered
-   */
-  func setPopover (_ vc:UIViewController) {
-    vc.popoverPresentationController?.sourceRect = CGRect(x: self.bridge.viewController.view.center.x, y: self.bridge.viewController.view.center.y, width: 0, height: 0)
-    vc.popoverPresentationController?.sourceView = self.bridge.viewController.view
-    vc.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection(rawValue: 0)
-  }
 }


### PR DESCRIPTION
Browser example was crashing on iPad because the popover was not configured.
I've moved the `setPopover` method from `Camera.swift` to `AVCPlugin.m` so all plugins can make use of it. Also renamed it to `setCenteredPopover` in case we want to offer more ways of configuring the popover by the users in the future and not just the current centered one. 