### PR TITLE
[Android] Allow custom webviews to load capacitor

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -240,14 +240,13 @@ public class Bridge {
 
       private void injectScriptFile(WebView view, String script) {
 
-        // String-ify the script byte-array using BASE64 encoding !!!
+        // Base64 encode string before injecting as innerHTML
         String encoded = Base64.encodeToString(script.getBytes(), Base64.NO_WRAP);
-        Log.d(TAG, "Trying to inject - " + encoded);
         view.loadUrl("javascript:(function() {" +
                 "var parent = document.getElementsByTagName('head').item(0);" +
                 "var script = document.createElement('script');" +
                 "script.type = 'text/javascript';" +
-                // Tell the browser to BASE64-decode the string into your script !!!
+                // Base64 decode injected javascript
                 "script.innerHTML = window.atob('" + encoded + "');" +
                 "parent.appendChild(script)" +
                 "})()");

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -216,7 +216,8 @@ public class Bridge {
   private void loadCustomWebView() {
     webView.setWebChromeClient(new BridgeWebChromeClient(this));
 
-    // Get to work
+    // Saving off old client so no functionality is lost if
+    // custom webview implements an existing client
     final WebViewClient oldClient = webView.getWebViewClient();
     webView.setWebViewClient(new WebViewClient() {
 

--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -39,6 +39,16 @@ class JSInjector {
     this.cordovaPluginsFileJS = cordovaPluginsFileJS;
   }
 
+  /**
+   * Generates injectable JS content.
+   * This may be used in other forms of injecting that aren't using an InputStream.
+   * @return
+   */
+  public String getScriptString() {
+    return globalJS + "\n\n" +
+              coreJS + "\n\n" + pluginJS + "\n\n" + cordovaJS + "\n\n" +
+              cordovaPluginsFileJS + "\n\n" + cordovaPluginsJS;
+  }
 
   /**
    * Given an InputStream from the web server, prepend it with
@@ -48,9 +58,7 @@ class JSInjector {
    */
   public InputStream getInjectedStream(InputStream responseStream) {
     try {
-      String js = "<script type=\"text/javascript\">" + globalJS + "\n\n" +
-              coreJS + "\n\n" + pluginJS + "\n\n" + cordovaJS + "\n\n" +
-              cordovaPluginsFileJS + "\n\n" + cordovaPluginsJS + "</script>";
+      String js = "<script type=\"text/javascript\">" + getScriptString() + "</script>";
       InputStream jsInputStream = new ByteArrayInputStream(js.getBytes(StandardCharsets.UTF_8.name()));
       return new SequenceInputStream(jsInputStream, responseStream);
     } catch(UnsupportedEncodingException ex) {


### PR DESCRIPTION
This is the Android equivalent PR for https://github.com/ionic-team/capacitor/pull/294

## What got changed
- Added a new boolean to the `Bridge` constructor to setup a `WebClient` to load from a custom URL
- The new custom URL `WebClient` will inject all the `JSInjector` javascript at `pageFinished`
  - This also saves off the previous `WebClient` and will call those methods as well just incase the custom implementation depended on that `WebClient`

## Proof
This is using a Turbolinks Android project showing GPS and Modal plugins working 

![screen shot 2018-04-06 at 1 36 43 pm](https://user-images.githubusercontent.com/401294/38439404-25fb96ea-39a3-11e8-98eb-1b71c8898fe5.png)

```java
public class MainActivity extends AppCompatActivity implements TurbolinksAdapter, TabLayout.OnTabSelectedListener {

    @BindView(R.id.turbolinks_view) TurbolinksView turbolinksView;
    @BindView(R.id.tab_view) TabLayout tabView;
    private JsonArray tabs;

    protected Bridge bridge;
    public CordovaInterfaceImpl cordovaInterface;
    private ArrayList<PluginEntry> pluginEntries;
    PluginManager pluginManager;
    private CordovaPreferences preferences;

    private int activityDepth = 0;

    private String lastActivityPlugin;

    private List<Class<? extends Plugin>> initialPlugins = new ArrayList<>();

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);
        ButterKnife.bind(this);

        tabView.addOnTabSelectedListener(this);

        TurbolinksSession.getDefault(this)
                .activity(this)
                .adapter(this)
                .view(turbolinksView)
                .visit("https://myurl.com");

        loadConfig(this.getApplicationContext(),this);
        this.load(savedInstanceState);
    }

    /**
     * Load the WebView and create the Bridge
     */
    protected void load(Bundle savedInstanceState) {
        Log.d(Bridge.TAG, "Starting BridgeActivity");

        WebView webView = TurbolinksSession.getDefault(this).getWebView();

        WebView webview = new WebView(this);
        webView.setWebContentsDebuggingEnabled(true);

        cordovaInterface = new CordovaInterfaceImpl(this);
        if (savedInstanceState != null) {
            cordovaInterface.restoreInstanceState(savedInstanceState);
        }

        MockCordovaWebViewImpl mockWebView = new MockCordovaWebViewImpl(this.getApplicationContext());
        mockWebView.init(cordovaInterface, pluginEntries, preferences, webView);

        this.pluginManager = mockWebView.getPluginManager();
        cordovaInterface.onCordovaInit(this.pluginManager);
        bridge = new Bridge(this, webView, initialPlugins, cordovaInterface, this.pluginManager, true);

        if (savedInstanceState != null) {
            bridge.restoreInstanceState(savedInstanceState);
        }
    }
    public Bridge getBridge() {
        return this.bridge;
    }

    /**
     * Notify the App plugin that the current state changed
     * @param isActive
     */
    private void fireAppStateChanged(boolean isActive) {
        PluginHandle handle = bridge.getPlugin("App");
        if (handle == null) {
            return;
        }

        App appState = (App) handle.getInstance();
        if (appState != null) {
            appState.fireChange(isActive);
        }
    }

    @Override
    public void onSaveInstanceState(Bundle outState) {
        super.onSaveInstanceState(outState);
        bridge.saveInstanceState(outState);
    }

    @Override
    public void onStart() {
        super.onStart();

        activityDepth++;

        this.bridge.onStart();

        Log.d(Bridge.TAG, "App started");
    }

    @Override
    public void onRestart() {
        super.onRestart();
        this.bridge.onRestart();
        Log.d(Bridge.TAG, "App restarted");
    }

    @Override
    public void onResume() {
        super.onResume();

        fireAppStateChanged(true);

        this.bridge.onResume();

        Log.d(Bridge.TAG, "App resumed");
    }

    @Override
    public void onPause() {
        super.onPause();

        this.bridge.onPause();

        Log.d(Bridge.TAG, "App paused");
    }

    @Override
    public void onStop() {
        super.onStop();

        activityDepth = Math.max(0, activityDepth - 1);
        if (activityDepth == 0) {
            fireAppStateChanged(false);
        }

        this.bridge.onStop();

        Log.d(Bridge.TAG, "App stopped");
    }

    @Override
    public void onDestroy() {
        super.onDestroy();
        Log.d(Bridge.TAG, "App destroyed");
    }

    @Override
    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
        if (this.bridge == null) {
            return;
        }

        this.bridge.onRequestPermissionsResult(requestCode, permissions, grantResults);
    }

    @Override
    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
        if (this.bridge == null) {
            return;
        }
        this.bridge.onActivityResult(requestCode, resultCode, data);
    }

    @Override
    protected void onNewIntent(Intent intent) {
        if (this.bridge == null) {
            return;
        }

        this.bridge.onNewIntent(intent);
    }

    public void loadConfig(Context context, Activity activity) {
        ConfigXmlParser parser = new ConfigXmlParser();
        parser.parse(context);
        preferences = parser.getPreferences();
        preferences.setPreferencesBundle(activity.getIntent().getExtras());
        pluginEntries = parser.getPluginEntries();
    }

    @Override
    public void onReceivedError(int errorCode) {}

    @Override
    public void pageInvalidated() {}

    @Override
    public void requestFailedWithStatusCode(int statusCode) {}

    @Override
    public void visitCompleted() {}

    @Override
    public void visitProposedToLocationWithAction(String location, String action) {}

    @Override
    public void onTabUnselected(TabLayout.Tab tab) {}

    @Override
    public void onTabReselected(TabLayout.Tab tab) {}
}
```