### PR TITLE
doc(getting-started): move dependencies before installation

### DIFF
--- a/site/src/components/site-menu/site-menu.tsx
+++ b/site/src/components/site-menu/site-menu.tsx
@@ -14,16 +14,16 @@ export class SiteMenu {
           url: '/docs/'
         },
         { 
+          title: 'Required Dependencies',
+          url: '/docs/getting-started/dependencies'
+        },
+        { 
           title: 'Installation',
           url: '/docs/getting-started/'
         },
         {
           title: 'Using with Ionic',
           url: '/docs/getting-started/with-ionic'
-        },
-        { 
-          title: 'Required Dependencies',
-          url: '/docs/getting-started/dependencies'
         }
         /*
         ,


### PR DESCRIPTION
I believe when starting with a project, people tend to read and follow along with the "Getting Started" section in the order it is there. In that light, it makes sense to put the checking of required dependencies before the installation section.