### PR TITLE
Fix iOS project build when app uses a locally installed plugin

### DIFF
--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -10,6 +10,7 @@ export enum OS {
 export interface PackageJson {
   name: string;
   version: string;
+  dependencies: any;
 }
 
 export interface ExternalConfig {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -90,7 +90,7 @@ export async function updatePodfile(config: Config, plugins: Plugin[]) {
 export function generatePodFile(config: Config, plugins: Plugin[]) {
   const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Core);
   const pods = capacitorPlugins
-    .map((p) => `pod '${p.ios!.name}', :path => '../../node_modules/${p.id}'`);
+    .map((p) => `pod '${p.ios!.name}', :path => '${p.rootPath}'`);
   const cordovaPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Cordova);
   const noPodPlugins = cordovaPlugins.filter(filterNoPods);
   if (noPodPlugins.length > 0) {

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -53,11 +53,16 @@ export async function resolvePlugin(config: Config, name: string): Promise<Plugi
       return null;
     }
     if (meta.capacitor) {
+      let path = rootPath;
+      let dep = config.app.package.dependencies[name];
+      if (dep && dep.startsWith('file:')) {
+        path = config.app.package.dependencies[name].replace('file:', '../../');
+      }
       return {
         id: name,
         name: fixName(name),
         version: meta.version,
-        rootPath: rootPath,
+        rootPath: path,
         repository: meta.repository,
         manifest: meta.capacitor
       };


### PR DESCRIPTION
When using a locally installed plugin, the app failed to build.
Changed the Podfile generation to use the path of the plugin instead of picking it from node_modules