### PR TITLE
MimeType was not set correctly

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -71,7 +71,7 @@ public class WebViewLocalServer {
    * minimum.
    */
   public abstract static class PathHandler {
-    private String mimeType;
+    protected String mimeType;
     private String encoding;
     private String charset;
     private int statusCode;
@@ -360,11 +360,15 @@ public class WebViewLocalServer {
           return null;
         }
 
-        String mimeType = null;
         try {
-          mimeType = URLConnection.guessContentTypeFromName(path);
-          if (mimeType == null)
-            mimeType = URLConnection.guessContentTypeFromStream(stream);
+          mimeType = URLConnection.guessContentTypeFromName(path); // Does not recognize *.js
+          if (mimeType == null){
+            if(path.endsWith(".js")) {
+              mimeType = "application/javascript"; //ES6 Modules need mime
+            }else{
+              mimeType = URLConnection.guessContentTypeFromStream(stream);
+            }
+          }
         } catch (Exception ex) {
           Log.e(TAG, "Unable to get mime type" + url);
         }


### PR DESCRIPTION
The MimeType was never set. Additionally the URLConnection.guessContentTypeFromName does not recognize *.js types. But this is required to enable ES6 Modules like used in stenciljs.

This fixes https://github.com/ionic-team/capacitor/issues/153