### PR TITLE
Small inconsistencies in the Device plugin's Core and Android implemenation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
@@ -64,10 +64,10 @@ public class Device extends Plugin {
   }
 
   private String getPlatform() {
-    if (android.os.Build.MANUFACTURER.equals("Amazon")) {
+    if (android.os.Build.MANUFACTURER.equalsIgnoreCase("Amazon")) {
       return "amazon-fireos";
     }
-    return "Android";
+    return "android";
   }
 
   private String getUuid() {
@@ -78,18 +78,26 @@ public class Device extends Plugin {
     IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     Intent batteryStatus = getContext().registerReceiver(null, ifilter);
 
-    int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
-    int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+    int level = -1;
+    int scale = -1;
 
-    return level / (float)scale;
+    if (batteryStatus != null) {
+      level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+      scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+    }
+
+    return level / (float) scale;
   }
 
   private boolean isCharging() {
     IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
     Intent batteryStatus = getContext().registerReceiver(null, ifilter);
 
-    int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-    return status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
+    if (batteryStatus != null) {
+      int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+      return status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
+    }
+    return false;
   }
 
   private boolean isVirtual() {

--- a/core/src/web/device.ts
+++ b/core/src/web/device.ts
@@ -30,7 +30,7 @@ export class DevicePluginWeb extends WebPlugin implements DevicePlugin {
 
     return Promise.resolve({
       model: uaFields.model,
-      platform: "pwa",
+      platform: "web",
       appVersion: '',
       osVersion: uaFields.osVersion,
       manufacturer: navigator.vendor,


### PR DESCRIPTION
Android: 
1) The platform value should be lower case to match the docs in [DeviceInfo](https://github.com/ionic-team/capacitor/blob/78dfcc419b1e3417086569ca9b3d5411531a4391/core/src/core-plugin-definitions.ts#L380)
2) Added a few null checks to prevent NPEs

Core: 
There are 2 platform values in this class: "web" and "pwa". I changed it to "web" because of the doc in DeviceInfo.