### PR TITLE
Destroy webview on app exit

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public class BridgeActivity extends AppCompatActivity {
   protected Bridge bridge;
+  private WebView webView;
   public CordovaInterfaceImpl cordovaInterface;
   private ArrayList<PluginEntry> pluginEntries;
   PluginManager pluginManager;
@@ -60,7 +61,7 @@ public class BridgeActivity extends AppCompatActivity {
   protected void load(Bundle savedInstanceState) {
     Log.d(Bridge.TAG, "Starting BridgeActivity");
 
-    WebView webView = findViewById(R.id.webview);
+    webView = findViewById(R.id.webview);
     cordovaInterface = new CordovaInterfaceImpl(this);
     if (savedInstanceState != null) {
       cordovaInterface.restoreInstanceState(savedInstanceState);
@@ -162,6 +163,15 @@ public class BridgeActivity extends AppCompatActivity {
   public void onDestroy() {
     super.onDestroy();
     Log.d(Bridge.TAG, "App destroyed");
+  }
+
+  @Override
+  public void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    if (webView != null) {
+      webView.removeAllViews();
+      webView.destroy();
+    }
   }
 
   @Override


### PR DESCRIPTION
Call removeAllViews and destroy on webview object when the app is closed so it doesn't create a new webview on next launch

Closes #669