### PR TITLE
Update app.package after plugin install to refresh dependencies

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,6 +1,6 @@
 import { accessSync, readFileSync } from 'fs';
 import { basename, join, resolve } from 'path';
-import { logFatal } from './common';
+import { logFatal, readJSON } from './common';
 import { CliConfig, ExternalConfig, OS, PackageJson } from './definitions';
 
 let Package: PackageJson;
@@ -151,6 +151,10 @@ export class Config implements CliConfig {
     this.app.rootDir = currentWorkingDir;
     this.app.package = loadPackageJson(currentWorkingDir);
     this.app.assets.templateDir = join(this.cli.assetsDir, this.app.assets.templateName);
+  }
+
+  async updateAppPackage() {
+    this.app.package = await readJSON(resolve(this.app.rootDir, 'package.json'));
   }
 
   private initElectronConfig() {

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -265,6 +265,7 @@ export async function checkAndInstallDependencies(config: Config, cordovaPlugins
           logInfo(`installing missing dependency plugin ${plugin}`);
           try {
             await runCommand(`cd "${config.app.rootDir}" && npm install ${plugin}`);
+            await config.updateAppPackage();
             needsUpdate = true;
           } catch (e) {
             console.log("\n");


### PR DESCRIPTION
When a plugin has dependencies it enters in an infinite loop because the app dependencies are not updated after the plugin install, so it doesn't find it and try to install it again.
