### PR TITLE
Add console and compat plugins to incompatible list

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -285,5 +285,5 @@ export async function checkAndInstallDependencies(config: Config, cordovaPlugins
 }
 
 export function getIncompatibleCordovaPlugins(){
-  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview", "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine"];
+  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview", "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console", "cordova-plugin-compat"];
 }


### PR DESCRIPTION
Add "cordova-plugin-console" and "cordova-plugin-compat" to the skip list so they don't get installed as console can cause problems with Capacitor console and compat causes multiple dex problem as the same classes are in cordova-android.