### PR TITLE
Change authority

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -151,11 +151,13 @@ public class Bridge {
   private void loadWebView() {
     final String appUrlConfig = Config.getString("server.url");
 
-    String authority = null;
+    String authority = "localhost";
+    boolean isLocal = true;
     if (appUrlConfig != null) {
       try {
         URL appUrlObject = new URL(appUrlConfig);
         authority = appUrlObject.getAuthority();
+        isLocal = false;
       } catch (Exception ex) {
       }
 
@@ -165,7 +167,7 @@ public class Bridge {
     final boolean html5mode = Config.getBoolean("server.html5mode", true);
 
     // Start the local web server
-    localServer = new WebViewLocalServer(context, this, getJSInjector(), authority, html5mode);
+    localServer = new WebViewLocalServer(context, this, getJSInjector(), authority, html5mode, isLocal);
     WebViewLocalServer.AssetHostingDetails ahd = localServer.hostAssets(DEFAULT_WEB_ASSET_DIR);
 
     // Load the index route from our www folder

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -50,10 +50,6 @@ import java.util.UUID;
 public class WebViewLocalServer {
   private static String TAG = "WebViewAssetServer";
 
-  /**
-   * capacitorapp.net is reserved by the Ionic team for use in local capacitor apps.
-   */
-  public final static String knownUnusedAuthority = "capacitorapp.net";
   private final static String httpScheme = "http";
   private final static String httpsScheme = "https";
 
@@ -170,17 +166,12 @@ public class WebViewLocalServer {
     }
   }
 
-  WebViewLocalServer(Context context, Bridge bridge, JSInjector jsInjector, String authority, boolean html5mode) {
+  WebViewLocalServer(Context context, Bridge bridge, JSInjector jsInjector, String authority, boolean html5mode, boolean isLocal) {
     uriMatcher = new UriMatcher(null);
     this.html5mode = html5mode;
     this.protocolHandler = new AndroidProtocolHandler(context.getApplicationContext());
-    if (authority != null) {
-      this.authority = authority;
-      this.isLocal = false;
-    } else {
-      this.isLocal = true;
-      this.authority = UUID.randomUUID().toString() + "" + knownUnusedAuthority;
-    }
+    this.authority = authority;
+    this.isLocal = isLocal;
     this.bridge = bridge;
     this.jsInjector = jsInjector;
   }


### PR DESCRIPTION
Removed the random UUID generation on the authority and use localhost instead.

The port will be picked from server.port configuration in capacitor.config.json.
If the configuration is not present, then it will generate a random port number and store the port in SharedPreferences for reuse.


Closes #636