### PR TITLE
multiple tiny changes in "with Ionic" docs

### DIFF
--- a/site/docs-md/getting-started/with-ionic.md
+++ b/site/docs-md/getting-started/with-ionic.md
@@ -52,7 +52,7 @@ npx cap add android
 
 ## Syncing your app with Capacitor
 
-Every time you perform a build that changes `/www`, you'll need to copy those changes down to your native projects:
+Every time you perform a build that changes your web directory (default: `www`), you'll need to copy those changes down to your native projects:
 
 ```bash
 npm run build

--- a/site/docs-md/getting-started/with-ionic.md
+++ b/site/docs-md/getting-started/with-ionic.md
@@ -1,6 +1,6 @@
 # Using Capacitor with Ionic
 
-Capacitor installs directly into any Ionic project (1.0-4.0x+) with a simple `npm install`:
+Capacitor installs directly into any Ionic project (1.0-4.x+) with a simple `npm install`:
 
 ## Start Ionic Project
 
@@ -52,7 +52,7 @@ npx cap add android
 
 ## Syncing your app with Capacitor
 
-Every time you perform a build, you'll need to copy those changes down to your native projects:
+Every time you perform a build that changes `/www`, you'll need to copy those changes down to your native projects:
 
 ```bash
 npm run build
@@ -61,12 +61,11 @@ npx cap copy
 
 ## Using Ionic Native
 
-Ionic Native is supported in Capacitor. Currently, Ionic Native contains only Cordova plugins, so whenever you find
-an Ionic Native wrapper you'd like to use, install it and then install the corresponding Cordova plugin by running
+[Ionic Native](https://ionicframework.com/docs/native/) is supported in Capacitor. Currently, Ionic Native contains only Cordova plugins, so whenever you find an Ionic Native wrapper you'd like to use, install it and then install the corresponding Cordova plugin by running
 
 ```bash
 npm install your-cordova-plugin
 npx cap update
 ```
 
-See the [Cordova](../basics/cordova) guide for more information.
+See the [Cordova](../../basics/cordova/) guide for more information.


### PR DESCRIPTION
- Fix Ionic version
- clarify what build requires `cap copy`
- Link Ionic Native
- fix "Cordova" link (right now links to https://capacitor.ionicframework.com/docs/getting-started/basics/cordova which is an endless load loop)