### PR TITLE
Call pluginInitialize after plugin instantiation

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -388,6 +388,7 @@ enum BridgeError: Error {
         }
         plugin = vcClass!.init()
         cordovaPlugins[className] = plugin
+        plugin.pluginInitialize()
       }
 
       plugin.viewController = self.viewController


### PR DESCRIPTION
geolocation plugin wasn't working and the problem was the pluginInitialize method was not called, so this will call it after the instantiation