### PR TITLE
Append special chars to active element

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -23,6 +23,10 @@ public class CapacitorWebView extends WebView {
 
   @Override
   public boolean dispatchKeyEvent(KeyEvent event) {
+    if (event.getAction() == KeyEvent.ACTION_MULTIPLE) {
+      evaluateJavascript("document.activeElement.value = document.activeElement.value + '" + event.getCharacters() + "';", null);
+      return false;
+    }
     return super.dispatchKeyEvent(event);
   }
 }


### PR DESCRIPTION
super.dispatchKeyEvent(event); doesn't dispatch special chars properly, so they are not passed to the webview.

This appends them to the active element, but won't fire Keyboard Events for them.
