### PR TITLE
Fix Capacitor plugin paths

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -86,7 +86,7 @@ export async function updatePodfile(config: Config, plugins: Plugin[]) {
 export function generatePodFile(config: Config, plugins: Plugin[]) {
   const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) !== PluginType.Cordova);
   const pods = capacitorPlugins
-    .map((p) => `pod '${p.ios!.name}', :path => '../../node_modules/${p.id}/${p.ios!.path}'`);
+    .map((p) => `pod '${p.ios!.name}', :path => '../../node_modules/${p.id}'`);
   const cordovaPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Cordova);
   const noPodPlugins = cordovaPlugins.filter(filterNoPods);
   if (noPodPlugins.length > 0) {

--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -142,7 +142,7 @@ function generatePodspec(config: Config, answers: any) {
     s.homepage = '${answers.git}'
     s.author = '${answers.author}'
     s.source = { :git => '${answers.git}', :tag => s.version.to_s }
-    s.source_files = 'Plugin/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+    s.source_files = 'ios/Plugin/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '${config.ios.minVersion}'
     s.dependency 'Capacitor'
   end`;


### PR DESCRIPTION
The podspec for the plugins is on the root, update the sources path of the podspec and the Podfile path for using the plugin root.