### PR TITLE
iOS - Adds presentationStyle to BrowserOpenOptions

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -237,6 +237,11 @@ export interface BrowserOpenOptions {
    * A hex color to set the toolbar color to.
    */
   toolbarColor?: string;
+
+   /**
+   * iOS only: The presentation style of the browser. Defaults to fullscreen.
+   */
+  presentationStyle?: 'fullscreen' | 'popover';
 }
 
 export interface BrowserPrefetchOptions {

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -17,7 +17,15 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
     DispatchQueue.main.async {
       self.vc = SFSafariViewController.init(url: url!)
       self.vc!.delegate = self
-      self.vc!.modalPresentationStyle = .popover
+
+      switch call.getString("presentationStyle") {
+      case "fullscreen":
+        self.vc!.modalPresentationStyle = .fullScreen
+      case "popover":
+        self.vc!.modalPresentationStyle = .popover
+      default:
+        self.vc!.modalPresentationStyle = .fullScreen
+      }
       
       if toolbarColor != nil {
         self.vc!.preferredBarTintColor = UIColor(fromHex: toolbarColor!)


### PR DESCRIPTION
Fixes #616. Also changes default to fullscreen. See: [https://developer.apple.com/documentation/uikit/uimodalpresentationstyle](UIViewController API) for other possible presentation styles. I just stuck with fullScreen and popover for now.