### PR TITLE
Android: Unify logs

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 
 public class AndroidProtocolHandler {
-  private static final String TAG = "AndroidProtocolHandler";
 
   private Context context;
 
@@ -62,19 +61,12 @@ public class AndroidProtocolHandler {
       if (valueType == TypedValue.TYPE_STRING) {
         return context.getResources().openRawResource(fieldId);
       } else {
-        Log.e(TAG, "Asset not of type string: " + uri);
-        return null;
+        Log.e(LogUtils.getCoreTag(), "Asset not of type string: " + uri);
       }
-    } catch (ClassNotFoundException e) {
-      Log.e(TAG, "Unable to open resource URL: " + uri, e);
-      return null;
-    } catch (NoSuchFieldException e) {
-      Log.e(TAG, "Unable to open resource URL: " + uri, e);
-      return null;
-    } catch (IllegalAccessException e) {
-      Log.e(TAG, "Unable to open resource URL: " + uri, e);
-      return null;
+    } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
+      Log.e(LogUtils.getCoreTag(), "Unable to open resource URL: " + uri, e);
     }
+    return null;
   }
 
   private static int getFieldId(Context context, String assetType, String assetName)

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceRequest;
@@ -69,13 +68,13 @@ import java.util.concurrent.ThreadLocalRandom;
  *   BridgeActivity.java</a>
  */
 public class Bridge {
+
+  private static final String LOG_TAG = LogUtils.getCoreTag();
   private static final String PREFS_NAME = "CapacitorSettings";
   private static final String BUNDLE_LAST_PLUGIN_ID_KEY = "capacitorLastActivityPluginId";
   private static final String BUNDLE_LAST_PLUGIN_CALL_METHOD_NAME_KEY = "capacitorLastActivityPluginMethod";
   private static final String BUNDLE_PLUGIN_CALL_OPTIONS_SAVED_KEY = "capacitorLastPluginCallOptions";
   private static final String BUNDLE_PLUGIN_CALL_BUNDLE_KEY = "capacitorLastPluginCallBundle";
-
-  public static final String TAG = "Capacitor";
 
   // The name of the directory we use to look for index.html and the rest of our web assets
   public static final String DEFAULT_WEB_ASSET_DIR = "public";
@@ -177,7 +176,7 @@ public class Bridge {
 
     final String appUrl = appUrlConfig == null ? url.replace("%3A", ":") : appUrlConfig;
 
-    log("Loading app at " + appUrl);
+    Log.d(LOG_TAG, "Loading app at " + appUrl);
 
     webView.setWebChromeClient(new BridgeWebChromeClient(this));
     webView.setWebViewClient(new WebViewClient() {
@@ -241,7 +240,7 @@ public class Bridge {
   public void handleAppUrlLoadError(Exception ex) {
     if (ex instanceof SocketTimeoutException) {
       Toast.show(getContext(), "Unable to load app. Are you sure the server is running at " + localServer.getAuthority() + "?");
-      Log.e(TAG, "Unable to load app. Ensure the server is running at " + localServer.getAuthority() + ", or modify the " +
+      Log.e(LOG_TAG, "Unable to load app. Ensure the server is running at " + localServer.getAuthority() + ", or modify the " +
           "appUrl setting in capacitor.config.json (make sure to npx cap copy after to commit changes).", ex);
     }
   }
@@ -283,16 +282,16 @@ public class Bridge {
 
   /*
   public void registerPlugins() {
-    Log.d(TAG, "Finding plugins");
+    Log.d(LOG_TAG, "Finding plugins");
     try {
       Enumeration<URL> roots = getClass().getClassLoader().getResources("");
       while (roots.hasMoreElements()) {
         URL url = roots.nextElement();
-        Log.d(TAG, "CLASSAPTH ROOT: " + url.getPath());
+        Log.d(LOG_TAG, "CLASSAPTH ROOT: " + url.getPath());
         //File root = new File(url.getPath());
       }
     } catch(Exception ex) {
-      Log.e(TAG, "Unable to query for plugin classes", ex);
+      Log.e(LOG_TAG, "Unable to query for plugin classes", ex);
     }
   }
   */
@@ -366,7 +365,7 @@ public class Bridge {
     NativePlugin pluginAnnotation = pluginClass.getAnnotation(NativePlugin.class);
 
     if (pluginAnnotation == null) {
-      Log.e(Bridge.TAG, "NativePlugin doesn't have the @NativePlugin annotation. Please add it");
+      Log.e(LOG_TAG, "NativePlugin doesn't have the @NativePlugin annotation. Please add it");
       return;
     }
 
@@ -377,16 +376,16 @@ public class Bridge {
       pluginId = pluginAnnotation.name();
     }
 
-    Log.d(Bridge.TAG, "Registering plugin: " + pluginId);
+    Log.d(LOG_TAG, "Registering plugin: " + pluginId);
 
     try {
       this.plugins.put(pluginId, new PluginHandle(this, pluginClass));
     } catch (InvalidPluginException ex) {
-      Log.e(TAG, "NativePlugin " + pluginClass.getName() +
+      Log.e(LOG_TAG, "NativePlugin " + pluginClass.getName() +
           " is invalid. Ensure the @NativePlugin annotation exists on the plugin class and" +
           " the class extends Plugin");
     } catch (PluginLoadException ex) {
-      Log.e(TAG, "NativePlugin " + pluginClass.getName() + " failed to load", ex);
+      Log.e(LOG_TAG, "NativePlugin " + pluginClass.getName() + " failed to load", ex);
     }
   }
 
@@ -433,12 +432,12 @@ public class Bridge {
       final PluginHandle plugin = this.getPlugin(pluginId);
 
       if (plugin == null) {
-        Log.e(Bridge.TAG, "unable to find plugin : " + pluginId);
+        Log.e(LOG_TAG, "unable to find plugin : " + pluginId);
         call.errorCallback("unable to find plugin : " + pluginId);
         return;
       }
 
-      Log.d(Bridge.TAG, "callback: " + call.getCallbackId() +
+      Log.v(LOG_TAG, "callback: " + call.getCallbackId() +
           ", pluginId: " + plugin.getId() +
           ", methodName: " + methodName + ", methodData: " + call.getData().toString());
 
@@ -452,9 +451,9 @@ public class Bridge {
               saveCall(call);
             }
           } catch(PluginLoadException | InvalidPluginMethodException | PluginInvocationException ex) {
-            Log.e(Bridge.TAG, "Unable to execute plugin method", ex);
+            Log.e(LOG_TAG, "Unable to execute plugin method", ex);
           } catch(Exception ex) {
-            Log.e(Bridge.TAG, "Serious error executing plugin", ex);
+            Log.e(LOG_TAG, "Serious error executing plugin", ex);
           }
         }
       };
@@ -465,19 +464,6 @@ public class Bridge {
       Log.e("callPluginMethod", "error : " + ex);
       call.errorCallback(ex.toString());
     }
-  }
-
-  public void error(String... args) {
-    Log.e(TAG, "⚡️ " + TextUtils.join(" ", args));
-  }
-
-  public void fatalError(String... args) {
-    Log.e(TAG, "⚡️ FATAL ERROR ⚡️");
-    error(args);
-  }
-
-  public void log(String... args) {
-    Log.d(TAG, TextUtils.join(" ", args));
   }
 
   /**
@@ -587,7 +573,7 @@ public class Bridge {
 
       return new JSInjector(globalJS, coreJS, pluginJS, cordovaJS, cordovaPluginsJS, cordovaPluginsFileJS);
     } catch(JSExportException ex) {
-      Log.e(TAG, "Unable to export Capacitor JS. App will not function!", ex);
+      Log.e(LOG_TAG, "Unable to export Capacitor JS. App will not function!", ex);
     }
     return null;
   }
@@ -618,7 +604,7 @@ public class Bridge {
               lastPluginId, PluginCall.CALLBACK_ID_DANGLING, lastPluginCallMethod, options);
 
         } catch (JSONException ex) {
-          Log.e(TAG, "Unable to restore plugin call, unable to parse persisted JSON object", ex);
+          Log.e(LOG_TAG, "Unable to restore plugin call, unable to parse persisted JSON object", ex);
         }
       }
 
@@ -632,7 +618,7 @@ public class Bridge {
   }
 
   public void saveInstanceState(Bundle outState) {
-    Log.d(TAG, "Saving instance state!");
+    Log.d(LOG_TAG, "Saving instance state!");
 
     // If there was a last PluginCall for a started activity, we need to
     // persist it so we can load it again in case our app gets terminated
@@ -650,7 +636,7 @@ public class Bridge {
   }
 
   public void startActivityForPluginWithResult(PluginCall call, Intent intent, int requestCode) {
-    Log.d(TAG, "Starting activity for result");
+    Log.d(LOG_TAG, "Starting activity for result");
 
     pluginCallForLastActivity = call;
 
@@ -669,11 +655,11 @@ public class Bridge {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
     if (plugin == null) {
-      Log.d(Bridge.TAG, "Unable to find a Capacitor plugin to handle requestCode, try with Cordova plugins " + requestCode);
+      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle requestCode, try with Cordova plugins " + requestCode);
       try {
         cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);
       } catch (JSONException e) {
-        Log.d(Bridge.TAG, "Error on Cordova plugin permissions request " + e.getMessage());
+        Log.d(LOG_TAG, "Error on Cordova plugin permissions request " + e.getMessage());
       }
       return;
     }
@@ -692,7 +678,7 @@ public class Bridge {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
     if (plugin == null || plugin.getInstance() == null) {
-      Log.d(Bridge.TAG, "Unable to find a Capacitor plugin to handle requestCode, trying Cordova plugins " + requestCode);
+      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle requestCode, trying Cordova plugins " + requestCode);
       cordovaInterface.onActivityResult(requestCode, resultCode, data);
       return;
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -7,11 +7,9 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.webkit.WebView;
-
 import com.getcapacitor.android.R;
 import com.getcapacitor.cordova.MockCordovaWebViewImpl;
 import com.getcapacitor.plugin.App;
-
 import org.apache.cordova.ConfigXmlParser;
 import org.apache.cordova.CordovaInterfaceImpl;
 import org.apache.cordova.CordovaPreferences;
@@ -59,7 +57,7 @@ public class BridgeActivity extends AppCompatActivity {
    * Load the WebView and create the Bridge
    */
   protected void load(Bundle savedInstanceState) {
-    Log.d(Bridge.TAG, "Starting BridgeActivity");
+    Log.d(LogUtils.getCoreTag(), "Starting BridgeActivity");
 
     webView = findViewById(R.id.webview);
     cordovaInterface = new CordovaInterfaceImpl(this);
@@ -115,14 +113,14 @@ public class BridgeActivity extends AppCompatActivity {
 
     this.bridge.onStart();
 
-    Log.d(Bridge.TAG, "App started");
+    Log.d(LogUtils.getCoreTag(), "App started");
   }
 
   @Override
   public void onRestart() {
     super.onRestart();
     this.bridge.onRestart();
-    Log.d(Bridge.TAG, "App restarted");
+    Log.d(LogUtils.getCoreTag(), "App restarted");
   }
 
   @Override
@@ -133,7 +131,7 @@ public class BridgeActivity extends AppCompatActivity {
 
     this.bridge.onResume();
 
-    Log.d(Bridge.TAG, "App resumed");
+    Log.d(LogUtils.getCoreTag(), "App resumed");
   }
 
   @Override
@@ -142,7 +140,7 @@ public class BridgeActivity extends AppCompatActivity {
 
     this.bridge.onPause();
 
-    Log.d(Bridge.TAG, "App paused");
+    Log.d(LogUtils.getCoreTag(), "App paused");
   }
 
   @Override
@@ -156,13 +154,13 @@ public class BridgeActivity extends AppCompatActivity {
 
     this.bridge.onStop();
 
-    Log.d(Bridge.TAG, "App stopped");
+    Log.d(LogUtils.getCoreTag(), "App stopped");
   }
 
   @Override
   public void onDestroy() {
     super.onDestroy();
-    Log.d(Bridge.TAG, "App destroyed");
+    Log.d(LogUtils.getCoreTag(), "App destroyed");
   }
 
   @Override

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -120,7 +120,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
   @Override
   public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
     super.onGeolocationPermissionsShowPrompt(origin, callback);
-    Log.d(Bridge.TAG, "onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
+    Log.d(LogUtils.getCoreTag(), "onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
 
     // Set that we want geolocation perms for this origin
     callback.invoke(origin, true, false);
@@ -129,7 +129,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     if (!geo.hasRequiredPermissions()) {
       geo.pluginRequestAllPermissions();
     } else {
-      Log.d(bridge.TAG, "onGeolocationPermissionsShowPrompt: has required permis");
+      Log.d(LogUtils.getCoreTag(), "onGeolocationPermissionsShowPrompt: has required permis");
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Config.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Config.java
@@ -14,6 +14,7 @@ import java.io.InputStreamReader;
  * Management interface for accessing values in capacitor.config.json
  */
 public class Config {
+  public static final String CAPACITOR_CONFIG_JSON = "capacitor.config.json";
   private JSONObject config = new JSONObject();
 
   private static Config instance;
@@ -31,9 +32,9 @@ public class Config {
   }
 
   private void loadConfig(Activity activity) {
-    BufferedReader reader = null;
-    try {
-      reader = new BufferedReader(new InputStreamReader(activity.getAssets().open("capacitor.config.json")));
+
+    try (BufferedReader reader =
+           new BufferedReader(new InputStreamReader(activity.getAssets().open(CAPACITOR_CONFIG_JSON)))) {
 
       // do reading, usually loop until end of file reading
       StringBuilder b = new StringBuilder();
@@ -46,16 +47,9 @@ public class Config {
       String jsonString = b.toString();
       this.config = new JSONObject(jsonString);
     } catch (IOException ex) {
-      Log.e(Bridge.TAG, "Unable to load capacitor.config.json. Run npx cap copy first", ex);
+      Log.e(LogUtils.getCoreTag(), "Unable to load capacitor.config.json. Run npx cap copy first", ex);
     } catch (JSONException ex) {
-      Log.e(Bridge.TAG, "Unable to parse capacitor.config.json. Make sure it's valid json", ex);
-    } finally {
-      if (reader != null) {
-        try {
-          reader.close();
-        } catch (IOException e) {
-        }
-      }
+      Log.e(LogUtils.getCoreTag(), "Unable to parse capacitor.config.json. Make sure it's valid json", ex);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Config.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Config.java
@@ -14,7 +14,7 @@ import java.io.InputStreamReader;
  * Management interface for accessing values in capacitor.config.json
  */
 public class Config {
-  public static final String CAPACITOR_CONFIG_JSON = "capacitor.config.json";
+
   private JSONObject config = new JSONObject();
 
   private static Config instance;
@@ -32,9 +32,9 @@ public class Config {
   }
 
   private void loadConfig(Activity activity) {
-
-    try (BufferedReader reader =
-           new BufferedReader(new InputStreamReader(activity.getAssets().open(CAPACITOR_CONFIG_JSON)))) {
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new InputStreamReader(activity.getAssets().open("capacitor.config.json")));
 
       // do reading, usually loop until end of file reading
       StringBuilder b = new StringBuilder();
@@ -50,6 +50,13 @@ public class Config {
       Log.e(LogUtils.getCoreTag(), "Unable to load capacitor.config.json. Run npx cap copy first", ex);
     } catch (JSONException ex) {
       Log.e(LogUtils.getCoreTag(), "Unable to parse capacitor.config.json. Make sure it's valid json", ex);
+    } finally {
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (IOException e) {
+        }
+      }
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -48,7 +48,7 @@ public class JSExport {
     try {
       fileContent = getJS(context, "public/cordova.js");
     } catch(IOException ex) {
-      Log.e(Bridge.TAG, "Unable to read public/cordova.js file, Cordova plugins will not work");
+      Log.e(LogUtils.getCoreTag(), "Unable to read public/cordova.js file, Cordova plugins will not work");
     }
     return fileContent;
   }
@@ -58,7 +58,7 @@ public class JSExport {
     try {
       fileContent = getJS(context, "public/cordova_plugins.js");
     } catch(IOException ex) {
-      Log.e(Bridge.TAG, "Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
+      Log.e(LogUtils.getCoreTag(), "Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
     }
     return fileContent;
   }
@@ -112,7 +112,7 @@ public class JSExport {
         return getJS(context, path);
       }
     } catch(IOException ex) {
-      Log.e(Bridge.TAG, "Unable to read file at path "+path);
+      Log.e(LogUtils.getCoreTag(), "Unable to read file at path " + path);
     }
     return builder.toString();
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -54,7 +54,7 @@ class JSInjector {
       InputStream jsInputStream = new ByteArrayInputStream(js.getBytes(StandardCharsets.UTF_8.name()));
       return new SequenceInputStream(jsInputStream, responseStream);
     } catch(UnsupportedEncodingException ex) {
-      Log.e(Bridge.TAG, "Unable to get encoding! Serious internal error, please file an issue", ex);
+      Log.e(LogUtils.getCoreTag(), "Unable to get encoding! Serious internal error, please file an issue", ex);
     }
     return null;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/LogUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/LogUtils.java
@@ -1,0 +1,37 @@
+package com.getcapacitor;
+
+import android.text.TextUtils;
+
+/**
+ *
+ */
+public abstract class LogUtils {
+
+  public static final String LOG_TAG_CORE = "Capacitor";
+  public static final String LOG_TAG_PLUGIN = LOG_TAG_CORE + "/Plugin";
+
+  /**
+   * Creates a core log TAG
+   * @param subTags sub log tags joined by a slash
+   */
+  public static String getCoreTag(String... subTags) {
+    return getLogTag(LOG_TAG_CORE, subTags);
+  }
+
+  /**
+   * Creates a plugin log TAG
+   * @param subTags sub log tags joined by a slash
+   */
+  public static String getPluginTag(String... subTags) {
+    return getLogTag(LOG_TAG_PLUGIN, subTags);
+  }
+
+  private static String getLogTag(String mainTag, String[] subTags) {
+    if (subTags != null && subTags.length > 0) {
+      return mainTag + "/" + TextUtils.join("/", subTags);
+    }
+    return mainTag;
+  }
+
+
+}

--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -41,25 +41,25 @@ public class MessageHandler {
         String service = postData.getString("service");
         String action = postData.getString("action");
         String actionArgs = postData.getString("actionArgs");
-        Log.d(Bridge.TAG, "To native (Cordova): " + callbackId + ", service: " + service +
+        Log.v(LogUtils.getPluginTag(), "To native (Cordova): callbackId: " + callbackId + ", service: " + service +
           ", action: " + action + ", actionArgs: " + actionArgs);
         this.callCordovaPluginMethod(callbackId, service, action, actionArgs);
       } else if (type != null && type.equals("js.error")) {
-        Log.e(Bridge.TAG, "JavaScript Error: " + jsonStr);
+        Log.e(LogUtils.getCoreTag(), "JavaScript Error: " + jsonStr);
       } else {
         String callbackId = postData.getString("callbackId");
         String pluginId = postData.getString("pluginId");
         String methodName = postData.getString("methodName");
         JSObject methodData = postData.getJSObject("options", new JSObject());
         if (!pluginId.equals("Console")) {
-          Log.d(Bridge.TAG, "To native: " + callbackId + ", pluginId: " + pluginId +
+          Log.v(LogUtils.getPluginTag(), "To native (Capacitor): callbackId: " + callbackId + ", pluginId: " + pluginId +
               ", methodName: " + methodName);
         }
         this.callPluginMethod(callbackId, pluginId, methodName, methodData);
       }
 
     } catch (Exception ex) {
-      Log.e(Bridge.TAG, "Post message error:", ex);
+      Log.e(LogUtils.getCoreTag(), "Post message error:", ex);
     }
   }
 
@@ -84,7 +84,7 @@ public class MessageHandler {
       if (errorResult != null) {
         data.put("success", false);
         data.put("error", errorResult);
-        Log.d(Bridge.TAG, "Sending plugin error: " + data.toString());
+        Log.d(LogUtils.getCoreTag(), "Sending plugin error: " + data.toString());
       } else {
         data.put("success", true);
         data.put("data", successResult);
@@ -106,7 +106,7 @@ public class MessageHandler {
       }
 
     } catch (Exception ex) {
-      Log.e(Bridge.TAG, "sendResponseMessage: error: " + ex);
+      Log.e(LogUtils.getCoreTag(), "sendResponseMessage: error: " + ex);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -41,7 +41,7 @@ public class MessageHandler {
         String service = postData.getString("service");
         String action = postData.getString("action");
         String actionArgs = postData.getString("actionArgs");
-        Log.v(LogUtils.getPluginTag(), "To native (Cordova): callbackId: " + callbackId + ", service: " + service +
+        Log.v(LogUtils.getPluginTag(), "To native (Cordova plugin): callbackId: " + callbackId + ", service: " + service +
           ", action: " + action + ", actionArgs: " + actionArgs);
         this.callCordovaPluginMethod(callbackId, service, action, actionArgs);
       } else if (type != null && type.equals("js.error")) {
@@ -52,7 +52,7 @@ public class MessageHandler {
         String methodName = postData.getString("methodName");
         JSObject methodData = postData.getJSObject("options", new JSObject());
         if (!pluginId.equals("Console")) {
-          Log.v(LogUtils.getPluginTag(), "To native (Capacitor): callbackId: " + callbackId + ", pluginId: " + pluginId +
+          Log.v(LogUtils.getPluginTag(), "To native (Capacitor plugin): callbackId: " + callbackId + ", pluginId: " + pluginId +
               ", methodName: " + methodName);
         }
         this.callPluginMethod(callbackId, pluginId, methodName, methodData);

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -324,10 +323,10 @@ public class Plugin {
    * @param data
    */
   protected void notifyListeners(String eventName, JSObject data, boolean retainUntilConsumed) {
-    Log.d(Bridge.TAG, "Notifying listeners for event " + eventName);
+    Log.v(getLogTag(), "Notifying listeners for event " + eventName);
     List<PluginCall> listeners = eventListeners.get(eventName);
     if (listeners == null) {
-      Log.d(Bridge.TAG, "No listeners found for event " + eventName);
+      Log.d(getLogTag(), "No listeners found for event " + eventName);
       if (retainUntilConsumed) {
         retainedEventArguments.put(eventName, data);
       }
@@ -546,23 +545,17 @@ public class Plugin {
   }
 
   /**
-   * Tired of supplying the first argument to Log.d? Well with log() you don't have to!
-   * Simply pass in the String like you do in literally every other programming language
-   * and save your wrists the RSI.
-   * @param args
+   * Shortcut for getting the plugin log tag
+   * @param subTags
    */
-  protected void log(String... args) {
-    StringBuffer b = new StringBuffer();
-    int i = 0;
-    int l = args.length;
-    for(String s : args) {
-      b.append(s);
-      if(i++ < l) b.append(" ");
-    }
-    Log.d(Bridge.TAG, b.toString());
+  protected String getLogTag(String... subTags) {
+    return LogUtils.getPluginTag(subTags);
   }
 
-  protected void logError(final String msg, final Throwable t) {
-    Log.e(Bridge.TAG, msg, t);
+  /**
+   * Gets a plugin log tag with the child's class name as subTag.
+   */
+  protected String getLogTag() {
+    return LogUtils.getPluginTag(this.getClass().getSimpleName());
   }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -84,13 +84,13 @@ public class PluginCall {
     PluginResult errorResult = new PluginResult();
 
     if(ex != null) {
-      ex.printStackTrace();
+      Log.e(LogUtils.getPluginTag(), msg, ex);
     }
 
     try {
       errorResult.put("message", msg);
     } catch (Exception jsonEx) {
-      Log.e(LogUtils.getPluginTag(), jsonEx.toString());
+      Log.e(LogUtils.getPluginTag(), jsonEx.getMessage());
     }
 
     this.msgHandler.sendResponseMessage(this, null, errorResult);

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -74,7 +74,7 @@ public class PluginCall {
     try {
       errorResult.put("message", msg);
     } catch (Exception jsonEx) {
-      Log.e(Bridge.TAG, jsonEx.toString());
+      Log.e(LogUtils.getPluginTag(), jsonEx.toString());
     }
 
     this.msgHandler.sendResponseMessage(this, null, errorResult);
@@ -90,7 +90,7 @@ public class PluginCall {
     try {
       errorResult.put("message", msg);
     } catch (Exception jsonEx) {
-      Log.e(Bridge.TAG, jsonEx.toString());
+      Log.e(LogUtils.getPluginTag(), jsonEx.toString());
     }
 
     this.msgHandler.sendResponseMessage(this, null, errorResult);

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginResult.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginResult.java
@@ -62,7 +62,7 @@ public class PluginResult {
     try {
       this.json.put(name, value);
     } catch (Exception ex) {
-      Log.e("PluginResultPut", ex.toString());
+      Log.e(LogUtils.getPluginTag(), "", ex);
     }
     return this;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -193,7 +193,7 @@ public class Splash {
     // Warn the user if the splash was hidden automatically, which means they could be experiencing an app
     // that feels slower than it actually is.
     if(isLaunchSplash && isVisible) {
-      Log.d("Splash hide", "SplashScreen was automatically hidden after the launch timeout. " +
+      Log.d(LogUtils.getCoreTag(), "SplashScreen was automatically hidden after the launch timeout. " +
               "You should call `SplashScreen.hide()` as soon as your web app is loaded (or increase the timeout)." +
               "Read more at https://capacitor.ionicframework.com/docs/apis/splash-screen/#hiding-the-splash-screen");
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -17,19 +17,15 @@ package com.getcapacitor;
 
 import android.content.Context;
 import android.net.Uri;
-import android.os.Build;
 import android.util.Log;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.SequenceInputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
@@ -37,7 +33,6 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Helper class meant to be used with the android.webkit.WebView class to enable hosting assets,
@@ -52,7 +47,6 @@ import java.util.UUID;
  * methods.
  */
 public class WebViewLocalServer {
-  private static String TAG = "WebViewAssetServer";
 
   private final static String httpScheme = "http";
   private final static String httpsScheme = "https";

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -186,12 +186,12 @@ public class WebViewLocalServer {
     }
     Uri uri = Uri.parse(url);
     if (uri == null) {
-      Log.e(TAG, "Malformed URL: " + url);
+      Log.e(LogUtils.getCoreTag(), "Malformed URL: " + url);
       return null;
     }
     String path = uri.getPath();
     if (path == null || path.length() == 0) {
-      Log.e(TAG, "URL does not have a path: " + url);
+      Log.e(LogUtils.getCoreTag(), "URL does not have a path: " + url);
       return null;
     }
     return uri;
@@ -216,7 +216,7 @@ public class WebViewLocalServer {
     }
 
     if (this.isLocal) {
-      Log.d("SERVER", "Handling local request: " + request.getUrl().toString());
+      Log.d(LogUtils.getCoreTag(), "Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {
       return handleProxyRequest(request, handler);
@@ -236,7 +236,7 @@ public class WebViewLocalServer {
       try {
         stream = protocolHandler.openAsset("public/index.html", "");
       } catch (IOException e) {
-        Log.e(TAG, "Unable to open index.html", e);
+        Log.e(LogUtils.getCoreTag(), "Unable to open index.html", e);
         return null;
       }
 
@@ -292,7 +292,7 @@ public class WebViewLocalServer {
       }
       return out.toString();
     } catch (Exception e) {
-      Log.e(Bridge.TAG, "Unable to process HTML asset file. This is a fatal error", e);
+      Log.e(LogUtils.getCoreTag(), "Unable to process HTML asset file. This is a fatal error", e);
     }
 
     return "";
@@ -358,7 +358,7 @@ public class WebViewLocalServer {
     try {
       mimeType = URLConnection.guessContentTypeFromName(path); // Does not recognize *.js
       if (mimeType != null && path.endsWith(".js") && mimeType.equals("image/x-icon")) {
-        Log.d(Bridge.TAG, "We shouldn't be here");
+        Log.d(LogUtils.getCoreTag(), "We shouldn't be here");
       }
       if (mimeType == null) {
         if (path.endsWith(".js")) {
@@ -369,7 +369,7 @@ public class WebViewLocalServer {
         }
       }
     } catch (Exception ex) {
-      Log.e(TAG, "Unable to get mime type" + path, ex);
+      Log.e(LogUtils.getCoreTag(), "Unable to get mime type" + path, ex);
     }
     return mimeType;
   }
@@ -464,7 +464,7 @@ public class WebViewLocalServer {
         try {
           stream = protocolHandler.openAsset(path, assetPath);
         } catch (IOException e) {
-          Log.e(TAG, "Unable to open asset URL: " + url);
+          Log.e(LogUtils.getCoreTag(), "Unable to open asset URL: " + url);
           return null;
         }
 
@@ -548,7 +548,7 @@ public class WebViewLocalServer {
         try {
           mimeType = URLConnection.guessContentTypeFromStream(stream);
         } catch (Exception ex) {
-          Log.e(TAG, "Unable to get mime type" + url);
+          Log.e(LogUtils.getPluginTag("LN"), "Unable to get mime type" + url);
         }
 
         return stream;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
@@ -3,8 +3,6 @@ package com.getcapacitor.plugin;
 import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.accessibility.AccessibilityManager;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -37,8 +35,9 @@ public class Accessibility extends Plugin {
 
   @PluginMethod()
   public void isScreenReaderEnabled(PluginCall call) {
-    Log.d(Bridge.TAG, "Checking for screen reader");
-    Log.d(Bridge.TAG, "Is it enabled? " + am.isTouchExplorationEnabled());
+    Log.d(getLogTag(), "Checking for screen reader");
+    Log.d(getLogTag(), "Is it enabled? " + am.isTouchExplorationEnabled());
+
     JSObject ret = new JSObject();
     ret.put("value", am.isTouchExplorationEnabled());
     call.success(ret);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -16,20 +14,21 @@ import com.getcapacitor.PluginResult;
 
 @NativePlugin()
 public class App extends Plugin {
+
   private static final String EVENT_BACK_BUTTON = "backButton";
   private static final String EVENT_URL_OPEN = "appUrlOpen";
   private static final String EVENT_STATE_CHANGE = "appStateChange";
   private static final String EVENT_RESTORED_RESULT = "appRestoredResult";
 
   public void fireChange(boolean isActive) {
-    Log.d(Bridge.TAG, "Firing change: " + isActive);
+    Log.d(getLogTag(), "Firing change: " + isActive);
     JSObject data = new JSObject();
     data.put("isActive", isActive);
     notifyListeners(EVENT_STATE_CHANGE, data, true);
   }
 
   public void fireRestoredResult(PluginResult result) {
-    Log.d(Bridge.TAG, "Firing restored result");
+    Log.d(getLogTag(), "Firing restored result");
     notifyListeners(EVENT_RESTORED_RESULT, result.getData(), true);
   }
 
@@ -78,7 +77,9 @@ public class App extends Plugin {
       ret.put("value", true);
       call.success(ret);
       return;
-    } catch(PackageManager.NameNotFoundException e) {}
+    } catch(PackageManager.NameNotFoundException e) {
+      Log.e(getLogTag(), "Package name '"+url+"' not found!");
+    }
 
     ret.put("value", false);
     call.success(ret);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
@@ -9,15 +9,12 @@ import android.support.customtabs.CustomTabsIntent;
 import android.support.customtabs.CustomTabsServiceConnection;
 import android.support.customtabs.CustomTabsSession;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.PluginRequestCodes;
-
 import org.json.JSONException;
 
 /**
@@ -50,7 +47,7 @@ public class Browser extends Plugin {
       try {
         builder.setToolbarColor(Color.parseColor(toolbarColor));
       } catch (IllegalArgumentException ex) {
-        Log.e(Bridge.TAG, "Browser: Invalid color provided for toolbarColor. Using default");
+        Log.e(getLogTag(), "Invalid color provided for toolbarColor. Using default");
       }
     }
 
@@ -110,7 +107,7 @@ public class Browser extends Plugin {
   protected void handleOnResume() {
     boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
     if (!ok) {
-      Log.e(Bridge.TAG, "Error binding to custom tabs service");
+      Log.e(getLogTag(), "Error binding to custom tabs service");
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -13,12 +12,8 @@ import android.provider.MediaStore;
 import android.support.v4.content.FileProvider;
 import android.util.Base64;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.Dialogs;
 import com.getcapacitor.FileUtils;
-import com.getcapacitor.plugin.camera.ExifWrapper;
-import com.getcapacitor.plugin.camera.ImageUtils;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -28,6 +23,8 @@ import com.getcapacitor.PluginRequestCodes;
 import com.getcapacitor.plugin.camera.CameraResultType;
 import com.getcapacitor.plugin.camera.CameraSettings;
 import com.getcapacitor.plugin.camera.CameraSource;
+import com.getcapacitor.plugin.camera.ExifWrapper;
+import com.getcapacitor.plugin.camera.ImageUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -182,7 +179,7 @@ public class Camera extends Plugin {
     try {
       return CameraResultType.valueOf(resultType.toUpperCase());
     } catch (IllegalArgumentException ex) {
-      log("Invalid result type \"" + resultType + "\", defaulting to base64");
+      Log.d(getLogTag(), "Invalid result type \"" + resultType + "\", defaulting to base64");
       return CameraResultType.BASE64;
     }
   }
@@ -276,7 +273,7 @@ public class Camera extends Plugin {
         try {
           imageStream.close();
         } catch (IOException e) {
-          logError(UNABLE_TO_PROCESS_IMAGE, e);
+          Log.e(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
         }
       }
     }
@@ -364,7 +361,7 @@ public class Camera extends Plugin {
         try {
           bis.close();
         } catch (IOException e) {
-          logError(UNABLE_TO_PROCESS_IMAGE, e);
+          Log.e(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
         }
       }
     }
@@ -414,7 +411,7 @@ public class Camera extends Plugin {
     String imageFileName = "JPEG_" + timeStamp + "_";
     File storageDir;
     if(saveToGallery) {
-      log("Trying to save image to public external directory");
+      Log.d(getLogTag(), "Trying to save image to public external directory");
       storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
     }  else {
       storageDir = getActivity().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
@@ -433,10 +430,10 @@ public class Camera extends Plugin {
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
 
-    log("handling request perms result");
+    Log.d(getLogTag(),"handling request perms result");
 
     if (getSavedCall() == null) {
-      log("No stored plugin call for permissions request result");
+      Log.d(getLogTag(),"No stored plugin call for permissions request result");
       return;
     }
 
@@ -446,7 +443,7 @@ public class Camera extends Plugin {
       int result = grantResults[i];
       String perm = permissions[i];
       if(result == PackageManager.PERMISSION_DENIED) {
-        Log.d(Bridge.TAG, "User denied camera permission: " + perm);
+        Log.d(getLogTag(), "User denied camera permission: " + perm);
         savedCall.error(PERMISSION_DENIED_ERROR);
         return;
       }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
@@ -5,8 +5,6 @@ import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -52,14 +50,14 @@ public class Clipboard extends Plugin {
         c.getSystemService(Context.CLIPBOARD_SERVICE);
 
     if(clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-      Log.d(Bridge.TAG, "Got plaintxt");
+      Log.d(getLogTag(), "Got plaintxt");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
 
       JSObject ret = new JSObject();
       ret.put("value", item.getText());
       call.success(ret);
     } else {
-      Log.d(Bridge.TAG, "Not plaintext!");
+      Log.d(getLogTag(), "Not plaintext!");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
       String value = item.coerceToText(this.getContext()).toString();
       JSObject ret = new JSObject();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Console.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Console.java
@@ -1,7 +1,6 @@
 package com.getcapacitor.plugin;
 
 import android.util.Log;
-
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -11,21 +10,21 @@ import com.getcapacitor.PluginMethod;
 @NativePlugin()
 public class Console extends Plugin {
 
-  private static final String TAG_CONSOLE = "console";
-
   @PluginMethod(returnType = PluginMethod.RETURN_NONE)
   public void log(PluginCall call) {
     String level = call.getString("level");
     String message = call.getString("message", "");
 
     if ("error".equalsIgnoreCase(level)) {
-      Log.e(TAG_CONSOLE, message);
+      Log.e(getLogTag(), message);
     } else if ("warn".equalsIgnoreCase(level)) {
-      Log.w(TAG_CONSOLE, message);
+      Log.w(getLogTag(), message);
     } else if ("debug".equalsIgnoreCase(level)) {
-      Log.d(TAG_CONSOLE, message);
+      Log.d(getLogTag(), message);
+    } else if ("trace".equalsIgnoreCase(level)) {
+      Log.v(getLogTag(), message);
     } else {
-      Log.i(TAG_CONSOLE, message);
+      Log.i(getLogTag(), message);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Network.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Network.java
@@ -8,8 +8,6 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
@@ -47,7 +45,7 @@ public class Network extends Plugin {
         if (hasRequiredPermissions()) {
           notifyListeners(NETWORK_CHANGE_EVENT, getStatusJSObject(cm.getActiveNetworkInfo()));
         } else {
-          Log.e(Bridge.TAG, PERMISSION_NOT_SET);
+          Log.e(getLogTag(), PERMISSION_NOT_SET);
         }
       }
     };

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
 
+import android.util.Log;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -116,8 +117,8 @@ public class PushNotifications extends Plugin {
         channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
         channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
         channel.put(CHANNEL_VISIBILITY, notificationChannel.getLockscreenVisibility());
-        System.out.println("visibility " + notificationChannel.getLockscreenVisibility());
-        System.out.println("importance " + notificationChannel.getImportance());
+        Log.d(getLogTag(), "visibility " + notificationChannel.getLockscreenVisibility());
+        Log.d(getLogTag(), "importance " + notificationChannel.getImportance());
         channels.put(channel);
       }
       JSObject result = new JSObject();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/background/BackgroundTaskService.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/background/BackgroundTaskService.java
@@ -4,8 +4,7 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
+import com.getcapacitor.LogUtils;
 
 public class BackgroundTaskService extends IntentService {
   public BackgroundTaskService() {
@@ -16,7 +15,7 @@ public class BackgroundTaskService extends IntentService {
   protected void onHandleIntent(Intent intent) {
     // Gets data from the incoming Intent
     String taskId = intent.getStringExtra("taskId");
-    Log.d(Bridge.TAG, "Doing background task: " + taskId);
+    Log.d(LogUtils.getCoreTag(), "Doing background task: " + taskId);
 
     Intent localIntent = new Intent(BackgroundTask.TASK_BROADCAST_ACTION)
         .putExtra("taskId", taskId);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -11,6 +11,7 @@ import android.provider.MediaStore;
 import android.util.Log;
 
 import com.getcapacitor.FileUtils;
+import com.getcapacitor.LogUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -124,7 +125,7 @@ public class ImageUtils {
 
       return new ExifWrapper(exifInterface);
     } catch (IOException ex) {
-      Log.e("CapacitorImageUtils", "Error loading exif data from image", ex);
+      Log.e(LogUtils.getCoreTag(), "Error loading exif data from image", ex);
     } finally {
     }
     return new ExifWrapper(null);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.LogUtils;
 import com.getcapacitor.PluginCall;
 
 import org.json.JSONException;
@@ -241,7 +242,7 @@ public class LocalNotification {
       JSONObject jsonObject = new JSONObject(extraFromString);
       this.extra = JSObject.fromJSONObject(jsonObject);
     } catch (JSONException e) {
-      Log.e("LNParser", "Cannot rebuild extra data", e);
+      Log.e(LogUtils.getPluginTag("LN"), "Cannot rebuild extra data", e);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -16,12 +16,10 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.RemoteInput;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.LogUtils;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.android.R;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -58,10 +56,10 @@ public class LocalNotificationManager {
    * Method extecuted when notification is launched by user from the notification bar.
    */
   public JSObject handleNotificationActionPerformed(Intent data, NotificationStorage notificationStorage) {
-    Log.d(Bridge.TAG, "LocalNotification received: " + data.getDataString());
+    Log.d(LogUtils.getPluginTag("LN"), "LocalNotification received: " + data.getDataString());
     int notificationId = data.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (notificationId == Integer.MIN_VALUE) {
-      Log.d("LocalNotification", "Activity started without notification attached");
+      Log.d(LogUtils.getPluginTag("LN"), "Activity started without notification attached");
       return null;
     }
     boolean isRemovable = data.getBooleanExtra(LocalNotificationManager.NOTIFICATION_IS_REMOVABLE_KEY, true);
@@ -247,7 +245,7 @@ public class LocalNotificationManager {
     Date at = schedule.getAt();
     if (at != null) {
       if (at.getTime() < new Date().getTime()) {
-        Log.e(Bridge.TAG, "Scheduled time must be *after* current time");
+        Log.e(LogUtils.getPluginTag("LN"), "Scheduled time must be *after* current time");
         return;
       }
       if (schedule.isRepeating()) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationAction.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationAction.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 
+import com.getcapacitor.LogUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -57,7 +58,7 @@ public class NotificationAction {
         }
       }
     } catch (Exception e) {
-      Log.e("LNActionType", "Error when building action types", e);
+      Log.e(LogUtils.getPluginTag("LN"), "Error when building action types", e);
     }
     return actionTypeMap;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationDismissReceiver.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationDismissReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import com.getcapacitor.LogUtils;
 
 
 /**
@@ -16,7 +17,7 @@ public class NotificationDismissReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     int intExtra = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (intExtra == Integer.MIN_VALUE) {
-      Log.e("LNotificationDismiss", "Invalid notification dismiss operation");
+      Log.e(LogUtils.getPluginTag("LN"), "Invalid notification dismiss operation");
       return;
     }
     boolean isRemovable = intent.getBooleanExtra(LocalNotificationManager.NOTIFICATION_IS_REMOVABLE_KEY, true);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import com.getcapacitor.LogUtils;
 
 import java.util.Date;
 
@@ -28,7 +29,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     Notification notification = intent.getParcelableExtra(NOTIFICATION_KEY);
     int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (id == Integer.MIN_VALUE) {
-      Log.e("LNPublisher", "No valid id supplied");
+      Log.e(LogUtils.getPluginTag("LN"), "No valid id supplied");
     }
     notificationManager.notify(id, notification);
     rescheduleNotificationIfNeeded(context, intent, id);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/AssetUtil.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/AssetUtil.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.os.StrictMode;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
+import com.getcapacitor.LogUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -87,7 +88,7 @@ public final class AssetUtil {
         File file      = new File(absPath);
 
         if (!file.exists()) {
-            Log.e("Asset", "File not found: " + file.getAbsolutePath());
+            Log.e(LogUtils.getCoreTag(), "File not found: " + file.getAbsolutePath());
             return Uri.EMPTY;
         }
 
@@ -116,8 +117,7 @@ public final class AssetUtil {
             FileOutputStream out = new FileOutputStream(file);
             copyFile(in, out);
         } catch (Exception e) {
-            Log.e("Asset", "File not found: assets/" + resPath);
-            e.printStackTrace();
+            Log.e(LogUtils.getCoreTag(), "File not found: assets/" + resPath);
             return Uri.EMPTY;
         }
 
@@ -137,7 +137,7 @@ public final class AssetUtil {
         int resId      = getResId(resPath);
 
         if (resId == 0) {
-            Log.e("Asset", "File not found: " + resPath);
+            Log.e(LogUtils.getCoreTag(), "File not found: " + resPath);
             return Uri.EMPTY;
         }
 
@@ -181,14 +181,11 @@ public final class AssetUtil {
             copyFile(in, out);
             return getUriFromFile(file);
         } catch (MalformedURLException e) {
-            Log.e("Asset", "Incorrect URL");
-            e.printStackTrace();
+            Log.e("Asset", "Incorrect URL", e);
         } catch (FileNotFoundException e) {
-            Log.e("Asset", "Failed to create new File from HTTP Content");
-            e.printStackTrace();
+            Log.e("Asset", "Failed to create new File from HTTP Content", e);
         } catch (IOException e) {
-            Log.e("Asset", "No Input can be created from http Stream");
-            e.printStackTrace();
+            Log.e("Asset", "No Input can be created from http Stream", e);
         }
 
         return Uri.EMPTY;
@@ -211,7 +208,7 @@ public final class AssetUtil {
             out.flush();
             out.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.e(LogUtils.getCoreTag(), "Error copiing", e);
         }
     }
 
@@ -335,7 +332,7 @@ public final class AssetUtil {
             String authority = context.getPackageName() + ".provider";
             return FileProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
+            Log.e(LogUtils.getCoreTag(), "File not supported by provider", e);
             return Uri.EMPTY;
         }
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/ui/ModalsBottomSheetDialogFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/ui/ModalsBottomSheetDialogFragment.java
@@ -12,11 +12,9 @@ import android.view.View;
 import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-
+import com.getcapacitor.LogUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -95,7 +93,7 @@ public class ModalsBottomSheetDialogFragment extends BottomSheetDialogFragment {
         tv.setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.d(Bridge.TAG, "CliCKED: " + optionIndex);
+            Log.d(LogUtils.getCoreTag(), "CliCKED: " + optionIndex);
 
             if (listener != null) {
               listener.onSelected(optionIndex);
@@ -118,7 +116,7 @@ public class ModalsBottomSheetDialogFragment extends BottomSheetDialogFragment {
         ((BottomSheetBehavior) behavior).setBottomSheetCallback(mBottomSheetBehaviorCallback);
       }
     } catch (JSONException ex) {
-      Log.e(Bridge.TAG, "JSON error processing an option for showActions", ex);
+      Log.e(LogUtils.getCoreTag(), "JSON error processing an option for showActions", ex);
     }
   }
 }


### PR DESCRIPTION
To make Capacitor's log stream better searchable by Logcat all Capacitor Android runtime and plugin log tags should have the same form.

I introduced a new class `com.getcapacitor.LogUtils` with a **core** and **plugin** tag method, which should be used for the obvious purposes.

```
Log.i(LogUtils.getCoreTag(), "Your message");
Log.i(LogUtils.getPluginTag(), "Your plugin message");
```

These methods might have subTags: String[] param, joining the Strings together separated by a slash.

For plugins extending `com.getcapacitor.Plugin` the super method `com.getcapacitor.Plugin#getLogTag()` should be used, which builds the log tag using a prefix and the class name of the sub class.

Refactorings during the cleanup:
* Replaced all `System.out.println()` and `printStackTrace()` with log statements
* Changed some log levels, where appropriate
* Removed unused or not needed logging helpers

After changing this I was able to use the filter string `/Capacitor` in LogCat and get only log statements belonging to Capacitor or search by `Capacitor/Plugin` to get everything related to plugins.

BR,
Michael