### PR TITLE
Remove fb entry for LSApplicationQueriesSchemes

### DIFF
--- a/example/ios/IonicRunner/IonicRunner/Info.plist
+++ b/example/ios/IonicRunner/IonicRunner/Info.plist
@@ -31,8 +31,6 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<string>fb</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios-template/App/App/Info.plist
+++ b/ios-template/App/App/Info.plist
@@ -31,8 +31,6 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<string>fb</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
It's not used and should be an array of strings, not a string.