### PR TITLE
Import Cordova in .swift files

### DIFF
--- a/cli/src/util/fs.ts
+++ b/cli/src/util/fs.ts
@@ -20,6 +20,8 @@ export const removeAsync = fsExtra.remove;
 export const removeSync = fsExtra.removeSync;
 export const ensureDirSync = fsExtra.ensureDirSync;
 export const copySync = fsExtra.copySync;
+export const readFileSync = fsExtra.readFileSync;
+export const writeFileSync = fsExtra.writeFileSync;
 export const existsAsync = async (path: string) => {
   try {
     const stat = await statAsync(path);


### PR DESCRIPTION
Related to #612, not completely fixes it yet.

It will add `import Cordova` to .swift files to make them compile