### PR TITLE
Only apply google-services plugin if json file is present

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -41,4 +41,12 @@ dependencies {
 }
 
 apply from: 'capacitor.build.gradle'
-apply plugin: 'com.google.gms.google-services'
+
+try {
+    def servicesJSON = file('google-services.json')
+    if (servicesJSON.text) {
+        apply plugin: 'com.google.gms.google-services'
+    }
+} catch(Exception e) {
+    logger.warn("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+}


### PR DESCRIPTION
to apply google-services plugin, it requires a google-services.json file present on the project.
Only apply it if the file is present, otherwise log a warning telling Push Notifications won't work.

Closes #724