### PR TITLE
Add more incompatible plugins

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -278,5 +278,5 @@ export async function checkAndInstallDependencies(config: Config, cordovaPlugins
 }
 
 export function getIncompatibleCordovaPlugins(){
-  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview"];
+  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview", "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine"];
 }


### PR DESCRIPTION
Add more webview plugins that are incompatible as we only use our webview and don't allow changing it with Cordova plugins