### PR TITLE
Handle Out of Memory error

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -258,6 +258,8 @@ public class Camera extends Plugin {
       }
 
       returnResult(call, bitmap, u);
+    } catch (OutOfMemoryError err) {
+      call.error("Out of memory");
     } catch (FileNotFoundException ex) {
       call.error("No such image found", ex);
     } finally {


### PR DESCRIPTION
If the image is very big or it's corrupt it will increase memory until it crash the app.
With this change, we catch the OutOfMemory and return an error instead of crashing.