### PR TITLE
Site: Fix assets in CSS to also work in docs

### DIFF
--- a/site/src/components/capacitor-site/capacitor-site.scss
+++ b/site/src/components/capacitor-site/capacitor-site.scss
@@ -286,7 +286,7 @@ code {
 .landing-page {
   footer {
     .ionic-oss-logo {
-      background-image: url(assets/img/ionic-os-logo.png);
+      background-image: url(/assets/img/ionic-os-logo.png);
     }
   }
 }
@@ -302,7 +302,7 @@ footer {
   flex: 0 0 8em;
 
   .ionic-oss-logo {
-    background: url(assets/img/ionic-os-dark-logo.png) no-repeat transparent;
+    background: url(/assets/img/ionic-os-dark-logo.png) no-repeat transparent;
     width: 124px;
     height: 16px;
     background-size: 100%;


### PR DESCRIPTION
Right now each Docs page requests the image relative to itself:
https://capacitor.ionicframework.com/docs/plugins/ios/assets/img/ionic-os-dark-logo.png
https://capacitor.ionicframework.com/docs/ios/troubleshooting/assets/img/ionic-os-dark-logo.png
...
