### PR TITLE
Handle new Cordova plugin paths

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -118,7 +118,7 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
       if (sourceFiles) {
         sourceFiles.map((sourceFile: any) => {
           const fileName = sourceFile.$.src.split('/').pop();
-          const target = sourceFile.$['target-dir'].replace('src/', 'java/');
+          const target = sourceFile.$['target-dir'].replace('app/src/main/', '').replace('src/', 'java/');
           copySync(getFilePath(config, p, sourceFile.$.src), join(pluginsPath, target, fileName));
         });
       }


### PR DESCRIPTION
Some plugins have updated the target path to point to the new location (`app/src/main/`) instead of `src`, handle those targets too