### PR TITLE
Make Description and git repository mandatory on plugin generator

### DIFF
--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -59,12 +59,24 @@ export async function newPlugin(config: Config) {
     {
       type: 'input',
       name: 'description',
-      message: 'description:'
+      message: 'description:',
+      validate: function(input) {
+        if (!input || input.trim() === '') {
+          return false;
+        }
+        return true;
+      }
     },
     {
       type: 'input',
       name: 'git',
-      message: 'git repository:'
+      message: 'git repository:',
+      validate: function(input) {
+        if (!input || input.trim() === '') {
+          return false;
+        }
+        return true;
+      }
     },
     {
       type: 'input',


### PR DESCRIPTION
Description and git repository are mandatory for iOS plugins, if the user doesn't provide them, then the generated .podspec will fail to validate and the plugin won't be able to install.