### PR TITLE
Fix encoding naming mistakes

### DIFF
--- a/cli/src/android/doctor.ts
+++ b/cli/src/android/doctor.ts
@@ -191,7 +191,7 @@ async function checkBuildGradle(config: Config, packageId: string) {
     return `${fileName} file is missing in: ${appDir}`;
   }
 
-  let fileContent = await readFileAsync(filePath, 'utf-8');
+  let fileContent = await readFileAsync(filePath, 'utf8');
 
   fileContent = fileContent.replace(/'|"/g, '').replace(/\s+/g, ' ');
 

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -139,7 +139,7 @@ export async function autoGenerateConfig(config: Config, cordovaPlugins: Plugin[
     const xmlString = await writeXML(item);
     return xmlString;
   }));
-  const content = `<?xml version='1.0' encoding='utf8'?>
+  const content = `<?xml version='1.0' encoding='utf-8'?>
   <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   ${pluginEntriesString.join('\n')}
   </widget>`;


### PR DESCRIPTION
When writing/reading it's `utf8` (default is `utf8`, so we don't even need it)
In xml file content it's `utf-8`
