### PR TITLE
Remove CORS workaround

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
-import android.webkit.MimeTypeMap;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 
@@ -210,9 +209,6 @@ public class WebViewLocalServer {
       handler = (PathHandler) uriMatcher.match(request.getUrl());
     }
     if (handler == null) {
-      if ( request.getRequestHeaders().get("Origin") != null ) {
-        return handleProxyRequest(request, handler);
-      }
       return null;
     }
 
@@ -286,19 +282,6 @@ public class WebViewLocalServer {
       conn.setRequestMethod(method);
       conn.setReadTimeout(30 * 1000);
       conn.setConnectTimeout(30 * 1000);
-
-      if (handler == null) {
-        Map<String, String> headers = request.getRequestHeaders();
-        headers.put("Access-Control-Allow-Origin", "*");
-
-        String ext = MimeTypeMap.getFileExtensionFromUrl(url.toString());
-        String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
-
-        conn.setDoInput(true);
-        conn.setUseCaches(false);
-
-        return new WebResourceResponse(mime, conn.getContentEncoding(), conn.getResponseCode(), conn.getResponseMessage(), headers, conn.getInputStream());
-      }
 
       InputStream stream = conn.getInputStream();
 


### PR DESCRIPTION
The CORS workaround causes problems with POST, PUT, DELETE and ORIGIN, and for GET will create a new connection that might not have the webview cookies, so removing it from the code.

People needing this because they can't configure the server to enable CORS will have to use a plugin that use native code for the connections.