### PR TITLE
Generate capacitor-ios package to publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ site/www
 android-template.iml
 !/build/.npmkeep
 lerna-debug.log
+capacitor-ios/

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
   "gitVersionPrefix": "",
   "packages": [
     "./cli/",
-    "./core/"
+    "./core/",
+    "./capacitor-ios/"
   ],
   "version": "1.0.0-alpha.13"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"publish": "lerna run build && lerna publish --force-publish --skip-git && npm run deploy",
+		"publish": "bash scripts/generate.sh && lerna run build && lerna publish --force-publish --skip-git && npm run deploy",
 		"deploy": "bash scripts/deploy.sh"
 	},
 	"devDependencies": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,6 +28,8 @@ git commit -m "Release v$LERNA_VERSION"
 git tag $LERNA_VERSION -m $LERNA_VERSION
 git push --follow-tags origin master
 
+rm -rf capacitor-ios
+
 # Do the actual native deploys second, because they require tags/releases in github
 bash scripts/deploy/pods.sh
 bash scripts/deploy/android.sh

--- a/scripts/deploy/package.json.template
+++ b/scripts/deploy/package.json.template
@@ -1,0 +1,18 @@
+{
+  "name": "@capacitor/capacitor-ios",
+  "version": "LERNA_VERSION",
+  "description": "Capacitor: cross-platform mobile apps with the web",
+  "homepage": "http://getcapacitor.com/",
+  "author": "Ionic Team <hi@ionic.io> (https://ionicframework.com) ",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ionic-team/capacitor.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ionic-team/capacitor/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,0 +1,9 @@
+LERNA_JSON=`cat lerna.json`;
+export LERNA_VERSION="$(node -pe "JSON.parse(\`$LERNA_JSON\`)['version']")"
+
+mkdir capacitor-ios
+cp -r ios capacitor-ios/ios/
+cp Capacitor.podspec capacitor-ios/
+cp CapacitorCordova.podspec capacitor-ios/
+sed "s/LERNA_VERSION/$LERNA_VERSION/g" scripts/deploy/package.json.template > capacitor-ios/package.json
+


### PR DESCRIPTION
Adds a generate script for creating capacitor-ios folder with ios folder inside and a package.json so it can be published on npm.

Not sure if it will work as I added capacitor-ios to the gitignore to not commit it.