### PR TITLE
Remove Podfile.lock and always run pod install instead of pod update

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -9,7 +9,7 @@ import { join, resolve } from 'path';
 
 const platform = 'android';
 
-export async function updateAndroid(config: Config, needsUpdate: boolean) {
+export async function updateAndroid(config: Config) {
   let plugins = await getPluginsTask(config);
 
   const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Core);

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -23,6 +23,6 @@ export async function syncCommand(config: Config, selectedPlatform: string) {
 }
 
 export async function sync(config: Config, platformName: string) {
-  const tasks = [() => copy(config, platformName), () => update(config, platformName, false)];
+  const tasks = [() => copy(config, platformName), () => update(config, platformName)];
   await allSerial(tasks);
 }

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -19,7 +19,7 @@ export async function updateCommand(config: Config, selectedPlatformName: string
       [checkPackage, ...updateChecks(config, platforms)]
     );
 
-    await allSerial(platforms.map(platformName => async () => await update(config, platformName, true)));
+    await allSerial(platforms.map(platformName => async () => await update(config, platformName)));
     const then = +new Date;
   } catch (e) {
     logFatal(e);
@@ -44,12 +44,12 @@ export function updateChecks(config: Config, platforms: string[]): CheckFunction
   return checks;
 }
 
-export async function update(config: Config, platformName: string, needsUpdate: boolean) {
+export async function update(config: Config, platformName: string) {
   runTask(chalk`{green {bold update}} {bold ${platformName}}`, async () => {
     if (platformName === config.ios.name) {
-      await updateIOS(config, needsUpdate);
+      await updateIOS(config);
     } else if (platformName === config.android.name) {
-      await updateAndroid(config, needsUpdate);
+      await updateAndroid(config);
     }
   });
 }


### PR DESCRIPTION
Remove Podfile.lock and always run pod install instead of pod update

Removed the needsUpdate flag as it was used to run install or update and now we always use install, and wasn't used on Android.
Also removed the log about running pod repo update regularly as our pods are local now.