### PR TITLE
Set flatDir for libs

### DIFF
--- a/capacitor-android-plugins/build.gradle
+++ b/capacitor-android-plugins/build.gradle
@@ -27,6 +27,9 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    flatDir{
+        dirs 'src/main/libs', 'libs'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Some aar files from Cordova plugins are still not found, point to the libs folder with flatDir