### PR TITLE
Handle no extConfig on app init

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -174,10 +174,10 @@ export class Config implements CliConfig {
     this.ios.platformDir = resolve(this.app.rootDir, this.ios.name);
     this.ios.assets.templateDir = resolve(this.cli.assetsDir, this.ios.assets.templateName);
     this.ios.webDirAbs = resolve(this.ios.platformDir, this.ios.nativeProjectName, this.ios.webDir);
-    if (this.app.extConfig.ios && this.app.extConfig.ios.cordovaSwiftVersion) {
+    if (this.app.extConfig && this.app.extConfig.ios && this.app.extConfig.ios.cordovaSwiftVersion) {
       this.ios.cordovaSwiftVersion = this.app.extConfig.ios.cordovaSwiftVersion;
     }
-    if (this.app.extConfig.ios && this.app.extConfig.ios.minVersion) {
+    if (this.app.extConfig && this.app.extConfig.ios && this.app.extConfig.ios.minVersion) {
       this.ios.minVersion = this.app.extConfig.ios.minVersion;
     }
   }


### PR DESCRIPTION
As extConfig is picked from capacitor.config.json file, on init command it doesn't exist yet, so it fails.