### PR TITLE
Update build.gradle dependency for Capacitor

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'ionic-team:capacitor-android:0.0.+'
+    implementation 'ionic-team:capacitor-android:1.0.+'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'


### PR DESCRIPTION
Updated to `ionic-team:capacitor-android:1.0.+` .

Using `+` to account for future release.

Closes issue #271 