### PR TITLE
Update capacitor dependency version for plugins

### DIFF
--- a/plugin-template/android/plugin/build.gradle
+++ b/plugin-template/android/plugin/build.gradle
@@ -42,7 +42,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'ionic-team:capacitor-android:0.0.+'
+    implementation 'ionic-team:capacitor-android:1+'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'


### PR DESCRIPTION
Tried to use a local dependency without success (because the plugin projects are modules and modules don't have the settings.gradle), so I think using 1+ is our best option here.

Closes #410