### PR TITLE
Make LocalNotification id an Integer

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -843,7 +843,7 @@ export interface LocalNotificationAttachmentOptions {
 export interface LocalNotification {
   title: string;
   body: string;
-  id: string;
+  id: number;
   schedule?: LocalNotificationSchedule;
   sound?: string;
   attachments?: LocalNotificationAttachment[];

--- a/example/src/pages/local-notifications/local-notifications.ts
+++ b/example/src/pages/local-notifications/local-notifications.ts
@@ -68,7 +68,7 @@ export class LocalNotificationsPage {
       notifications: [{
         title: 'Get 20% off!',
         body: 'Swipe to learn more',
-        id: 'special-deal',
+        id: 1,
         sound: 'beep.aiff',
         attachments: [
           { id: 'face', url: 'res://face.jpg' }
@@ -90,7 +90,7 @@ export class LocalNotificationsPage {
       notifications: [{
         title: 'Get 20% off!',
         body: 'Swipe to learn more',
-        id: 'special-deal',
+        id: 2,
         schedule: {
           on: {
             day: 1
@@ -99,7 +99,7 @@ export class LocalNotificationsPage {
       }, {
         title: 'Happy Holidays',
         body: 'Swipe to learn more',
-        id: 'holidays',
+        id: 3,
         schedule: {
           every: 'minute'
         }

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -51,7 +51,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin, UNUserNotificationCenterDe
     var ids = [String]()
     
     for notification in notifications {
-      guard let identifier = notification["id"] as? String else {
+      guard let identifier = notification["id"] as? Int else {
         call.error("Notification missing identifier")
         return
       }
@@ -79,7 +79,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin, UNUserNotificationCenterDe
       }
       
       // Schedule the request.
-      let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+      let request = UNNotificationRequest(identifier: "\(identifier)", content: content, trigger: trigger)
       
       notificationRequestLookup[request.identifier] = notification
       


### PR DESCRIPTION
Make notification id number in types, Int in Swift and updated examples.

Android push notifications need an Integer as Identifier, so changing it for iOS too