### PR TITLE
iOS: Fix BackgroundTask beforeExit method name

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -15,7 +15,7 @@ CAP_PLUGIN(CAPAppPlugin, "App",
 )
 
 CAP_PLUGIN(CAPBackgroundTaskPlugin, "BackgroundTask",
-  CAP_PLUGIN_METHOD(exec, CAPPluginReturnCallback);
+  CAP_PLUGIN_METHOD(beforeExit, CAPPluginReturnCallback);
   CAP_PLUGIN_METHOD(finish, CAPPluginReturnPromise);
 )
 


### PR DESCRIPTION
Renamed from 'exec' to 'beforeExit'. Would throw an error when trying to schedule a background task. Fixes #685 