### PR TITLE
fix(device): ios version and motorola model

### DIFF
--- a/core/src/web/device.ts
+++ b/core/src/web/device.ts
@@ -48,14 +48,14 @@ export class DevicePluginWeb extends WebPlugin implements DevicePlugin {
   parseUa(_ua: string) {
     let uaFields: any = {};
     const start = _ua.indexOf('(')+1;
-    const end = _ua.indexOf(')');
+    const end = _ua.indexOf('Apple')-2;
     const fields = _ua.substring(start, end);
     if (_ua.indexOf('Android') !== -1) {
-      uaFields.model = fields.split("; ").pop().split(' Build')[0];
+      uaFields.model = fields.replace(" wv", "").split("; ").pop().split(' Build')[0];
       uaFields.osVersion = fields.split('; ')[1];
     } else {
       uaFields.model = fields.split('; ')[0];
-      uaFields.osVersion = navigator.oscpu ? navigator.oscpu : fields.split('; ').pop();
+      uaFields.osVersion = navigator.oscpu ? navigator.oscpu : fields.split('; ').pop().split(" ")[3].replace(/_/g, ".");
     }
 
     return uaFields;


### PR DESCRIPTION
## Motivation
The last commit [74091ef](https://github.com/ionic-team/capacitor/commit/74091ef3049af958a2d85af74606ab77296ae22a) have errors while get the model in user agents that has parentheses between the infos about the device like mine below
```
Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4) Build/NMA26.42-97; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
```
Also, if you have an iPhone you will get `CPU iPhone OS {version}` like as the osVersion. Is a bunch of infos then i reduce to only the real OS version.

If you are in a webwiew, your user agent will has a ` wv` and this break the operation to get the model in android phones

## Changes
  - Get model before `AppleWebKit`;
  - Remove webview reference
  - Get only the version in non-Android devices
## References

[User agents in webview](https://developer.chrome.com/multidevice/user-agent)  
[List of user agents](https://deviceatlas.com/blog/list-of-user-agent-strings)