### PR TITLE
Added fallback logging to native-bridge.js

### DIFF
--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -272,31 +272,50 @@
   };
 
   capacitor.logToNative = function(call) {
-    var c = orgConsole;
-    c.groupCollapsed(`%cnative %c${call.pluginId}.${call.methodName} (#${call.callbackId})`,
-    `font-weight: lighter; color: gray`, `font-weight: bold; color: #000`);
-    c.dir(call);
-    c.groupEnd();
-    //orgConsole.log('LOG TO NATIVE', call);
+    if(Object.keys(win.console).length > 0) {
+        var c = orgConsole;
+        c.groupCollapsed(`%cnative %c${call.pluginId}.${call.methodName} (#${call.callbackId})`,
+            `font-weight: lighter; color: gray`, `font-weight: bold; color: #000`);
+        c.dir(call);
+        c.groupEnd();
+        //orgConsole.log('LOG TO NATIVE', call);
+    } else {
+        win.console.log('LOG TO NATIVE: ', call);
+        if (capacitor.isNative) {
+            try {
+                capacitor.toNative('Console', 'log', {message: JSON.stringify(call)});
+            } catch (e) {
+                win.console.log('Error converting/posting console messages');
+            }
+        }
+    }
   }
 
   capacitor.logFromNative = function(result) {
-    var c = orgConsole;
+      if(Object.keys(orgConsole).length > 0) {
+          var c = orgConsole;
 
-    const success = result.success === true;
+          var success = result.success === true;
 
-    const tagStyles = success ? `font-style: italic; font-weight: lighter; color: gray` :
-      `font-style: italic; font-weight: lighter; color: red`;
+          var tagStyles = success ? 'font-style: italic; font-weight: lighter; color: gray' :
+              'font-style: italic; font-weight: lighter; color: red';
 
-    c.groupCollapsed(`%cresult %c${result.pluginId}.${result.methodName} (#${result.callbackId})`,
-      tagStyles,
-      `font-style: italic; font-weight: bold; color: #444`);
-    if (result.success === false) {
-      c.error(result.error);
-    } else {
-      c.dir(result.data);
-    }
-    c.groupEnd();
+          c.groupCollapsed('%cresult %c' + result.pluginId + '.' + result.methodName + ' (#' + result.callbackId + ')',
+              tagStyles,
+              'font-style: italic; font-weight: bold; color: #444');
+          if (result.success === false) {
+              c.error(result.error);
+          } else {
+              c.dir(result.data);
+          }
+          c.groupEnd();
+      } else {
+          if (result.success === false) {
+              win.console.error(result.error);
+          } else {
+              win.console.log(result.data);
+          }
+      }
   }
 
   capacitor.uuidv4 = function() {

--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -44,6 +44,11 @@
     capacitor.platform = 'ios';
   }
 
+  var useFallbackLogging = Object.keys(win.console).length === 0;
+  if(useFallbackLogging) {
+    win.console.warn('Advance console logging disabled.')
+  }
+
   // patch window.console and store original console fns
   var orgConsole = {};
   Object.keys(win.console).forEach(level => {
@@ -272,7 +277,7 @@
   };
 
   capacitor.logToNative = function(call) {
-    if(Object.keys(win.console).length > 0) {
+    if(!useFallbackLogging) {
         var c = orgConsole;
         c.groupCollapsed(`%cnative %c${call.pluginId}.${call.methodName} (#${call.callbackId})`,
             `font-weight: lighter; color: gray`, `font-weight: bold; color: #000`);
@@ -292,7 +297,7 @@
   }
 
   capacitor.logFromNative = function(result) {
-      if(Object.keys(orgConsole).length > 0) {
+      if(!useFallbackLogging) {
           var c = orgConsole;
 
           var success = result.success === true;


### PR DESCRIPTION
Fallback logging to old console.log/error as no keys are exposed by Object.keys(console) until more recent versions of webview/chrome