### PR TITLE
Android: make splash resource name configurable

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Config.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Config.java
@@ -76,7 +76,7 @@ public class Config {
     // Search until the second to last part of the key
     for (int i = 0; i < parts.length-1; i++) {
       String k = parts[i];
-      o = this.config.getJSONObject(k);
+      o = o.getJSONObject(k);
     }
     return o;
   }
@@ -106,6 +106,17 @@ public class Config {
 
       return o.getBoolean(k);
     } catch (Exception ex) {}
+    return defaultValue;
+  }
+
+  public static int getInt(String key, int defaultValue) {
+    String k = getConfigKey(key);
+    try {
+      JSONObject o = getInstance().getConfigObjectDeepest(key);
+      return o.getInt(k);
+    } catch (Exception ignore) {
+      // value was not found
+    }
     return defaultValue;
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -12,10 +12,6 @@ import android.view.WindowManager;
 import android.view.animation.LinearInterpolator;
 import android.widget.ImageView;
 
-import com.getcapacitor.plugin.SplashScreen;
-
-import org.json.JSONObject;
-
 /**
  * A Splash Screen service for showing and hiding a splash screen in the app.
  */
@@ -25,10 +21,9 @@ public class Splash {
     void error();
   }
 
-  private static final String SPLASH_DRAWABLE = "splash";
+  public static final String CONFIG_KEY_PREFIX = "plugins.SplashScreen.";
 
-  public static final int LAUNCH_SHOW_DURATION = 3000;
-
+  public static final int DEFAULT_LAUNCH_SHOW_DURATION = 3000;
   public static final int DEFAULT_FADE_IN_DURATION = 200;
   public static final int DEFAULT_FADE_OUT_DURATION = 200;
   public static final int DEFAULT_SHOW_DURATION = 3000;
@@ -41,8 +36,10 @@ public class Splash {
 
   private static void buildViews(Context c) {
 
-    int splashId = c.getResources().getIdentifier("splash", "drawable", c.getPackageName());
-    Drawable splash = c.getResources().getDrawable(splashId);
+    String splashResourceName = Config.getString(CONFIG_KEY_PREFIX + "androidSplashResourceName", "splash");
+
+    int splashId = c.getResources().getIdentifier(splashResourceName, "drawable", c.getPackageName());
+    Drawable splash = c.getResources().getDrawable(splashId, c.getTheme());
 
     splashImage = new ImageView(c);
 
@@ -59,25 +56,7 @@ public class Splash {
    * @param a
    */
   public static void showOnLaunch(final BridgeActivity a) {
-    Bridge b = a.getBridge();
-    if (b == null) {
-      return;
-    }
-
-    PluginHandle splashPluginHandle = b.getPlugin("SplashScreen");
-    if (splashPluginHandle == null) {
-      return;
-    }
-
-    SplashScreen splashPlugin = (SplashScreen) splashPluginHandle.getInstance();
-
-    Integer durationValue = (Integer) splashPlugin.getConfigValue("launchShowDuration");
-
-    int duration = LAUNCH_SHOW_DURATION;
-    if (durationValue != null) {
-      duration = durationValue.intValue();
-    }
-
+    Integer duration = Config.getInt(CONFIG_KEY_PREFIX + "launchShowDuration", DEFAULT_LAUNCH_SHOW_DURATION);
     show(a, duration, 0, DEFAULT_FADE_OUT_DURATION, true, null, true);
   }
 
@@ -86,7 +65,7 @@ public class Splash {
    * @param a
    */
   public static void show(final Activity a) {
-    show(a, LAUNCH_SHOW_DURATION, DEFAULT_FADE_IN_DURATION, DEFAULT_FADE_OUT_DURATION, DEFAULT_AUTO_HIDE, null);
+    show(a, DEFAULT_LAUNCH_SHOW_DURATION, DEFAULT_FADE_IN_DURATION, DEFAULT_FADE_OUT_DURATION, DEFAULT_AUTO_HIDE, null);
   }
 
   /**

--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -46,6 +46,61 @@ If your app needs longer than 3 seconds to load, configure the default duration 
 
 Then run `npx cap copy` to apply these changes.
 
+## Configuration
+
+These config parameters are availiable in `capacitor.config.json`:
+
+```json
+{
+  "plugins": {
+    "SplashScreen": {
+      "launchShowDuration": 3000,
+      "androidSplashResourceName": "splash"
+    }
+  }
+}
+```
+
+## Add your own splash screen images
+
+See [Josh Morony's blog post](https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/) on how to change it. 
+
+### Android
+
+If your splash screen images aren't named "splash.png" but for example "screen.png" you have to change `"androidSplashResourceName": "screen"` in `capacitor.config.json` and change the following files in you're Android app as well:
+
+`android/app/src/main/res/drawable/launch_splash.xml` 
+
+replace
+```
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/splash"
+    android:scaleType="centerCrop"
+    />
+```
+with
+```
+<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@drawable/screen"
+    android:scaleType="centerCrop"
+    />
+```
+
+`android/app/src/main/res/values/styles.xml` 
+
+replace
+```
+    <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
+        <item name="android:background">@drawable/splash</item>
+    </style>
+```
+with
+```
+    <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
+        <item name="android:background">@drawable/screen</item>
+    </style>
+```
+
 ## API
 
 <plugin-api name="splash-screen"></plugin-api>


### PR DESCRIPTION
Creating custom icons and splashscreens following Josh Morony's great post works like charm. https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/

To generate my splashscreens I used one of the tools listed https://apetools.webprofusion.com/app/#/tools/imagegorilla. This tool generates the image files needed but names it `screen` instead of `splash`.

Instead of renaming all files it would be nice to let users configure the resource name for the splashscreen image.
```
  "android": {
    "splashResourceName": "screen",
  }
```
I searched but didn't find anything according on ios. If there is I'm happy to add a config param there as well.

BR, Michael

