### PR TITLE
Return empty cordova.js for Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -211,6 +211,12 @@ public class WebViewLocalServer {
     }
 
     String path = request.getUrl().getPath();
+
+    if (path.equals("/cordova.js")) {
+      return new WebResourceResponse(handler.getMimeType(), handler.getEncoding(),
+              handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), null);
+    }
+
     int periodIndex = path.lastIndexOf(".");
     if (periodIndex >= 0) {
       String ext = path.substring(path.lastIndexOf("."), path.length());


### PR DESCRIPTION
Same as #118 but for Android, when cordova.js is linked in the index.html, return an empty response to avoid problems with the injected one.