### PR TITLE
Use the AvocadoCordova in ios folder instead of the Specs private one

### DIFF
--- a/example/ios/IonicRunner/Podfile
+++ b/example/ios/IonicRunner/Podfile
@@ -1,11 +1,11 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
-source 'https://github.com/ionic-team/Specs'
 
 target 'IonicRunner' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
 
   # Pods for IonicRunner
+  pod 'AvocadoCordova', :path => '../../../ios/AvocadoCordova'
   pod 'Avocado', :path => '../../../ios/Avocado'
 end

--- a/example/ios/IonicRunner/Podfile.lock
+++ b/example/ios/IonicRunner/Podfile.lock
@@ -5,15 +5,18 @@ PODS:
 
 DEPENDENCIES:
   - Avocado (from `../../../ios/Avocado`)
+  - AvocadoCordova (from `../../../ios/AvocadoCordova`)
 
 EXTERNAL SOURCES:
   Avocado:
     :path: ../../../ios/Avocado
+  AvocadoCordova:
+    :path: ../../../ios/AvocadoCordova
 
 SPEC CHECKSUMS:
   Avocado: ac0b9c5e2a23c1d17eb21b77d087334090607f46
-  AvocadoCordova: 14ef5ae409ce34a09e9893008755ef87aabf2148
+  AvocadoCordova: d38c9c2ded6bf26b2414c0724aadf899869a0d45
 
-PODFILE CHECKSUM: 27766402febf7fb461318cd7e734d63ebe5c94e5
+PODFILE CHECKSUM: a063ff6f6bdf2b6b3e9a9f4af9113e431d48f95f
 
 COCOAPODS: 1.3.1

--- a/ios/Avocado/Podfile
+++ b/ios/Avocado/Podfile
@@ -1,8 +1,7 @@
-source 'https://github.com/ionic-team/Specs'
 
 target 'Avocado' do
   use_frameworks!
-  pod 'AvocadoCordova', '0.0.1'
+  pod 'AvocadoCordova', :path => '../AvocadoCordova'
   target 'AvocadoTests' do
     inherit! :search_paths
     

--- a/ios/Avocado/Podfile.lock
+++ b/ios/Avocado/Podfile.lock
@@ -2,11 +2,15 @@ PODS:
   - AvocadoCordova (0.0.1)
 
 DEPENDENCIES:
-  - AvocadoCordova (= 0.0.1)
+  - AvocadoCordova (from `../AvocadoCordova`)
+
+EXTERNAL SOURCES:
+  AvocadoCordova:
+    :path: ../AvocadoCordova
 
 SPEC CHECKSUMS:
-  AvocadoCordova: 14ef5ae409ce34a09e9893008755ef87aabf2148
+  AvocadoCordova: d38c9c2ded6bf26b2414c0724aadf899869a0d45
 
-PODFILE CHECKSUM: 1d2cb81f0c095e0dacfc1f4c33819eddc516e473
+PODFILE CHECKSUM: 30f7a012ae7e737fb5f0e4c80d6cd910431af3f1
 
 COCOAPODS: 1.3.1

--- a/ios/AvocadoCordova/AvocadoCordova.podspec
+++ b/ios/AvocadoCordova/AvocadoCordova.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "AvocadoCordova"
   s.module_name = 'Cordova'
-  s.version      = "1.0.0"
+  s.version      = "0.0.1"
   s.summary      = "Avocado Cordova Compatibility Bridge"
   s.homepage     = "https://ionicframework.com"
   s.license      = 'MIT'


### PR DESCRIPTION
I created the private Specs repo for CocoaPods while trying to fix the problem with IonicRunner not finding Cordova.
That problem is fixed now and not related to where AvocadoCordova was located, so it's better if we continue using the local AvocadoCordova in ios folder instead of the one in Specs, so it's easier to maintain and make changes while in development.
