### PR TITLE
Add cookie manager to the mock cordova webview

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/CapacitorCordovaCookieManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/CapacitorCordovaCookieManager.java
@@ -1,0 +1,38 @@
+package com.getcapacitor.cordova;
+
+import android.webkit.CookieManager;
+import android.webkit.WebView;
+import org.apache.cordova.ICordovaCookieManager;
+
+class CapacitorCordovaCookieManager implements ICordovaCookieManager {
+
+  protected final WebView webView;
+  private final CookieManager cookieManager;
+
+  public CapacitorCordovaCookieManager(WebView webview) {
+    webView = webview;
+    cookieManager = CookieManager.getInstance();
+    cookieManager.setAcceptFileSchemeCookies(true);
+    cookieManager.setAcceptThirdPartyCookies(webView, true);
+  }
+
+  public void setCookiesEnabled(boolean accept) {
+    cookieManager.setAcceptCookie(accept);
+  }
+
+  public void setCookie(final String url, final String value) {
+    cookieManager.setCookie(url, value);
+  }
+
+  public String getCookie(final String url) {
+    return cookieManager.getCookie(url);
+  }
+
+  public void clearCookies() {
+    cookieManager.removeAllCookie();
+  }
+
+  public void flush() {
+    cookieManager.flush();
+  }
+};

--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -17,6 +17,8 @@ import org.apache.cordova.PluginEntry;
 import org.apache.cordova.PluginManager;
 import org.apache.cordova.PluginResult;
 
+
+
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +30,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
   private CordovaResourceApi resourceApi;
   private NativeToJsMessageQueue nativeToJsMessageQueue;
   private CordovaInterface cordova;
+  private CapacitorCordovaCookieManager cookieManager;
 
   public MockCordovaWebViewImpl(Context context) {
     this.context = context;
@@ -51,6 +54,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
     nativeToJsMessageQueue = new NativeToJsMessageQueue();
     nativeToJsMessageQueue.addBridgeMode(new CapacitorEvalBridgeMode(webView, this.cordova));
     nativeToJsMessageQueue.setBridgeMode(0);
+    this.cookieManager = new CapacitorCordovaCookieManager(webView);
   }
 
   public static class CapacitorEvalBridgeMode extends NativeToJsMessageQueue.BridgeMode {
@@ -212,7 +216,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
 
   @Override
   public ICordovaCookieManager getCookieManager() {
-    return null;
+    return cookieManager;
   }
 
   @Override


### PR DESCRIPTION
Added a cookie manager based on Cordova's SystemCookieManager (couldn't use that one as it isn't public)
The cookie manager is needed for file-transfer to work.