### PR TITLE
Remove arrow function

### DIFF
--- a/app-template/www/js/capacitor-welcome.js
+++ b/app-template/www/js/capacitor-welcome.js
@@ -84,7 +84,7 @@ window.customElements.define('capacitor-welcome', class extends HTMLElement {
   }
 
   connectedCallback() {
-    this.shadowRoot.querySelector('#take-photo').addEventListener('click', async (e) => {
+    this.shadowRoot.querySelector('#take-photo').addEventListener('click', async function(e) {
       const { Camera } = Capacitor.Plugins;
       const photo = await Camera.getPhoto({
         resultType: "uri"


### PR DESCRIPTION
Testing the generated app on iOS 10 it wasn't working.
It turns out that there are a problem with async arrow functions on iOS 10 (https://bugs.webkit.org/show_bug.cgi?id=166879)

Removed the arrow function to make it work on iOS 10.