### PR TITLE
Make getString understand keys with .

### DIFF
--- a/ios/Capacitor/Capacitor/CAPConfig.swift
+++ b/ios/Capacitor/Capacitor/CAPConfig.swift
@@ -71,12 +71,11 @@
   }
   
   @objc public static func getString(_ key: String) -> String? {
-    let k = CAPConfig.getConfigKey(key)
-    let o = getInstance().getConfigObjectDeepest(key: key)
-    if o == nil {
+    let value = getValue(key)
+    if value == nil {
       return nil
     }
-    return getValue(k) as? String
+    return value as? String
   }
   
 }


### PR DESCRIPTION
`CAPConfig.getString("server.port")` or `CAPConfig.getString("server.url")` don't return a value, while `CAPConfig.getValue("server.port")` and `CAPConfig.getValue("server.url")` do.

With this fix both of them will work