### PR TITLE
Fix windows Android Studio path

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -76,7 +76,7 @@ export class Config implements CliConfig {
     webDir: 'www',
     webDirAbs: '',
     package: Package,
-    windowsAndroidStudioPath: 'C:\\Program Files\\Android Studio\\bin\\studio64.exe',
+    windowsAndroidStudioPath: 'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe',
     linuxAndroidStudioPath: '',
     extConfigName: 'capacitor.config.json',
     extConfigFilePath: '',

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -33,7 +33,7 @@ The current ones you might configure are:
   // On Windows, we aren't able to automatically open Android Studio
   // without knowing the full path. The default is set to the default
   // Android Studio install path, but you may change it manually.
-  "windowsAndroidStudioPath": 'C:\\Program Files\\Android Studio\\bin\\studio64.exe',
+  "windowsAndroidStudioPath": 'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe',
 }
 ```
 

--- a/site/src/assets/docs-content/basics/configuring-your-app.html
+++ b/site/src/assets/docs-content/basics/configuring-your-app.html
@@ -25,7 +25,7 @@ the Capacitor documentation exists to help web developers do just that.</p>
   <span class="hljs-comment">// On Windows, we aren't able to automatically open Android Studio</span>
   <span class="hljs-comment">// without knowing the full path. The default is set to the default</span>
   <span class="hljs-comment">// Android Studio install path, but you may change it manually.</span>
-  <span class="hljs-string">"windowsAndroidStudioPath"</span>: <span class="hljs-string">'C:\\Program Files\\Android Studio\\bin\\studio64.exe'</span>,
+  <span class="hljs-string">"windowsAndroidStudioPath"</span>: <span class="hljs-string">'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe'</span>,
 }
 </code></pre>
 <h2 id="native-configuration">Native Configuration</h2>


### PR DESCRIPTION
I was looking into a windows issue and npx cap open android wasn't working despite https://github.com/ionic-team/capacitor/commit/49e94b3c8d33962ab15ca2d3464eb358ad36bba0

As windowsAndroidStudioPath is set, it's using it's value, so changing the default path it there too.
Also changed the path in some docs