### PR TITLE
Make posible for plugins to call evaluateJavaScript on the engine

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -22,6 +22,7 @@
 #import "CDVPluginResult.h"
 #import "CDVCommandDelegate.h"
 #import "CDVAvailability.h"
+#import <WebKit/WebKit.h>
 
 @interface UIView (org_apache_cordova_UIView_Extension)
 


### PR DESCRIPTION
Without this, Cordova plugins calling `self.webViewEngine evaluateJavaScript` will fail to build as WKWebView is not available to use.