### PR TITLE
Create a Cordova Plugin manager to handle plugins

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.h
@@ -20,6 +20,7 @@
 #import <UIKit/UIKit.h>
 #import "CDVCommandDelegate.h"
 #import <WebKit/WebKit.h>
+#import "CDVPluginManager.h"
 
 @class CDVViewController;
 @class CDVCommandQueue;
@@ -27,11 +28,12 @@
 @interface CDVCommandDelegateImpl : NSObject <CDVCommandDelegate>{
     @private
     __weak WKWebView* _webView;
+    __weak CDVPluginManager* _manager;
     NSRegularExpression* _callbackIdPattern;
     @protected
     __weak CDVCommandQueue* _commandQueue;
     BOOL _delayResponses;
 }
-- (id)initWithWebView:(WKWebView*)webView;
+- (id)initWithWebView:(WKWebView*)webView pluginManager:(CDVPluginManager *)manager;
 - (void)flushCommandQueueWithDelayedJs;
 @end

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.m
@@ -25,12 +25,12 @@
 
 @synthesize urlTransformer;
 
-- (id)initWithWebView:(WKWebView*)webView
+- (id)initWithWebView:(WKWebView*)webView pluginManager:(CDVPluginManager *)manager
 {
     self = [super init];
     if (self != nil) {
         _webView = webView;
-
+        _manager = manager;
         NSError* err = nil;
         _callbackIdPattern = [NSRegularExpression regularExpressionWithPattern:@"[^A-Za-z0-9._-]" options:0 error:&err];
         if (err != nil) {
@@ -128,7 +128,7 @@
 
 - (id)getCommandInstance:(NSString*)pluginName
 {
-    return nil;
+    return [_manager getCommandInstance:pluginName];
 }
 
 - (void)runInBackground:(void (^)())block

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -53,6 +53,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 
 @property (nonatomic, weak) UIView* webView;
 @property (nonatomic, weak) id webViewEngine;
+@property (nonatomic, strong) NSString * className;
 
 @property (nonatomic, weak) UIViewController* viewController;
 @property (nonatomic, strong) id <CDVCommandDelegate> commandDelegate;

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.h
@@ -1,0 +1,19 @@
+//
+//  CDVPluginManager.h
+//  CapacitorCordova
+//
+//  Created by Julio Cesar Sanchez Hernandez on 26/2/18.
+//
+
+#import <Foundation/Foundation.h>
+#import "CDVPlugin.h"
+
+@interface CDVPluginManager : NSObject
+
+@property (nonatomic, strong) NSMutableDictionary * pluginsMap;
+@property (nonatomic, strong) NSMutableDictionary * pluginObjects;
+
+- (id)initWithMapping:(NSMutableDictionary*)mapping;
+- (CDVPlugin *)getCommandInstance:(NSString*)pluginName;
+
+@end

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
@@ -1,0 +1,54 @@
+#import "CDVPluginManager.h"
+#import "CDVPlugin.h"
+
+@implementation CDVPluginManager
+
+- (id)initWithMapping:(NSMutableDictionary*)mapping
+{
+  self = [super init];
+  if (self != nil) {
+    _pluginsMap = mapping;
+  }
+  return self;
+}
+
+/**
+ Returns an instance of a CordovaCommand object, based on its name.  If one exists already, it is returned.
+ */
+- (CDVPlugin *)getCommandInstance:(NSString*)pluginName
+{
+  NSString* className = [self.pluginsMap objectForKey:[pluginName lowercaseString]];
+
+  if (className == nil) {
+    return nil;
+  }
+
+  id obj = [self.pluginObjects objectForKey:className];
+  if (!obj) {
+    obj = [[NSClassFromString(className)alloc] init];
+    if (!obj) {
+      NSString* fullClassName = [NSString stringWithFormat:@"%@.%@",
+                                 NSBundle.mainBundle.infoDictionary[@"CFBundleExecutable"],
+                                 className];
+      obj = [[NSClassFromString(fullClassName)alloc] init];
+    }
+
+    if (obj != nil) {
+      [self registerPlugin:obj withClassName:className];
+    } else {
+      NSLog(@"CDVPlugin class %@ (pluginName: %@) does not exist.", className, pluginName);
+    }
+  }
+  [obj setClassName:className];
+
+  return obj;
+}
+
+
+- (void)registerPlugin:(CDVPlugin*)plugin withClassName:(NSString*)className
+{
+  [self.pluginObjects setObject:plugin forKey:className];
+  [plugin pluginInitialize];
+}
+
+@end


### PR DESCRIPTION
Some Cordova plugins need to instantiate other plugins, but we had all that logic in CAPBridge, not accesible from Cordova plugins.
So created a CDVPluginManager class in CapacitorCordova to handle the Cordova plugin classes and changed CAPBridge to use it