### PR TITLE
fix(SplashScreenPlugin): use correct return type

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1242,11 +1242,11 @@ export interface SplashScreenPlugin extends Plugin {
   /**
    * Show the splash screen
    */
-  show(options?: SplashScreenShowOptions, callback?: Function): void;
+  show(options?: SplashScreenShowOptions, callback?: Function): Promise<void>;
   /**
    * Hide the splash screen
    */
-  hide(options?: SplashScreenHideOptions, callback?: Function): void;
+  hide(options?: SplashScreenHideOptions, callback?: Function): Promise<void>;
 }
 
 export interface SplashScreenShowOptions {


### PR DESCRIPTION
`show` and `hide` actually return a `Promise`. Related to #590.

Also should the `callback?: Function` be there?