### PR TITLE
Add postBuildExtras script

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -73,6 +73,10 @@ ${capacitorPlugins.map(p => {
 ${frameworkString}
 }
 ${applyArray.join('\n')}
+
+if (hasProperty('postBuildExtras')) {
+  postBuildExtras()
+}
 `;
 
   await writeFileAsync(join(config.app.rootDir, 'android/capacitor.settings.gradle'), settingsLines);


### PR DESCRIPTION
This is needed if a plugin's gradle file has a postBuildExtras task declared, otherwise the task won't be executed.

The PR writes it in the capacitor.build.gradle, but we can put it in the app's build.gradle instead.