### PR TITLE
Amazon schema

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -212,6 +212,7 @@ ${applicationXMLEntries.join('\n')}
 </application>
 ${rootXMLEntries.join('\n')}
 </manifest>`;
+  content = content.replace(new RegExp(('$PACKAGE_NAME').replace('$', '\\$&'), 'g'), config.app.appId);
   await writeFileAsync(manifestPath, content);
 }
 

--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -204,7 +204,9 @@ async function writeCordovaAndroidManifest(cordovaPlugins: Plugin[], config: Con
     });
   });
   let content = `<?xml version='1.0' encoding='utf-8'?>
-<manifest package="capacitor.android.plugins" xmlns:android='http://schemas.android.com/apk/res/android'>
+<manifest package="capacitor.android.plugins"
+xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:amazon="http://schemas.amazon.com/apk/res/android">
 <application>
 ${applicationXMLEntries.join('\n')}
 </application>


### PR DESCRIPTION
Add amazon schema to capacitor-android-plugins so it understand some possible amazon tags and doesn't show the `error: must not undeclare prefix.`.

Replace $PACKAGE_NAME from the generated AndroidManifest.xml with the appId from config, to avoid malformed manifest errors on install

closes #637 