### PR TITLE
Return empty response instead of cordova.js content

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -100,6 +100,10 @@ class CAPBridgeViewController: UIViewController, WKScriptMessageHandler, WKUIDel
     webServer.addHandler(forMethod: "GET", pathRegex: "/var/mobile/Containers/Data/Application/", request: GCDWebServerFileRequest.self) { (request, block) in
       block(GCDWebServerFileResponse(file: request.url.absoluteString.replacingOccurrences(of: "http://localhost:\(port)", with: ""), byteRange: request.byteRange))
     }
+
+    webServer.addHandler(forMethod: "GET", pathRegex: "cordova.js", request: GCDWebServerFileRequest.self) { (request, block) in
+      block(GCDWebServerResponse())
+    }
     /*
     webServer.addHandler(forMethod: "GET", path: "/", request: GCDWebServerRequest.self, processBlock: { (req) -> GCDWebServerResponse? in
       print("Also in here")


### PR DESCRIPTION
If the existing app has cordova.js linked in the index.html it will cause troubles.

Serving an empty response when cordova.js is requested we avoid this problems.