### PR TITLE
Improve iOS push notifications

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1211,11 +1211,13 @@ export enum PhotosAlbumType {
 //
 
 export interface PushNotification {
-  title: string;
-  subtitle: string;
-  body: string;
-  id: string;
-  badge: number;
+  title?: string;
+  subtitle?: string;
+  body?: string;
+  id?: string;
+  badge?: number;
+  notification?: any;
+  data?: any;
 }
 
 export interface PushNotificationActionPerformed {
@@ -1246,13 +1248,14 @@ export interface PushNotificationChannelList {
 
 export interface PushNotificationsPlugin extends Plugin {
   register(): Promise<void>;
-  getDeliveredNotifications(): Promise<void>;
+  getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
   removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;
   createChannel(channel: PushNotificationChannel): Promise<void>;
   deleteChannel(channel: PushNotificationChannel): Promise<void>;
   listChannels(): Promise<PushNotificationChannelList>;
   addListener(eventName: 'registration', listenerFunc: (token: PushNotificationToken) => void): PluginListenerHandle;
+  addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: PushNotificationActionPerformed) => void): PluginListenerHandle;
 }

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -94,10 +94,13 @@ CAP_PLUGIN(CAPNetworkPlugin, "Network",
 
 
 CAP_PLUGIN(CAPPushNotificationsPlugin, "PushNotifications",
-  CAP_PLUGIN_METHOD(requestPermissions, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(register, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getDeliveredNotifications, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeDeliveredNotifications, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeAllDeliveredNotifications, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(createChannel, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(deleteChannel, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(listChannels, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPPhotosPlugin, "Photos",

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -18,8 +18,9 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
   /**
    * Register for push notifications
    */
-  @objc func requestPermissions(_ call: CAPPluginCall) {
+  @objc func register(_ call: CAPPluginCall) {
     self.bridge.notificationsDelegate.requestPermissions()
+    call.success()
   }
 
   /**
@@ -48,6 +49,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
     let ids = notifications.map { $0["id"] as? String ?? "" }
 
     UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ids)
+    call.success()
   }
 
   /**
@@ -55,6 +57,19 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    */
   @objc func removeAllDeliveredNotifications(_ call: CAPPluginCall) {
     UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    call.success()
+  }
+
+  @objc func createChannel(_ call: CAPPluginCall) {
+    call.error("not available")
+  }
+
+  @objc func deleteChannel(_ call: CAPPluginCall) {
+    call.error("not available")
+  }
+
+  @objc func listChannels(_ call: CAPPluginCall) {
+    call.error("not available")
   }
 
   @objc public func didRegisterForRemoteNotificationsWithDeviceToken(notification: NSNotification){
@@ -62,7 +77,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
       return
     }
     let deviceTokenString = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
-    notifyListeners("didRegisterForRemoteNotificationsWithDeviceToken", data:[
+    notifyListeners("registration", data:[
       "value": deviceTokenString
     ])
 
@@ -72,7 +87,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
     guard let error = notification.object as? Error else {
       return
     }
-    notifyListeners("didFailToRegisterForRemoteNotificationsWithError", data:[
+    notifyListeners("registrationError", data:[
       "error": error.localizedDescription
     ])
   }


### PR DESCRIPTION
call success on available methods
call error("not available") on Android only methods
make getDeliveredNotifications return a PushNotificationDeliveredList Promise
add registrationError listener
make PushNotification fields optional and add notification and data for Android
rename didRegisterForRemoteNotificationsWithDeviceToken listener to registration