### PR TITLE
Document how to configure the port and how to load an external url

### DIFF
--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -38,7 +38,16 @@ The current ones you might configure are:
   // On Android, Capacitor loads your local assets using https
   // Chrome by default prevents loading files from a different scheme (i.e. from http)
   // This setting allows to mix content from different schemes
-  "allowMixedContent": true
+  "allowMixedContent": true,
+
+  // Server object contains port and url configurations 
+  "server": {
+    // Capacitor runs a local web server, you can configure what port to use.
+    // If you don't configure it, a random port will be assigned and persisted.
+    "port": "8787",
+    // You can make the app to load an external url (i.e. to live reload)
+    "url": "http://192.168.1.33:8100"
+  }
 }
 ```
 


### PR DESCRIPTION
With the changes made yesterday (https://github.com/ionic-team/capacitor/pull/648/commits/88de42219c14561ab975044d0d581bc51ac505f8 and https://github.com/ionic-team/capacitor/pull/650/commits/ac99702a6b19cdcabaa43bcc126c8d1b4b9f8c52), it's possible to configure the port.

This just documents how to do it.
And also, how to load an external url.

Closes #617