### PR TITLE
Inject Capacitor scripts when the app is loaded from external url

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.util.Base64;
 import android.util.Log;
 import android.webkit.ValueCallback;
 import android.webkit.WebResourceRequest;
@@ -88,6 +89,7 @@ public class Bridge {
   private WebViewLocalServer localServer;
   private String localUrl;
   private String appUrl;
+  private String appUrlConfig;
   // A reference to the main WebView for the app
   private final WebView webView;
   public final CordovaInterfaceImpl cordovaInterface;
@@ -151,7 +153,7 @@ public class Bridge {
   }
 
   private void loadWebView() {
-    final String appUrlConfig = Config.getString("server.url");
+    appUrlConfig = Config.getString("server.url");
 
     String port = getPort();
     String authority = "localhost" + ":" + port;
@@ -188,6 +190,13 @@ public class Bridge {
       @Override
       public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
         return localServer.shouldInterceptRequest(request);
+      }
+
+      @Override
+      public void onPageFinished(WebView view, final String location) {
+        if (appUrlConfig != null) {
+          injectScriptFile(view, getJSInjector().getScriptString());
+        }
       }
 
       @Override
@@ -793,5 +802,19 @@ public class Bridge {
         webView.loadUrl(appUrl);
       }
     });
+  }
+
+  private void injectScriptFile(WebView view, String script) {
+
+    // Base64 encode string before injecting as innerHTML
+    String encoded = Base64.encodeToString(script.getBytes(), Base64.NO_WRAP);
+    view.loadUrl("javascript:(function() {" +
+            "var parent = document.getElementsByTagName('head').item(0);" +
+            "var script = document.createElement('script');" +
+            "script.type = 'text/javascript';" +
+            // Base64 decode injected javascript
+            "script.innerHTML = window.atob('" + encoded + "');" +
+            "parent.appendChild(script)" +
+            "})()");
   }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -42,6 +42,17 @@ class JSInjector {
     this.localUrlJS = localUrlJS;
   }
 
+  /**
+   * Generates injectable JS content.
+   * This may be used in other forms of injecting that aren't using an InputStream.
+   * @return
+   */
+  public String getScriptString() {
+    return globalJS + "\n\n" +
+            coreJS + "\n\n" + pluginJS + "\n\n" + cordovaJS + "\n\n" +
+            cordovaPluginsFileJS + "\n\n" + cordovaPluginsJS + "\n\n" +
+            localUrlJS;
+  }
 
   /**
    * Given an InputStream from the web server, prepend it with
@@ -51,10 +62,7 @@ class JSInjector {
    */
   public InputStream getInjectedStream(InputStream responseStream) {
     try {
-      String js = "<script type=\"text/javascript\">" + globalJS + "\n\n" +
-              coreJS + "\n\n" + pluginJS + "\n\n" + cordovaJS + "\n\n" +
-              cordovaPluginsFileJS + "\n\n" + cordovaPluginsJS + "\n\n" +
-              localUrlJS + "</script>";
+      String js = "<script type=\"text/javascript\">" + getScriptString() + "</script>";
       InputStream jsInputStream = new ByteArrayInputStream(js.getBytes(StandardCharsets.UTF_8.name()));
       return new SequenceInputStream(jsInputStream, responseStream);
     } catch(UnsupportedEncodingException ex) {


### PR DESCRIPTION
When configuring server.url on Android, the Capacitor js files/code are not injected, so you can't use Capacitor plugins.

Used code from #438 