### PR TITLE
Add an Android preference 'captureInput' to use special keyboard

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -12,13 +12,22 @@ import android.webkit.WebView;
 import java.util.Date;
 
 public class CapacitorWebView extends WebView {
+  private BaseInputConnection capInputConnection;
+
   public CapacitorWebView(Context context, AttributeSet attrs) {
     super(context, attrs);
   }
 
   @Override
   public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-    return new BaseInputConnection(this, false);
+    boolean captureInput = Config.getBoolean("android.captureInput", false);
+    if (captureInput) {
+      if (capInputConnection == null) {
+        capInputConnection = new BaseInputConnection(this, false);
+      }
+      return capInputConnection;
+    }
+    return super.onCreateInputConnection(outAttrs);
   }
 
   @Override


### PR DESCRIPTION
Added a new `captureInput` preference for Android that allows the keyboard key capture, otherwise it will use the default keyboard as the `BaseInputConnection` has a few issues (no autocompletion, no emoji, problems with special chars, not respecting type number, etc)

Closes #676
Closes #701

Also reuse the same `BaseInputConnection` instead of creating a new one every time.