### PR TITLE
Improve frameworks

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -158,6 +158,7 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config) 
   let linkedFrameworks: Array<string> = [];
   let customFrameworks: Array<string> = [];
   let systemLibraries: Array<string> = [];
+  let sourceFrameworks: Array<string> = [];
   cordovaPlugins.map((plugin: any) => {
     const frameworks = getPlatformElement(plugin, platform, 'framework');
     frameworks.map((framework: any) => {
@@ -185,6 +186,16 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config) 
         }
       }
     });
+    const sourceFiles = getPlatformElement(plugin, platform, 'source-file');
+    sourceFiles.map((sourceFile: any) => {
+      if (sourceFile.$.framework && sourceFile.$.framework === 'true') {
+        const fileName = sourceFile.$.src.split("/").pop();
+        const frameworktPath = join('sources', plugin.name, fileName);
+        if (!sourceFrameworks.includes(frameworktPath)) {
+          sourceFrameworks.push(frameworktPath);
+        }
+      }
+    })
   });
   let frameworkDeps: Array<string> = [];
   if (weakFrameworks.length > 0) {
@@ -198,6 +209,9 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config) 
   }
   if (customFrameworks.length > 0) {
     frameworkDeps.push(`s.vendored_frameworks = '${customFrameworks.join("', '")}'`);
+  }
+  if (sourceFrameworks.length > 0) {
+    frameworkDeps.push(`s.vendored_libraries = '${sourceFrameworks.join("', '")}'`);
   }
   const frameworksString = frameworkDeps.join("\n    ");
   const content = `

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -169,8 +169,9 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config) 
               weakFrameworks.push(name);
             }
           } if (framework.$.custom && framework.$.custom === 'true') {
-            if (!customFrameworks.includes(name)) {
-              customFrameworks.push(name);
+            const frameworktPath = join('sources', plugin.name, name);
+            if (!customFrameworks.includes(frameworktPath)) {
+              customFrameworks.push(frameworktPath);
             }
           } else {
             if (!linkedFrameworks.includes(name)) {
@@ -222,9 +223,10 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
     const sourceFiles = getPlatformElement(p, platform, 'source-file');
     const headerFiles = getPlatformElement(p, platform, 'header-file');
     const codeFiles = sourceFiles.concat(headerFiles);
+    const sourcesFolder = join(pluginsPath, 'sources', p.name);
     codeFiles.map( (codeFile: any) => {
       const fileName = codeFile.$.src.split("/").pop();
-      copySync(join(p.rootPath, codeFile.$.src), join(pluginsPath, 'sources', p.name, fileName));
+      copySync(join(p.rootPath, codeFile.$.src), join(sourcesFolder, fileName));
     });
     const resourceFiles = getPlatformElement(p, platform, 'resource-file');
     resourceFiles.map( (resourceFile: any) => {
@@ -234,7 +236,7 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
     const frameworks = getPlatformElement(p, platform, 'framework');
     frameworks.map((framework: any) => {
       if (framework.$.custom && framework.$.custom === 'true') {
-        copySync(join(p.rootPath, framework.$.src),  join(pluginsPath, framework.$.src));
+        copySync(join(p.rootPath, framework.$.src),  join(sourcesFolder, framework.$.src));
       }
     });
   });


### PR DESCRIPTION
Improved the custom framework handling to move them to sources folder so they get deleted on update (in case the plugin was removed), and to be grouped with other files from the same plugin.

Also handle source-file tags with framework property. Those are framework libs. Mapped them to `s.vendored_libraries` in CocoaPods