### PR TITLE
Make create don't add platforms

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -4,8 +4,11 @@ import { setTimeout } from 'timers';
 import { basename, join, resolve } from 'path';
 import { copyAsync, existsAsync, readFileAsync, renameAsync, writeFileAsync } from './util/fs';
 import { readFile } from 'fs';
+import { emoji as _e } from './util/emoji';
 
 import * as inquirer from 'inquirer';
+
+const chalk = require('chalk');
 
 export type CheckFunction = (config: Config, ...args: any[]) => Promise<string | null>;
 
@@ -301,4 +304,21 @@ export async function copyTemplate(src: string, dst: string) {
   if ( await existsAsync(gitignorePath)) {
     await renameAsync(gitignorePath, join(dst, '.gitignore'));
   }
+}
+
+export async function printNextSteps(config: Config, appDir: string) {
+  log('\n');
+  log(`${chalk.bold(`${_e('🎉', '*')}   Your Capacitor project is ready to go!  ${_e('🎉', '*')}`)}\n`);
+  if (appDir !== "") {
+    log(`Next steps:`);
+    log('');
+    log(chalk`cd {bold ./${appDir}}`);
+    log('');
+  }
+  log(`Add platforms using "npx cap add":\n`);
+  log(`  npx cap add android`);
+  log(`  npx cap add ios`);
+  log(`  npx cap add electron`);
+  log('');
+  log(`Follow the Developer Workflow guide to get building:\n${chalk.bold(`https://capacitor.ionicframework.com/docs/basics/workflow`)}\n`);
 }

--- a/cli/src/tasks/create.ts
+++ b/cli/src/tasks/create.ts
@@ -20,6 +20,7 @@ import {
   getOrCreateConfig,
   log,
   logFatal,
+  printNextSteps,
   runCommand,
   runTask
 } from '../common';
@@ -68,14 +69,6 @@ export async function createCommand(config: Config, dir: string, name: string, i
     await create(config, appDir, appName, appId);
     // npm install
     await installDeps(config, appDir);
-    // Add default platforms (ios on mac, android)
-    await addPlatforms(config, appDir);
-    // Apply project-specific settings to platform projects
-    await editPlatforms(config, appName, appId);
-    // Clean platforms if needed
-    await cleanPlatforms(config);
-    // Copy web and capacitor to web assets
-    await copy(config, config.web.name);
     // Say something nice
     printNextSteps(config, appDir);
   } catch (e) {
@@ -127,33 +120,4 @@ async function installDeps(config: Config, dir: string) {
   await runTask(chalk`Installing dependencies`, async () => {
     return runCommand(`cd "${dir}" && npm install --save @capacitor/cli @capacitor/core`);
   });
-}
-
-async function addPlatforms(config: Config, dir: string) {
-  await runTask(chalk`{green {bold add}} default platforms`, async () => {
-    if (config.cli.os === OS.Mac) {
-      await addIOS(config);
-      await sync(config, config.ios.name);
-    }
-    await addAndroid(config);
-    await sync(config, config.android.name);
-  });
-}
-
-async function editPlatforms(config: Config, appName: string, appId: string) {
-  if (config.cli.os === OS.Mac) {
-    await editProjectSettingsIOS(config);
-  }
-  await editProjectSettingsAndroid(config);
-}
-
-async function cleanPlatforms(config: Config) {
-  await gradleClean(config);
-}
-
-function printNextSteps(config: Config, appDir: string) {
-  log(chalk`{green ✔} Your app is ready!`);
-  log(`\nNext steps:`);
-  log(chalk`cd {bold ./${appDir}}`);
-  log(`Get to work by following the Capacitor Development Workflow: https://capacitor.ionicframework.com/docs/basics/workflow`);
 }

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -14,6 +14,7 @@ import {
   logError,
   logFatal,
   mergeConfig,
+  printNextSteps,
   runCommand,
   runTask
 } from '../common';
@@ -52,7 +53,7 @@ export async function initCommand(config: Config, name: string, id: string) {
       });
     });
 
-    await printNextSteps(config);
+    await printNextSteps(config, "");
   } catch (e) {
     log('Usage: npx cap init appName appId\n');
     log('Example: npx cap init "My App" "com.example.myapp"\n');
@@ -98,15 +99,4 @@ async function addPlatforms(config: Config) {
       await addCommand(config, 'android');
     });
   });
-}
-
-async function printNextSteps(config: Config) {
-  log('\n');
-  log(`${chalk.bold(`${_e('🎉', '*')}   Your Capacitor project is ready to go!  ${_e('🎉', '*')}`)}\n`);
-  log(`Add platforms using "npx cap add":\n`);
-  log(`  npx cap add android`);
-  log(`  npx cap add ios`);
-  log(`  npx cap add electron`);
-  log('');
-  log(`Follow the Developer Workflow guide to get building:\n${chalk.bold(`https://capacitor.ionicframework.com/docs/basics/workflow`)}`);
 }


### PR DESCRIPTION
Make create command not add the platforms as some users might not want them or might not have things ready (CocoaPods, Android SDK)
Instead log how to add them as in init command

Closes #480 #484 