### PR TITLE
Handle shouldOverrideUrlLoading for older Android versions

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -185,13 +185,21 @@ public class Bridge {
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         String url = request.getUrl().toString();
-        if (url.contains(appUrl)) {
-          return super.shouldOverrideUrlLoading(view, request);
-        } else {
-          Intent openIntent = new Intent(Intent.ACTION_VIEW, request.getUrl());
+        return launchIntent(url);
+      }
+
+      @Override
+      public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        return launchIntent(url);
+      }
+
+      private boolean launchIntent(String url) {
+        if (!url.contains(appUrl)) {
+          Intent openIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
           getContext().startActivity(openIntent);
           return true;
         }
+        return false;
       }
     });
 


### PR DESCRIPTION
shouldOverrideUrlLoading wasn't being called on my Android 5 device because the one we were using is API 24.

Added the old one to handle Android 21-23.

Simplified the code a bit as calling super.shouldOverrideUrlLoading does nothing, is better to return false.