### PR TITLE
Use plugin name in no impl. error message

### DIFF
--- a/core/src/web-runtime.ts
+++ b/core/src/web-runtime.ts
@@ -3,39 +3,21 @@ export class CapacitorWeb {
   platform = 'web';
   isNative = false;
 
-  NOOP_PLUGIN: any = {};
-
   constructor() {
-    // Construct a "Noop Plugin" that handles all method calls if a plugin
-    // isn't available, returning a rejected promise
-    /*
-    this.NOOP_PLUGIN = new Proxy<any>(this.NOOP_PLUGIN, {
-      get: (target, prop) => {
-        console.log('NOOP:: target: ' + JSON.stringify(target) + '  ---  prop: ' + JSON.stringify(prop));
-        if (typeof target[prop] === 'undefined') {
-          return this.pluginMethodNoop.bind(this, target, prop);
-        } else {
-          return target[prop];
-        }
-      }
-    });
-    */
-
     // Build a proxy for the Plugins object that returns the "Noop Plugin"
     // if a plugin isn't available
     this.Plugins = new Proxy<any>(this.Plugins, {
       get: (target, prop) => {
         if (typeof target[prop] === 'undefined') {
-          //return this.NOOP_PLUGIN;
           let thisRef = this;
           return new Proxy<any>({}, {
-              get: (_target, _prop) => {
-                  if (typeof _target[_prop] === 'undefined') {
-                      return thisRef.pluginMethodNoop.bind(thisRef, _target, _prop,  prop);
-                  } else {
-                      return _target[_prop];
-                  }
+            get: (_target, _prop) => {
+              if (typeof _target[_prop] === 'undefined') {
+                return thisRef.pluginMethodNoop.bind(thisRef, _target, _prop,  prop);
+              } else {
+                return _target[_prop];
               }
+            }
           });
         } else {
           return target[prop];

--- a/core/src/web-runtime.ts
+++ b/core/src/web-runtime.ts
@@ -8,8 +8,10 @@ export class CapacitorWeb {
   constructor() {
     // Construct a "Noop Plugin" that handles all method calls if a plugin
     // isn't available, returning a rejected promise
+    /*
     this.NOOP_PLUGIN = new Proxy<any>(this.NOOP_PLUGIN, {
       get: (target, prop) => {
+        console.log('NOOP:: target: ' + JSON.stringify(target) + '  ---  prop: ' + JSON.stringify(prop));
         if (typeof target[prop] === 'undefined') {
           return this.pluginMethodNoop.bind(this, target, prop);
         } else {
@@ -17,13 +19,24 @@ export class CapacitorWeb {
         }
       }
     });
+    */
 
     // Build a proxy for the Plugins object that returns the "Noop Plugin"
     // if a plugin isn't available
     this.Plugins = new Proxy<any>(this.Plugins, {
       get: (target, prop) => {
         if (typeof target[prop] === 'undefined') {
-          return this.NOOP_PLUGIN;
+          //return this.NOOP_PLUGIN;
+          let thisRef = this;
+          return new Proxy<any>({}, {
+              get: (_target, _prop) => {
+                  if (typeof _target[_prop] === 'undefined') {
+                      return thisRef.pluginMethodNoop.bind(thisRef, _target, _prop,  prop);
+                  } else {
+                      return _target[_prop];
+                  }
+              }
+          });
         } else {
           return target[prop];
         }
@@ -31,8 +44,8 @@ export class CapacitorWeb {
     })
   }
 
-  pluginMethodNoop(_target: any, _prop: PropertyKey) {
-    return Promise.reject(`Plugin does not have web implementation.`);
+  pluginMethodNoop(_target: any, _prop: PropertyKey, pluginName: string) {
+    return Promise.reject(`${pluginName} does not have web implementation.`);
   }
 
   getPlatform() {


### PR DESCRIPTION
"Plugin does not have web implementation." error message now uses the plugin name instead of just "Plugin"

ex: `Keyboard does not have web implementation.`

Addresses issue #253 