### PR TITLE
Don't show the full exception on the log message

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -107,7 +107,7 @@ public class JSExport {
         return getJS(context, path);
       }
     } catch(IOException ex) {
-      Log.e(Bridge.TAG, "Unable to read file at path "+path, ex);
+      Log.e(Bridge.TAG, "Unable to read file at path "+path);
     }
     return currentContent;
   }


### PR DESCRIPTION
Passing the ex to the log shows it like a crash message despite it doesn't crash, saw a few users on slack putting those messages as errors. 
This happens when there is no public/plugins folder