### PR TITLE
Fix share crash

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Share.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Share.swift
@@ -46,6 +46,7 @@ public class CAPSharePlugin : CAPPlugin {
         ])
       }
       
+      self.setCenteredPopover(actionController)
       self.bridge.viewController.present(actionController, animated: true, completion: nil)
     }
   }


### PR DESCRIPTION
I noticed this crash while testing Example app on iOS 12.
Not sure if it was happening before or if it's new on iOS 12, but what the fix do is to show the share sheet centered (as we do for all the other popovers), so shouldn't break previous versions (unless the share sheet was changed to be a popover now)