### PR TITLE
Make create copy web files

### DIFF
--- a/cli/src/tasks/create.ts
+++ b/cli/src/tasks/create.ts
@@ -69,6 +69,8 @@ export async function createCommand(config: Config, dir: string, name: string, i
     await create(config, appDir, appName, appId);
     // npm install
     await installDeps(config, appDir);
+    // Copy web and capacitor to web assets
+    await copy(config, config.web.name);
     // Say something nice
     printNextSteps(config, appDir);
   } catch (e) {


### PR DESCRIPTION
The default project generated by create command have `"bundledWebRuntime": true`, so it needs the `capacitor.js` file to work, but it's not copied until copy command is executed, so execute it as a create step.