### PR TITLE
fix for electron-template

### DIFF
--- a/electron-template/package.json
+++ b/electron-template/package.json
@@ -7,6 +7,7 @@
     "electron:start": "electron ./"
   },
   "dependencies": {
+    "@capacitor/electron": "^1.0.0-alpha.15",
     "electron-is-dev": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`@capacitor/electron` needs to be installed when an electron project is added, but the dependency was missing.