### PR TITLE
Improve cordova.js file

### DIFF
--- a/core/cordova.js
+++ b/core/cordova.js
@@ -19,7 +19,7 @@
  under the License.
 */
 ; (function () {
-    var PLATFORM_VERSION_BUILD_LABEL = '4.5.4';
+    var PLATFORM_VERSION_BUILD_LABEL = '1.0.0';
     // file: src/scripts/require.js
 
     /* jshint -W079 */
@@ -838,7 +838,6 @@
 
     });
 
-    // file: /Users/spindori/Documents/Cordova/cordova-ios/cordova-js-src/exec.js
     define("cordova/exec", function (require, exports, module) {
 
         /*global require, module, atob, document */
@@ -904,8 +903,7 @@
             return args;
         }
 
-        var iOSExec = function () {
-            console.log('ios exec');
+        var capacitorExec = function () {
             // detect change in bridge, if there is a change, we forward to new bridge
 
             var successCallback, failCallback, service, action, actionArgs;
@@ -960,7 +958,7 @@
             var cexec = cordovaExec();
 
             return (execProxy !== cexec && // proxy objects are different
-                iOSExec !== cexec      // proxy object is not the current iOSExec
+                capacitorExec !== cexec      // proxy object is not the current capacitorExec
             );
         }
 
@@ -1019,7 +1017,7 @@
             }, 50); // Making this > 0 improves performance (marginally) in the normal case (where it doesn't fire).
         }
 
-        iOSExec.nativeFetchMessages = function () {
+        capacitorExec.nativeFetchMessages = function () {
             // Stop listing for window detatch once native side confirms poke.
             if (failSafeTimerId) {
                 clearTimeout(failSafeTimerId);
@@ -1034,7 +1032,7 @@
             return json;
         };
 
-        iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
+        capacitorExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
             var success = status === 0 || status === 1;
             var args = convertMessageToArgsNativeToJs(message);
             setTimeout(function () {
@@ -1043,7 +1041,7 @@
         };
 
         // for backwards compatibility
-        iOSExec.nativeEvalAndFetch = function (func) {
+        capacitorExec.nativeEvalAndFetch = function (func) {
             try {
                 func();
             } catch (e) {
@@ -1055,7 +1053,7 @@
         function cordovaExec() {
             var cexec = require('cordova/exec');
             var cexec_valid = (typeof cexec.nativeFetchMessages === 'function') && (typeof cexec.nativeEvalAndFetch === 'function') && (typeof cexec.nativeCallback === 'function');
-            return (cexec_valid && execProxy !== cexec) ? cexec : iOSExec;
+            return (cexec_valid && execProxy !== cexec) ? cexec : capacitorExec;
         }
         function execProxy() {
             cordovaExec().apply(null, arguments);
@@ -1324,14 +1322,10 @@
 
     });
 
-    // file: /Users/spindori/Documents/Cordova/cordova-ios/cordova-js-src/platform.js
     define("cordova/platform", function (require, exports, module) {
-
         module.exports = {
-            id: 'ios',
+            id: Capacitor.platform,
             bootstrap: function () {
-                // Attach the console polyfill that is iOS-only to window.console
-
                 require('cordova/channel').onNativeReady.fire();
             }
         };


### PR DESCRIPTION
The cordova.js is based on the cordova-ios cordova.js.
Remove traces of ios by renaming iOSExec to capacitorExec
Use Capacitor.platform as platform.id instead of hardcode it to ios so cordova.platformId returns the right value.

Set version to 1.0.0, not sure if we can automate this with lerna to match the actual capacitor version