### PR TITLE
Init pluginObjects dictionary

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
@@ -8,6 +8,7 @@
   self = [super init];
   if (self != nil) {
     _pluginsMap = mapping;
+    _pluginObjects = [[NSMutableDictionary alloc] init];
   }
   return self;
 }


### PR DESCRIPTION
Retaining and reusing plugins wasn't working because pluginObjects dictionary was not initialized