### PR TITLE
Make sync run update even if copy fails

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -237,7 +237,7 @@ export async function runTask<T>(title: string, fn: () => Promise<T>): Promise<T
     return value;
 
   } catch (e) {
-    spinner.fail(`${title}: ${e.message}`);
+    spinner.fail(`${title}: ${e.message ? e.message : ''}`);
     spinner.stop();
     throw e;
   }

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -1,7 +1,7 @@
 import { Config } from '../config';
 import { copy } from './copy';
 import { update, updateChecks } from './update';
-import { check, checkPackage, checkWebDir, log, logFatal, logInfo } from '../common';
+import { check, checkPackage, checkWebDir, log, logError, logFatal, logInfo } from '../common';
 
 import { allSerial } from '../util/promise';
 
@@ -27,6 +27,10 @@ export async function syncCommand(config: Config, selectedPlatform: string) {
 }
 
 export async function sync(config: Config, platformName: string) {
-  const tasks = [() => copy(config, platformName), () => update(config, platformName)];
-  await allSerial(tasks);
+  try {
+    await copy(config, platformName);
+  } catch (e) {
+    logError(e);
+  }
+  await update(config, platformName);
 }


### PR DESCRIPTION
Changed copy method to show checkWebDir's error message (right now it's different if you run npx cap copy or if copy is called by other like sync) so it's consistent.

Changed sync function (called by add command) to execute copy and update even if copy fails.

Changed logFatal to logError because logFatal stops execution.

Changed spinner.fail to show only the error.message if defined, as I throw the message directly it was showing undefined, and throwing an Error object duplicated the message as both spinner.fail and logError were displaying the same.