### PR TITLE
Log error if dependency plugin fails to install

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -2,7 +2,7 @@ import { Config } from './config';
 import { getJSModules, getPlatformElement, getPluginPlatform, getPlugins, getPluginType, printPlugins, Plugin, PluginType } from './plugin';
 import { copySync, ensureDirSync, existsAsync, readFileAsync, removeSync, writeFileAsync } from './util/fs';
 import { join, resolve } from 'path';
-import { buildXmlElement, log, logFatal, logInfo, readXML, runCommand, writeXML } from './common';
+import { buildXmlElement, log, logError, logFatal, logInfo, readXML, runCommand, writeXML } from './common';
 import { copy as fsCopy } from 'fs-extra';
 import { getAndroidPlugins } from './android/common';
 import { getIOSPlugins } from './ios/common';
@@ -242,9 +242,14 @@ export async function checkAndInstallDependencies(config: Config, cordovaPlugins
           if (dep.$.url && dep.$.url.startsWith('http')) {
             plugin = dep.$.url;
           }
-          console.log(`installing missing dependency plugin ${plugin}`);
-          await runCommand(`npm install ${plugin}`);
-          needsUpdate = true;
+          logInfo(`installing missing dependency plugin ${plugin}`);
+          try {
+            await runCommand(`cd "${config.app.rootDir}" && npm install ${plugin}`);
+            needsUpdate = true;
+          } catch (e) {
+            console.log("\n");
+            logError(`couldn't install dependency plugin ${plugin}`);
+          }
         }
       }));
     }


### PR DESCRIPTION
If a dependency plugin can't be installed, log an error message, but don't break the execution.

Closes #541

