### PR TITLE
Electron Network plugin support

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1011,7 +1011,7 @@ export interface NetworkPlugin extends Plugin {
 
 export interface NetworkStatus {
   connected: boolean;
-  connectionType: 'wifi' | 'cellular' | 'none';
+  connectionType: 'wifi' | 'cellular' | 'none' | 'unknown';
 }
 
 export type NetworkStatusChangeCallback = (status: NetworkStatus) => void;

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -2,9 +2,12 @@ import {
   WebPlugin,
   FileReadOptions, FileReadResult,
   FilesystemPlugin, FileWriteOptions,
-  FileWriteResult,
-  FileAppendOptions, FileAppendResult, FileDeleteOptions, FileDeleteResult,
-  MkdirOptions, MkdirResult
+  FileWriteResult, FileDeleteResult,
+  FileAppendOptions, FileAppendResult,
+  ReaddirOptions, ReaddirResult,
+  MkdirOptions, MkdirResult, GetUriOptions,
+  RmdirOptions, RmdirResult, GetUriResult,
+  StatOptions, StatResult,FileDeleteOptions,
 } from "@capacitor/core";
 
 export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlugin {
@@ -74,7 +77,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
   deleteFile(options: FileDeleteOptions): Promise<FileDeleteResult> {
     return new Promise((resolve, reject) => {
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
-        reject(`${options.directory} is currently not supported in the Electron implementation.`);
+        reject(`${options.directory} directory is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
       this.NodeFS.unlink(lookupPath, (err:any) => {
         if(err)
@@ -98,7 +101,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
   }
 
   // TODO: continue bring to spec.
-  rmdir(options: {path: string}): Promise<any> {
+  rmdir(options: RmdirOptions): Promise<RmdirResult> {
     return new Promise((resolve, reject) => {
       this.NodeFS.rmdir(options.path, (err:any) => {
         if(err)
@@ -108,7 +111,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     });
   }
 
-  readdir(options: {path: string, encoding?: string}): Promise<any> {
+  readdir(options: ReaddirOptions): Promise<ReaddirResult> {
     return new Promise((resolve, reject) => {
       let opts = {path: options.path, encoding: 'utf-8'};
       this.NodeFS.readdir(opts.path, opts.encoding, (err:any, files: string[]) => {
@@ -119,25 +122,24 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     });
   }
 
-  getUri(options: any): Promise<any> {
+  getUri(options: GetUriOptions): Promise<GetUriResult> {
+    return new Promise((resolve, reject) => {
+      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
+        reject(`${options.directory} directory is currently not supported in the Electron implementation.`);
+      let lookupPath = this.fileLocations[options.directory] + options.path;
+      resolve({uri: lookupPath});
+    });
+  };
+
+  stat(options: StatOptions): Promise<StatResult> {
     return new Promise((resolve, reject) => {
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.mkdir(lookupPath, (err:any) => {
-        if(err)
-          reject(err);
-        resolve();
-      });
-    });
-  };
-
-  stat(options: {path: string}): Promise<any> {
-    return new Promise((resolve, reject) => {
       this.NodeFS.stat(options.path, (err:any, stats:any) => {
         if(err)
           reject(err);
-        resolve({type: 'Not Available', size: stats.size, ctime: stats.ctimeMs, mtime: stats.mtimeMs});
+        resolve({type: 'Not Available', size: stats.size, ctime: stats.ctimeMs, mtime: stats.mtimeMs, uri: lookupPath});
       });
     });
   }

--- a/electron/src/electron/network.ts
+++ b/electron/src/electron/network.ts
@@ -24,13 +24,13 @@ export class NetworkPluginElectron extends WebPlugin implements NetworkPlugin {
       if(!window.navigator)
         reject('Network info not available');
       let connected = window.navigator.onLine;
-      resolve({connected: connected, connectionType: connected ? 'wifi' : 'none'});
+      resolve({connected: connected, connectionType: connected ? 'unknown' : 'none'});
     });
   }
 
   addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle {
     let thisRef = this;
-    let onlineBindFunc = listenerFunc.bind(thisRef,{connected: true, connectionType: 'wifi'});
+    let onlineBindFunc = listenerFunc.bind(thisRef,{connected: true, connectionType: 'unknown'});
     let offlineBindFunc = listenerFunc.bind(thisRef,{connected: false, connectionType: 'none'});
     if(eventName.localeCompare('networkStatusChange') === 0) {
       window.addEventListener('online', onlineBindFunc);

--- a/electron/src/electron/network.ts
+++ b/electron/src/electron/network.ts
@@ -24,13 +24,23 @@ export class NetworkPluginElectron extends WebPlugin implements NetworkPlugin {
       if(!window.navigator)
         reject('Network info not available');
       let connected = window.navigator.onLine;
-      resolve({connected: connected, connectionType: connected ? 'unknown' : 'none'});
+      let connection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+      let connectionType = 'wifi';
+      if(connection) {
+        connectionType = connection.type;
+      }
+      resolve({connected: connected, connectionType: connected ? connectionType : 'none'});
     });
   }
 
   addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle {
     let thisRef = this;
-    let onlineBindFunc = listenerFunc.bind(thisRef,{connected: true, connectionType: 'unknown'});
+    let connection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+    let connectionType = 'wifi';
+    if(connection) {
+      connectionType = connection.type;
+    }
+    let onlineBindFunc = listenerFunc.bind(thisRef,{connected: true, connectionType: connectionType});
     let offlineBindFunc = listenerFunc.bind(thisRef,{connected: false, connectionType: 'none'});
     if(eventName.localeCompare('networkStatusChange') === 0) {
       window.addEventListener('online', onlineBindFunc);

--- a/electron/src/electron/network.ts
+++ b/electron/src/electron/network.ts
@@ -10,6 +10,8 @@ declare var window:any;
 
 export class NetworkPluginElectron extends WebPlugin implements NetworkPlugin {
 
+  listenerFunction:any = null;
+
   constructor() {
     super({
       name: 'Network',
@@ -27,13 +29,16 @@ export class NetworkPluginElectron extends WebPlugin implements NetworkPlugin {
   }
 
   addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle {
+    let thisRef = this;
+    let onlineBindFunc = listenerFunc.bind(thisRef,{connected: true, connectionType: 'wifi'});
+    let offlineBindFunc = listenerFunc.bind(thisRef,{connected: false, connectionType: 'none'});
     if(eventName.localeCompare('networkStatusChange') === 0) {
-      window.addEventListener('online', listenerFunc({connected: true, connectionType: 'wifi'}));
-      window.addEventListener('offline', listenerFunc({connected: false, connectionType: 'none'}));
+      window.addEventListener('online', onlineBindFunc);
+      window.addEventListener('offline', offlineBindFunc);
       return {
         remove: () => {
-          window.removeEventListener('online', listenerFunc({connected: true, connectionType: 'wifi'}));
-          window.removeEventListener('offline', listenerFunc({connected: false, connectionType: 'none'}));
+          window.removeEventListener('online', onlineBindFunc);
+          window.removeEventListener('offline', offlineBindFunc);
         }
       };
     }

--- a/electron/src/electron/network.ts
+++ b/electron/src/electron/network.ts
@@ -1,0 +1,47 @@
+import {
+  WebPlugin, NetworkPlugin,
+  NetworkStatus
+} from "@capacitor/core";
+
+export interface PluginListenerHandle {
+  remove: () => void;
+}
+
+declare var window:any;
+
+export class NetworkPluginElectron extends WebPlugin implements NetworkPlugin {
+
+  constructor() {
+    super({
+      name: 'Network',
+      platforms: ['electron']
+    });
+  }
+
+  getStatus(): Promise<NetworkStatus> {
+    return new Promise((resolve, reject) => {
+      if(!window.navigator)
+        reject('Network info not available');
+      let connected = window.navigator.onLine;
+      resolve({connected: connected, connectionType: connected ? 'wifi' : 'none'});
+    });
+  }
+
+  addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle {
+    if(eventName.localeCompare('networkStatusChange') === 0) {
+      window.addEventListener('online', listenerFunc({connected: true, connectionType: 'wifi'}));
+      window.addEventListener('offline', listenerFunc({connected: false, connectionType: 'none'}));
+      return {
+        remove: () => {
+          window.removeEventListener('online', listenerFunc({connected: true, connectionType: 'wifi'}));
+          window.removeEventListener('offline', listenerFunc({connected: false, connectionType: 'none'}));
+        }
+      };
+    }
+  }
+
+}
+
+const Network = new NetworkPluginElectron();
+
+export { Network };

--- a/electron/src/electron/network.ts
+++ b/electron/src/electron/network.ts
@@ -1,6 +1,5 @@
 import {
-  WebPlugin, NetworkPlugin,
-  NetworkStatus
+  WebPlugin, NetworkPlugin, NetworkStatus
 } from "@capacitor/core";
 
 export interface PluginListenerHandle {

--- a/electron/src/plugins.ts
+++ b/electron/src/plugins.ts
@@ -10,6 +10,7 @@ export * from '@capacitor/core/dist/esm/web/share';
 export * from '@capacitor/core/dist/esm/web/modals';
 export * from '@capacitor/core/dist/esm/web/storage';
 export * from './electron/filesystem';
+export * from './electron/network';
 
 mergeWebPlugins(Plugins);
 


### PR DESCRIPTION
Adds the core plugin `Network` to electron.

**Limitation:**
- At this time I can not find a way to detect type of connection, be it WiFi, Ethernet, ectra. So for now, the `connectionType` will either be set to `wifi` or `none` depending on the status of `connected`.