### PR TITLE
Save call before adding event listener

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -385,8 +385,8 @@ public class Plugin {
   @PluginMethod(returnType=PluginMethod.RETURN_NONE)
   public void addListener(PluginCall call) {
     String eventName = call.getString("eventName");
-    addEventListener(eventName, call);
     call.save();
+    addEventListener(eventName, call);
   }
 
   /**

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -94,8 +94,8 @@
 
 - (void)addListener:(CAPPluginCall *)call {
   NSString *eventName = [call.options objectForKey:@"eventName"];
-  [self addEventListener:eventName listener:call];
   [call setIsSaved:TRUE];
+  [self addEventListener:eventName listener:call];
 }
 
 - (void)removeListener:(CAPPluginCall *)call {


### PR DESCRIPTION
When adding an event listener, if there is a retained event, addEventListener method indirectly calls  call.success(), before call.save() is called. This causes native bridge to delete the call. After this subsequent events don't get handled by native bridge. Calling call.save() before addEventListener solves this problem.