### PR TITLE
Fixes iFrame behavior from opening in a new window

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -175,7 +175,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     }
     
     if let scheme = navUrl.scheme {
-      let validSchemes = ["tel", "mailto", "facetime", "sms", "maps", "itms-services", "http", "https"]
+      let validSchemes = ["tel", "mailto", "facetime", "sms", "maps", "itms-services"]
       if validSchemes.contains(scheme) && navUrl.absoluteString.range(of: hostname!) == nil  {
         UIApplication.shared.open(navUrl, options: [:], completionHandler: nil)
         decisionHandler(.cancel)


### PR DESCRIPTION
Reverts: https://github.com/ionic-team/capacitor/pull/664

Currently all framed content is opening in a new window. This is a bad workflow since certain types of content (Microsoft docs, E-learning docs) have custom viewers that have to be embedded to render correctly. 

Let the app decide how it consumes link taps instead of forcing a behavior for iOS.

Also, Cordova's behavior does not check for http/https as well: https://github.com/apache/cordova-ios/blob/d44cec6266f5890802268e996722a380a0e51927/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m#L199