### PR TITLE
Animate iOS statusbar when changing style

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -306,7 +306,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   
   public func setStatusBarStyle(_ statusBarStyle: UIStatusBarStyle) {
     self.statusBarStyle = statusBarStyle
-    self.setNeedsStatusBarAppearanceUpdate()
+    UIView.animate(withDuration: 0.2, animations: {
+      self.setNeedsStatusBarAppearanceUpdate()
+    })
   }
   
   public func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {


### PR DESCRIPTION
This will fade the status bar from white to black (and black to white) when changing the style instead of it just changing immediately. Just wanted the transition to look a little cleaner.