### PR TITLE
Added plugin blacklist to skip install

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -35,6 +35,11 @@ export async function updateAndroid(config: Config) {
   await installGradlePlugins(config, capacitorPlugins, cordovaPlugins);
   await handleCordovaPluginsGradle(config, cordovaPlugins);
   await writeCordovaAndroidManifest(cordovaPlugins, config);
+
+  const incompatibleCordovaPlugins = plugins
+  .filter(p => getPluginType(p, platform) === PluginType.Incompatible);
+  printPlugins(incompatibleCordovaPlugins, platform, 'incompatible');
+
 }
 
 export async function installGradlePlugins(config: Config, capacitorPlugins: Plugin[], cordovaPlugins: Plugin[]) {

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -252,3 +252,7 @@ export async function checkAndInstallDependencies(config: Config, cordovaPlugins
   }));
   return needsUpdate;
 }
+
+export function getIncompatibleCordovaPlugins(){
+  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview"];
+}

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -2,6 +2,7 @@ import { Config } from '../config';
 import { isInstalled } from '../common';
 import { readFileAsync, readdirAsync, writeFileAsync } from '../util/fs';
 import { join, resolve } from 'path';
+import { getIncompatibleCordovaPlugins } from '../cordova';
 
 import { getPluginPlatform, Plugin, PluginType } from '../plugin';
 
@@ -59,15 +60,10 @@ export async function resolvePlugin(config: Config, plugin: Plugin): Promise<Plu
       type: PluginType.Core,
       path: iosPath
     };
-    if (plugin.xml) {
+    if(getIncompatibleCordovaPlugins().includes(plugin.id)) {
+      plugin.ios.type = PluginType.Incompatible;
+    } else if (plugin.xml) {
       plugin.ios.type = PluginType.Cordova;
-    } else {
-      const files = await readdirAsync(join(plugin.rootPath, iosPath));
-      const podSpec = files.find(file => file.endsWith('.podspec'));
-      if (podSpec) {
-        plugin.ios.type = PluginType.Cocoapods;
-        plugin.ios.name = podSpec.split('.')[0];
-      }
     }
   } catch (e) {
     console.error('Unable to resolve plugin', e);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -61,6 +61,10 @@ export async function updateIOS(config: Config) {
   await installCocoaPodsPlugins(config, plugins);
   await logCordovaManualSteps(cordovaPlugins, config, platform);
 
+  const incompatibleCordovaPlugins = plugins
+  .filter(p => getPluginType(p, platform) === PluginType.Incompatible);
+  printPlugins(incompatibleCordovaPlugins, platform, 'incompatible');
+
 }
 
 export async function installCocoaPodsPlugins(config: Config, plugins: Plugin[]) {
@@ -84,7 +88,7 @@ export async function updatePodfile(config: Config, plugins: Plugin[]) {
 }
 
 export function generatePodFile(config: Config, plugins: Plugin[]) {
-  const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) !== PluginType.Cordova);
+  const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Core);
   const pods = capacitorPlugins
     .map((p) => `pod '${p.ios!.name}', :path => '../../node_modules/${p.id}'`);
   const cordovaPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Cordova);

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -1,12 +1,13 @@
 import { Config } from './config';
 import { join, resolve } from 'path';
 import { log, logInfo, readJSON, readXML } from './common';
+import { getIncompatibleCordovaPlugins } from './cordova';
 
 
 export const enum PluginType {
   Core,
-  Cocoapods,
   Cordova,
+  Incompatible
 }
 export interface PluginManifest {
   ios: {
@@ -100,6 +101,8 @@ export function printPlugins(plugins: Plugin[], platform: string, type: string =
 
   if (type === 'cordova') {
     log(`  Found ${plugins.length} Cordova plugin${plural} for ${platform}:`);
+  } else if (type === 'incompatible') {
+    log(`  Found ${plugins.length} incompatible Cordova plugin${plural} for ${platform}, skipped install:`);
   } else {
     log(`  Found ${plugins.length} Capacitor plugin${plural} for ${platform}:`);
   }


### PR DESCRIPTION
Added a plugin blacklist with "cordova-plugin-statusbar", "cordova-plugin-splashscreen" and "cordova-plugin-ionic-webview" to skip the install. It will also log that they were skipped.

Removed some old CocoaPods plugin type code as al iOS plugins should use CocoaPods now, but it's type is "Core", not "CocoaPods".

Anyway, I find the word "Core" a bit confusing as we use it for the 3rd party plugins, the real core plugins are the ones included in Capacitor and those are not logged/handled
