### PR TITLE
Copy and manage the Cordova plugins js

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -62,7 +62,7 @@ export async function resolvePlugin(name: string): Promise<Plugin | null> {
         id: name,
         name: fixName(name),
         rootPath: rootPath,
-        xml: xmlMeta.plugin.platform
+        xml: xmlMeta.plugin
       };
     }
   } catch (e) { }

--- a/cli/src/util/fs.ts
+++ b/cli/src/util/fs.ts
@@ -15,3 +15,6 @@ export const existsAsync = util.promisify(fs.exists);
 export const readdirAsync = util.promisify(fs.readdir);
 export const statAsync = util.promisify(fs.stat);
 export const lstatAsync = util.promisify(fs.lstat);
+export const removeSync = fsExtra.removeSync;
+export const ensureDirSync = fsExtra.ensureDirSync;
+export const copySync = fsExtra.copySync;


### PR DESCRIPTION
Copies the needed js files from node_modules to public folder following Cordova plugins structure modifying them as Cordova does.
Also generates a `cordova_plugins.js` file in public folder with the required content.