### PR TITLE
[WIP]: Network web implementation

### DIFF
--- a/core/src/web/net.ts
+++ b/core/src/web/net.ts
@@ -1,0 +1,37 @@
+import { WebPlugin } from './index';
+
+import {
+  NetworkPlugin,
+  NetworkStatus
+} from '../core-plugin-definitions';
+
+declare var navigator: any;
+
+export class NetworkPluginWeb extends WebPlugin implements NetworkPlugin {
+  constructor() {
+    super({
+      name: 'Network',
+      platforms: ['web']
+    });
+  }
+
+  getStatus(): Promise<NetworkStatus> {
+    return new Promise<NetworkStatus>((resolve, reject) => {
+      const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+      if (!connection) {
+        reject('NetInfo API not available in this browser');
+      }
+      const connected = navigator.onLine && (connection.type !== 'none' || connection.type >= 0)
+      resolve({
+        connected: connected,
+        connectionType: connected ? (typeof connection.type === 'number' ?
+                        Object.getOwnPropertyNames(connection)[++connection.type] :
+                        connection.type || 'unknow') : 'none',
+      });
+    });
+  }
+}
+
+const Network = new NetworkPluginWeb();
+
+export { Network };


### PR DESCRIPTION
Fixes: #534

As a lot of browser have not this feature or haven't the `type` property in `navigator.connection` (like Chrome for desktop, for android already have), I return `unknow` as the type of connection.

### Links:
 - [NetworkInformation API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
 - [NetInfo caniuse](https://caniuse.com/#feat=netinfo)
 - [Tutorial with an old spec of this feature](https://www.davidbcalhoun.com/2010/using-navigator-connection-android)

_P.S.: I put WIP mark because I don't know if this implementation works completely or if I should do any work on it_