### PR TITLE
Remove cordova defined check

### DIFF
--- a/core/cordova.js
+++ b/core/cordova.js
@@ -99,12 +99,6 @@
     // file: src/cordova.js
     define("cordova", function (require, exports, module) {
 
-        // Workaround for Windows 10 in hosted environment case
-        // http://www.w3.org/html/wg/drafts/html/master/browsers.html#named-access-on-the-window-object
-        if (window.cordova && !(window.cordova instanceof HTMLElement)) { // eslint-disable-line no-undef
-            throw new Error('cordova already defined');
-        }
-
         var channel = require('cordova/channel');
         var platform = require('cordova/platform');
 


### PR DESCRIPTION
cordova.js had a check to not allow multiple definitions of cordova and was throwing errors because of the native-bridge definition included recently.
Removing the check to avoid such errors