### PR TITLE
Set Access-Control-Allow-Origin header to workaround CORS

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 
@@ -209,6 +210,9 @@ public class WebViewLocalServer {
       handler = (PathHandler) uriMatcher.match(request.getUrl());
     }
     if (handler == null) {
+      if ( request.getRequestHeaders().get("Origin") != null ) {
+        return handleProxyRequest(request, handler);
+      }
       return null;
     }
 
@@ -275,12 +279,26 @@ public class WebViewLocalServer {
    */
   private WebResourceResponse handleProxyRequest(WebResourceRequest request, PathHandler handler) {
     try {
+      final String method = request.getMethod();
       String path = request.getUrl().getPath();
       URL url = new URL(request.getUrl().toString());
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      conn.setRequestMethod("GET");
+      conn.setRequestMethod(method);
       conn.setReadTimeout(30 * 1000);
       conn.setConnectTimeout(30 * 1000);
+
+      if (handler == null) {
+        Map<String, String> headers = request.getRequestHeaders();
+        headers.put("Access-Control-Allow-Origin", "*");
+
+        String ext = MimeTypeMap.getFileExtensionFromUrl(url.toString());
+        String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
+
+        conn.setDoInput(true);
+        conn.setUseCaches(false);
+
+        return new WebResourceResponse(mime, conn.getContentEncoding(), conn.getResponseCode(), conn.getResponseMessage(), headers, conn.getInputStream());
+      }
 
       InputStream stream = conn.getInputStream();
 


### PR DESCRIPTION
Use the handleProxyRequest method to workaround CORS problems by setting a Access-Control-Allow-Origin header to the request