### PR TITLE
Fix implicit declaration errors on some plugin classes

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -21,6 +21,7 @@
 #import <UIKit/UIKit.h>
 #import "CDVPluginResult.h"
 #import "CDVCommandDelegate.h"
+#import "CDVAvailability.h"
 
 @interface UIView (org_apache_cordova_UIView_Extension)
 


### PR DESCRIPTION
Plugins that use methods from `CDVAvailability` such as `IsAtLeastiOSVersion` fail to build. Importing it in CDVPlugin.h fixes it.