### PR TITLE
Make webViewEngine to be WKWebView class

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -53,7 +53,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 @interface CDVPlugin : NSObject {}
 
 @property (nonatomic, weak) UIView* webView;
-@property (nonatomic, weak) id webViewEngine;
+@property (nonatomic, weak) WKWebView * webViewEngine;
 @property (nonatomic, strong) NSString * className;
 
 @property (nonatomic, weak) UIViewController* viewController;

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.m
@@ -61,7 +61,7 @@ NSString* const CDVViewWillTransitionToSizeNotification = @"CDVViewWillTransitio
 @synthesize webViewEngine, viewController, commandDelegate, hasPendingOperation, webView;
 
 // Do not override these methods. Use pluginInitialize instead.
-- (instancetype)initWithWebViewEngine:(id)theWebViewEngine
+- (instancetype)initWithWebViewEngine:(WKWebView *)theWebViewEngine
 {
     self = [super init];
     if (self) {


### PR DESCRIPTION
So in Cordova webViewEngine can have UIWebView or WKWebView class, so it's declared as "id". 
For some reason that confuses InAppBrowser in Capacitor.

Changed it to always be WKWebView as in Capacitor that's the only option.

Closes #677