### PR TITLE
Make presentationStyle change compile on Swift 4.0

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -17,21 +17,18 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
     DispatchQueue.main.async {
       self.vc = SFSafariViewController.init(url: url!)
       self.vc!.delegate = self
-
-      switch call.getString("presentationStyle") {
-      case "fullscreen":
-        self.vc!.modalPresentationStyle = .fullScreen
-      case "popover":
+      let presentationStyle = call.getString("presentationStyle")
+      if presentationStyle != nil && presentationStyle == "popover" {
         self.vc!.modalPresentationStyle = .popover
-      default:
+        self.setCenteredPopover(self.vc)
+      } else {
         self.vc!.modalPresentationStyle = .fullScreen
       }
-      
+
       if toolbarColor != nil {
         self.vc!.preferredBarTintColor = UIColor(fromHex: toolbarColor!)
       }
-      
-      self.setCenteredPopover(self.vc)
+
       self.bridge.viewController.present(self.vc!, animated: true, completion: {
         call.success()
       })


### PR DESCRIPTION
Swift 4.0 didn't like the string cases (works fine on 4.1). One option was to add ? to them, but as there are only 2 options I changed the switch with an if.

Also moved the self.setCenteredPopover(self.vc) to only run it in the popover case, as it's not needed in full screen.

