### PR TITLE
fix(): adjust the layout guides

### DIFF
--- a/ios-template/App/App/Base.lproj/Main.storyboard
+++ b/ios-template/App/App/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14111" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
     </dependencies>
     <scenes>
         <!--Bridge View Controller-->


### PR DESCRIPTION
This adjust the Main.storyboard layouts to not use the safe-area guides. 

Going from this 
![simulator screen shot - iphone x - 2018-04-09 at 10 25 12](https://user-images.githubusercontent.com/2835826/38505209-a1dcdae2-3be4-11e8-94ca-164e8dea28bd.png)


To this:

![screen shot 2018-04-09 at 10 31 15 am](https://user-images.githubusercontent.com/2835826/38505222-aac87ef4-3be4-11e8-9654-fbf531073acf.png)

Ref #337 
