### PR TITLE
Use spec instead of lib and also check CapacitorCordova.podspec

### DIFF
--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -1,7 +1,8 @@
 set -e
 
 # Verify pods are good
-pod lib lint --allow-warnings
+pod spec lint --allow-warnings Capacitor.podspec
+pod spec lint --allow-warnings CapacitorCordova.podspec
 
 # Do the gradle
 cd android


### PR DESCRIPTION
use `pod spec lint` instead of `pod lib lint` in the prerelease script