### PR TITLE
Remove patch used to force the FCM Version

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -74,8 +74,6 @@ export async function handleCordovaPluginsGradle(config: Config,  cordovaPlugins
   });
   let buildGradle = await readFileAsync(pluginsGradlePath, 'utf8');
   buildGradle = buildGradle.replace(/(SUB-PROJECT DEPENDENCIES START)[\s\S]*(\/\/ SUB-PROJECT DEPENDENCIES END)/, '$1\n' + frameworkString.concat("\n") + '    $2');
-  //TODO - replace value with a confg.xml preference value or from capacitor config file.
-  buildGradle = buildGradle.replace('$FCM_VERSION','11.6.2');
   await writeFileAsync(pluginsGradlePath, buildGradle);
 }
 


### PR DESCRIPTION
This was to force the FCM version, but now it will use the default from the plugin.xml preferences.

