### PR TITLE
Move export js to the bridge

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -32,6 +32,7 @@ enum BridgeError: Error {
     self.viewController = vc
     self.userContentController = userContentController
     super.init()
+    exportCoreJS()
     registerPlugins()
     bindObservers()
   }
@@ -76,6 +77,14 @@ enum BridgeError: Error {
   
   func isAppActive() -> Bool {
     return isActive
+  }
+
+  func exportCoreJS() {
+    do {
+      try JSExport.exportAvocadoJS(userContentController: self.userContentController)
+    } catch {
+      CAPBridge.fatalError(error, error)
+    }
   }
   
   func registerPlugins() {

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -23,11 +23,6 @@ class CAPBridgeViewController: UIViewController, WKScriptMessageHandler, WKUIDel
     
     let o = WKUserContentController()
     o.add(self, name: "bridge")
-    do {
-      try JSExport.exportAvocadoJS(userContentController: o)
-    } catch {
-      CAPBridge.fatalError(error, error)
-    }
     bridge = CAPBridge(self, o)
     webViewConfiguration.userContentController = o
     


### PR DESCRIPTION
Moving the exportAvocadoJS to Bridge class again, I moved it to the VC for the native-bridge.js injection, but it's better here.