### PR TITLE
Add almost empty CDVViewController to make file plugin work

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
+++ b/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		2F5C87251FE98418004B09C7 /* CDVAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5C871A1FE98418004B09C7 /* CDVAvailability.h */; };
 		2F5C87261FE98418004B09C7 /* CDVPluginResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5C871B1FE98418004B09C7 /* CDVPluginResult.h */; };
 		2F5C87271FE98418004B09C7 /* CDVPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F5C871C1FE98418004B09C7 /* CDVPlugin.h */; };
+		2F856BFF203DEB320047344A /* CDVViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F856BFD203DEB320047344A /* CDVViewController.h */; };
+		2F856C00203DEB320047344A /* CDVViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F856BFE203DEB320047344A /* CDVViewController.m */; };
 		2FAD9772203C77B9000D30F8 /* CDVConfigParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FAD9770203C77B8000D30F8 /* CDVConfigParser.h */; };
 		2FAD9773203C77B9000D30F8 /* CDVConfigParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FAD9771203C77B9000D30F8 /* CDVConfigParser.m */; };
 /* End PBXBuildFile section */
@@ -38,6 +40,8 @@
 		2F5C871A1FE98418004B09C7 /* CDVAvailability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVAvailability.h; sourceTree = "<group>"; };
 		2F5C871B1FE98418004B09C7 /* CDVPluginResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVPluginResult.h; sourceTree = "<group>"; };
 		2F5C871C1FE98418004B09C7 /* CDVPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVPlugin.h; sourceTree = "<group>"; };
+		2F856BFD203DEB320047344A /* CDVViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVViewController.h; sourceTree = "<group>"; };
+		2F856BFE203DEB320047344A /* CDVViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVViewController.m; sourceTree = "<group>"; };
 		2FAD9770203C77B8000D30F8 /* CDVConfigParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVConfigParser.h; sourceTree = "<group>"; };
 		2FAD9771203C77B9000D30F8 /* CDVConfigParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVConfigParser.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,6 +94,8 @@
 		2F5C86E81FE94861004B09C7 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				2F856BFD203DEB320047344A /* CDVViewController.h */,
+				2F856BFE203DEB320047344A /* CDVViewController.m */,
 				2FAD9770203C77B8000D30F8 /* CDVConfigParser.h */,
 				2FAD9771203C77B9000D30F8 /* CDVConfigParser.m */,
 				2F5C87131FE98417004B09C7 /* CDV.h */,
@@ -121,6 +127,7 @@
 				2F5C86E11FE94845004B09C7 /* CapacitorCordova.h in Headers */,
 				2F5C87251FE98418004B09C7 /* CDVAvailability.h in Headers */,
 				2F5C87271FE98418004B09C7 /* CDVPlugin.h in Headers */,
+				2F856BFF203DEB320047344A /* CDVViewController.h in Headers */,
 				2F5C87231FE98418004B09C7 /* CDVCommandDelegateImpl.h in Headers */,
 				2F5C87241FE98418004B09C7 /* CDVInvokedUrlCommand.h in Headers */,
 			);
@@ -198,6 +205,7 @@
 				2F5C871D1FE98418004B09C7 /* CDVPluginResult.m in Sources */,
 				2F5C87211FE98418004B09C7 /* CDVPlugin.m in Sources */,
 				2FAD9773203C77B9000D30F8 /* CDVConfigParser.m in Sources */,
+				2F856C00203DEB320047344A /* CDVViewController.m in Sources */,
 				2F5C87201FE98418004B09C7 /* CDVInvokedUrlCommand.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/CapacitorCordova/CapacitorCordova/CapacitorCordova.h
+++ b/ios/CapacitorCordova/CapacitorCordova/CapacitorCordova.h
@@ -16,3 +16,4 @@ FOUNDATION_EXPORT const unsigned char CapacitorCordovaVersionString[];
 #import <Cordova/CDVCommandDelegate.h>
 #import <Cordova/CDVInvokedUrlCommand.h>
 #import <Cordova/CDVConfigParser.h>
+#import <Cordova/CDVViewController.h>

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVConfigParser.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVConfigParser.h
@@ -16,6 +16,7 @@
  specific language governing permissions and limitations
  under the License.
  */
+#import <Foundation/Foundation.h>
 
 @interface CDVConfigParser : NSObject <NSXMLParserDelegate>
 {

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVViewController.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVViewController.h
@@ -17,10 +17,10 @@
  under the License.
  */
 
-#import "CDVAvailability.h"
-#import "CDVPlugin.h"
-#import "CDVPluginResult.h"
-#import "CDVCommandDelegate.h"
-#import "CDVInvokedUrlCommand.h"
-#import "CDVViewController.h"
+#import <UIKit/UIKit.h>
 
+@interface CDVViewController : UIViewController
+
+@property (nonatomic, readonly, strong) NSMutableDictionary* settings;
+
+@end

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVViewController.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVViewController.m
@@ -17,10 +17,17 @@
  under the License.
  */
 
-#import "CDVAvailability.h"
-#import "CDVPlugin.h"
-#import "CDVPluginResult.h"
-#import "CDVCommandDelegate.h"
-#import "CDVInvokedUrlCommand.h"
+
 #import "CDVViewController.h"
 
+@interface CDVViewController () {
+  
+}
+
+
+
+@end
+
+@implementation CDVViewController
+
+@end


### PR DESCRIPTION
file plugin checks for CDVViewController class in code.
I can't import the Cordova original file as it imports a ton of other classes and we don't really use the CDVViewController, so adding a minimal one to make file plugin work.