### PR TITLE
Ignore the Cordova plugin if it doesn't have platform tag

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -1,8 +1,8 @@
 import { Config } from '../config';
 import { log, runTask } from '../common';
-import { Plugin, PluginType, getPlugins } from '../plugin';
+import { getPlatformElement, getPluginPlatform, getPlugins, getPluginType, Plugin, PluginType } from '../plugin';
 import { getAndroidPlugins } from './common';
-import { copyCordovaJS, copyPluginsJS, createEmptyCordovaJS, getPlatformElement, getPluginPlatform, getPluginType, removePluginFiles } from '../tasks/update';
+import { copyCordovaJS, copyPluginsJS, createEmptyCordovaJS, removePluginFiles } from '../tasks/update';
 import { copySync, ensureDirSync, readFileAsync, removeSync, writeFileAsync } from '../util/fs';
 import { allSerial } from '../util/promise';
 import { join, resolve } from 'path';

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -3,7 +3,7 @@ import { isInstalled } from '../common';
 import { readdirAsync } from '../util/fs';
 import { join } from 'path';
 
-import { Plugin, PluginType } from '../plugin';
+import { getPluginPlatform, Plugin, PluginType } from '../plugin';
 
 
 export async function findXcodePath(config: Config): Promise<string | null> {
@@ -47,11 +47,12 @@ export async function resolvePlugin(plugin: Plugin): Promise<Plugin|null> {
     if (!plugin.manifest.ios.src) {
       iosPath = 'ios';
     }
-  } else if (plugin.xml) {
+  } else if (plugin.xml && getPluginPlatform(plugin, 'ios')) {
     iosPath = 'src/ios';
   } else {
     return null;
   }
+
   try {
     plugin.ios = {
       name: plugin.name,

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -3,8 +3,8 @@ import { CheckFunction, log, logInfo, runCommand, runTask } from '../common';
 import { writeFileAsync } from '../util/fs';
 import { Config } from '../config';
 import { join } from 'path';
-import { Plugin, PluginType, getPlugins, printPlugins } from '../plugin';
-import { copyCordovaJS, copyPluginsJS, createEmptyCordovaJS, getPlatformElement, getPluginType, removePluginFiles } from '../tasks/update';
+import { getPlatformElement, getPlugins, getPluginType, Plugin, PluginType, printPlugins } from '../plugin';
+import { copyCordovaJS, copyPluginsJS, createEmptyCordovaJS, removePluginFiles } from '../tasks/update';
 
 import * as inquirer from 'inquirer';
 import { create } from 'domain';

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -107,3 +107,33 @@ ${pluginNames.map(p => `     ${p}`).join('\n')}
     logInfo('No Capacitor plugins found. That\'s ok, you can add more plugins later by npm installing them.');
   }
 }
+
+export function getPluginPlatform(p: Plugin, platform: string) {
+  const platforms = p.xml.platform;
+  if (platforms) {
+    const platforms = p.xml.platform.filter(function(item: any) { return item.$.name === platform; });
+    return platforms[0];
+  }
+  return null;
+}
+
+export function getPlatformElement(p: Plugin, platform: string, elementName: string) {
+  const platformTag = getPluginPlatform(p, platform);
+  if (platformTag) {
+    const element = platformTag[elementName];
+    if (element) {
+      return element;
+    }
+  }
+  return [];
+}
+
+export function getPluginType(p: Plugin, platform: string): PluginType {
+  if (platform === 'ios') {
+    return p.ios!.type;
+  }
+  if (platform === 'android') {
+    return p.android!.type;
+  }
+  return PluginType.Code;
+}

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -5,7 +5,7 @@ import { allSerial } from '../util/promise';
 import { CheckFunction, check, checkPackage, log, logFatal, logInfo } from '../common';
 import { copySync, ensureDirSync, readFileAsync, removeSync, writeFileAsync } from '../util/fs';
 import { join, resolve } from 'path';
-import { Plugin, PluginType } from '../plugin';
+import { getPluginPlatform, Plugin, PluginType } from '../plugin';
 import { existsAsync } from '../util/fs';
 import { copy as fsCopy } from 'fs-extra';
 
@@ -158,16 +158,6 @@ function getWebDir(config: Config, platform: string): string {
   return '';
 }
 
-export function getPluginType(p: Plugin, platform: string): PluginType {
-  if (platform === 'ios') {
-    return p.ios!.type;
-  }
-  if (platform === 'android') {
-    return p.android!.type;
-  }
-  return PluginType.Code;
-}
-
 export async function copyCordovaJS(config: Config, platform: string) {
   const cordovaPath = resolve('node_modules', '@capacitor/core', 'cordova.js');
   if (!await existsAsync(cordovaPath)) {
@@ -190,24 +180,4 @@ export function removePluginFiles(config: Config, platform: string) {
   const cordovaPluginsJSFile = join(webDir, 'cordova_plugins.js');
   removeSync(pluginsDir);
   removeSync(cordovaPluginsJSFile);
-}
-
-export function getPluginPlatform(p: Plugin, platform: string) {
-  const platforms = p.xml.platform;
-  if (platforms) {
-    const platforms = p.xml.platform.filter(function(item: any) { return item.$.name === platform; });
-    return platforms[0];
-  }
-  return null;
-}
-
-export function getPlatformElement(p: Plugin, platform: string, elementName: string) {
-  const platformTag = getPluginPlatform(p, platform);
-  if (platformTag) {
-    const element = platformTag[elementName];
-    if (element) {
-      return element;
-    }
-  }
-  return [];
 }


### PR DESCRIPTION
Rearranged code by moving plugin related method to plugin class.

Now when the plugin doesn't have code for the platform it won't be added to the list, so we avoid an iOS error when the src/ios folder is not found and tries to read a podspec form there