### PR TITLE
Geolocation fixes

### DIFF
--- a/example/src/pages/geolocation/geolocation.ts
+++ b/example/src/pages/geolocation/geolocation.ts
@@ -56,7 +56,7 @@ export class GeolocationPage {
 
   watchPosition() {
     try {
-      this.watchId = Plugins.Geolocation.watchPosition({}, (err, position) => {
+      this.watchId = Plugins.Geolocation.watchPosition({}, (position, err) => {
         console.log('Watch', position);
         this.zone.run(() => {
           this.watchCoords = position.coords;


### PR DESCRIPTION
The example had the callback params switched for watchPosition.

Make handleRequestPermissionsResult call super.handleRequestPermissionsResult so it handles missing permissions in AndroidManifest.xml

Removed the custom permissionWaitCall, switched to use the way provided by Plugin class.