### PR TITLE
Make buildXmlElement sync

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -162,15 +162,15 @@ async function writeCordovaAndroidManifest(cordovaPlugins: Plugin[], config: Con
   const manifestPath = join(pluginsFolder, 'src', 'main', 'AndroidManifest.xml');
   let rootXMLEntries: Array<any> = [];
   let applicationXMLEntries: Array<any> = [];
-  await Promise.all(cordovaPlugins.map(async p => {
+  cordovaPlugins.map(async p => {
     const editConfig = getPlatformElement(p, platform, 'edit-config');
     const configFile = getPlatformElement(p, platform, 'config-file');
-    await Promise.all(editConfig.concat(configFile).map(async (configElement: any) => {
+    editConfig.concat(configFile).map(async (configElement: any) => {
       if (configElement.$.target.includes('AndroidManifest.xml')) {
         const keys = Object.keys(configElement).filter(k  => k !== '$');
-        await Promise.all(keys.map(async k => {
-          await Promise.all(configElement[k].map(async (e: any) => {
-            const xmlElement = await buildXmlElement(e, k)
+        keys.map(k => {
+          configElement[k].map((e: any) => {
+            const xmlElement = buildXmlElement(e, k);
             const pathParts = getPathParts(configElement.$.parent);
             if(pathParts.length > 1) {
               if (pathParts.pop() === 'application') {
@@ -181,11 +181,11 @@ async function writeCordovaAndroidManifest(cordovaPlugins: Plugin[], config: Con
             } else {
               rootXMLEntries.push(xmlElement);
             }
-          }));
-        }));
+          });
+        });
       }
-    }));
-  }));
+    });
+  });
   let content = `<?xml version='1.0' encoding='utf-8'?>
 <manifest package='capacitor.android.plugins' xmlns:android='http://schemas.android.com/apk/res/android'>
 <application>

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -127,8 +127,8 @@ export function writeXML(object: any): Promise<any> {
   });
 }
 
-export async function buildXmlElement(configElement: any, rootName: string) {
-  const xml2js = await import('xml2js');
+export function buildXmlElement(configElement: any, rootName: string) {
+  const xml2js = require('xml2js');
   const builder = new xml2js.Builder({ headless: true, explicitRoot: false, rootName: rootName });
   return builder.buildObject(configElement);
 }

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -202,13 +202,13 @@ async function logiOSPlist (configElement: any, config: Config, plugin: Plugin) 
   const xmlMeta = await readXML(plistPath);
   const dict = xmlMeta.plist.dict.pop();
   if (!dict.key.includes(configElement.$.parent)) {
-    let xml = await buildConfigFileXml(configElement);
+    let xml = buildConfigFileXml(configElement);
     xml = `<key>${configElement.$.parent}</key>${getConfigFileTagContent(xml)}`;
     logInfo(`plugin ${plugin.id} requires to add \n  ${xml} to your Info.plist to work`);
   }
 }
 
-async function buildConfigFileXml(configElement: any) {
+function buildConfigFileXml(configElement: any) {
   return buildXmlElement(configElement, 'config-file');
 }
 


### PR DESCRIPTION
Changed `await import('xml2js');` to `require('xml2js');` so buildXmlElement is sync and doesn't need all those nested promises 
