### PR TITLE
Return [] instead of null when there is no platform tags

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -121,7 +121,7 @@ export function getPluginPlatform(p: Plugin, platform: string) {
     const platforms = p.xml.platform.filter(function(item: any) { return item.$.name === platform; });
     return platforms[0];
   }
-  return null;
+  return [];
 }
 
 export function getPlatformElement(p: Plugin, platform: string, elementName: string) {


### PR DESCRIPTION
Some Cordova plugins are just js code with no native code, so don't have platform tags.

By returning [] instead of null we detect it as Cordova plugin despite not having platform tag.

Closes #763 