### PR TITLE
If the file starts with node_modules, search on the root

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -1,6 +1,6 @@
 import { Config } from '../config';
 import { log, runTask } from '../common';
-import { getPlatformElement, getPluginPlatform, getPlugins, getPluginType, Plugin, PluginType } from '../plugin';
+import { getFilePath, getPlatformElement, getPluginPlatform, getPlugins, getPluginType, Plugin, PluginType } from '../plugin';
 import { getAndroidPlugins } from './common';
 import { handleCordovaPluginsJS } from '../cordova';
 import { copySync, ensureDirSync, readFileAsync, removeSync, writeFileAsync } from '../util/fs';
@@ -98,16 +98,16 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
         sourceFiles.map( (sourceFile: any) => {
           const fileName = sourceFile.$.src.split("/").pop();
           const target = sourceFile.$["target-dir"].replace('src/', 'java/');
-          copySync(join(p.rootPath, sourceFile.$.src), join(pluginsPath, target, fileName));
+          copySync(getFilePath(config, p, sourceFile.$.src), join(pluginsPath, target, fileName));
         });
       }
       const resourceFiles = androidPlatform['resource-file'];
       if(resourceFiles) {
         resourceFiles.map( (resourceFile: any) => {
           if (resourceFile.$.src.split(".").pop() === "aar") {
-            copySync(join(p.rootPath, resourceFile.$.src), join(pluginsPath, 'libs', resourceFile.$["target"].split("/").pop()));
+            copySync(getFilePath(config, p, resourceFile.$.src), join(pluginsPath, 'libs', resourceFile.$["target"].split("/").pop()));
           } else {
-            copySync(join(p.rootPath, resourceFile.$.src), join(pluginsPath, resourceFile.$["target"]));
+            copySync(getFilePath(config, p, resourceFile.$.src), join(pluginsPath, resourceFile.$["target"]));
           }
         });
       }
@@ -115,7 +115,7 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
       frameworks.map((framework: any) => {
         if (framework.$.custom && framework.$.custom === "true" && framework.$.type && framework.$.type === "gradleReference"){
           const fileName = framework.$.src.split("/").pop();
-          copySync(join(p.rootPath, framework.$.src), join(pluginsRoot, 'gradle-files', p.id, fileName));
+          copySync(getFilePath(config, p, framework.$.src), join(pluginsRoot, 'gradle-files', p.id, fileName));
         }
       });
     }

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -3,7 +3,7 @@ import { CheckFunction, log, logInfo, logWarn, runCommand, runTask } from '../co
 import { copySync, readFileAsync, removeSync, writeFileAsync } from '../util/fs';
 import { Config } from '../config';
 import { join, resolve } from 'path';
-import { getPlatformElement, getPluginPlatform, getPlugins, getPluginType, Plugin, PluginType, printPlugins } from '../plugin';
+import { getFilePath, getPlatformElement, getPluginPlatform, getPlugins, getPluginType, Plugin, PluginType, printPlugins } from '../plugin';
 import { handleCordovaPluginsJS } from '../cordova';
 
 import * as inquirer from 'inquirer';
@@ -232,17 +232,17 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
     const sourcesFolder = join(pluginsPath, 'sources', p.name);
     codeFiles.map( (codeFile: any) => {
       const fileName = codeFile.$.src.split("/").pop();
-      copySync(join(p.rootPath, codeFile.$.src), join(sourcesFolder, fileName));
+      copySync(getFilePath(config, p, codeFile.$.src), join(sourcesFolder, fileName));
     });
     const resourceFiles = getPlatformElement(p, platform, 'resource-file');
     resourceFiles.map( (resourceFile: any) => {
       const fileName = resourceFile.$.src.split("/").pop();
-      copySync(join(p.rootPath, resourceFile.$.src), join(pluginsPath, 'resources', fileName));
+      copySync(getFilePath(config, p, resourceFile.$.src), join(pluginsPath, 'resources', fileName));
     });
     const frameworks = getPlatformElement(p, platform, 'framework');
     frameworks.map((framework: any) => {
       if (framework.$.custom && framework.$.custom === 'true') {
-        copySync(join(p.rootPath, framework.$.src),  join(sourcesFolder, framework.$.src));
+        copySync(getFilePath(config, p, framework.$.src),  join(sourcesFolder, framework.$.src));
       }
     });
   });

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -153,3 +153,10 @@ export function getJSModules(p: Plugin, platform: string) {
   }
   return modules;
 }
+
+export function getFilePath(config: Config, plugin: Plugin, path: string) {
+  if (path.startsWith("node_modules")) {
+    return join(config.app.rootDir, path);
+  }
+  return join(plugin.rootPath, path);
+}


### PR DESCRIPTION
Some plugins (like sqlite), have sources/resources references to another plugin files, so search on the root of the project instead of inside the plugin when the file src starts with "node_modules"