### PR TITLE
Allow to configure Swift version for Cordova Plugins

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -43,6 +43,7 @@ export class Config implements CliConfig {
   ios = {
     name: 'ios',
     minVersion: '10.0',
+    cordovaSwiftVersion: '4.0',
     platformDir: '',
     webDir: 'public',
     webDirAbs: '',
@@ -122,13 +123,13 @@ export class Config implements CliConfig {
     try {
       this.initAppConfig(resolve(currentWorkingDir));
       this.initAndroidConfig();
-      this.initIosConfig();
       this.initElectronConfig();
       this.initPluginsConfig();
       this.loadExternalConfig();
       this.mergeConfigData();
 
       // Post-merge
+      this.initIosConfig();
       this.initWindowsConfig();
       this.initLinuxConfig();
 
@@ -173,6 +174,12 @@ export class Config implements CliConfig {
     this.ios.platformDir = resolve(this.app.rootDir, this.ios.name);
     this.ios.assets.templateDir = resolve(this.cli.assetsDir, this.ios.assets.templateName);
     this.ios.webDirAbs = resolve(this.ios.platformDir, this.ios.nativeProjectName, this.ios.webDir);
+    if (this.app.extConfig.ios && this.app.extConfig.ios.cordovaSwiftVersion) {
+      this.ios.cordovaSwiftVersion = this.app.extConfig.ios.cordovaSwiftVersion;
+    }
+    if (this.app.extConfig.ios && this.app.extConfig.ios.minVersion) {
+      this.ios.minVersion = this.app.extConfig.ios.minVersion;
+    }
   }
 
   private initWindowsConfig() {

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -16,6 +16,7 @@ export interface PackageJson {
 export interface ExternalConfig {
   webDir: string;
   startPage: string;
+  ios: any;
 }
 
 export interface AppPluginsConfig {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -211,7 +211,6 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
     end`);
   }
   const frameworksString = frameworkDeps.join("\n    ");
-
   const content = `
   Pod::Spec.new do |s|
     s.name = '${name}'
@@ -224,6 +223,7 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
     s.source_files = '${sourcesFolderName}/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '${config.ios.minVersion}'
     s.dependency 'CapacitorCordova'
+    s.swift_version  = '${config.ios.cordovaSwiftVersion}'
     ${frameworksString}
   end`;
   await writeFileAsync(join(pluginsPath, `${name}.podspec`), content);


### PR DESCRIPTION
With this we can close #612

It adds a configurable option to set the Swift version for Cordova plugins.

Also makes the iOS min version configurable, which we already had as a config value, but wasn't really configurable.

To configure both, this will need to be added to the capacitor.config.json file:

```
"ios": {
    "cordovaSwiftVersion": "3.2",
    "minVersion": "11.0"
}
```