### PR TITLE
Android: Enable Filesystem#writeFile to save files to "Documents" directory

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -8,4 +8,5 @@ public class PluginRequestCodes {
   public static final int CAMERA_IMAGE_EDIT = 9005;
   public static final int NOTIFICATION_OPEN = 9006;
   public static final int FILE_CHOOSER = 9007;
+  public static final int FILESYSTEM_REQUEST_WRITE_PERMISSIONS = 9008;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -1,19 +1,23 @@
 package com.getcapacitor.plugin;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Base64;
 import android.util.Log;
-
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
-
+import com.getcapacitor.PluginRequestCodes;
 import org.json.JSONException;
 
 import java.io.BufferedReader;
@@ -30,7 +34,9 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-@NativePlugin()
+@NativePlugin(requestCodes = {
+  PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_PERMISSIONS
+})
 public class Filesystem extends Plugin {
   private Charset getEncoding(String encoding) {
     if (encoding == null) {
@@ -54,7 +60,7 @@ public class Filesystem extends Plugin {
       case "APPLICATION":
         return c.getFilesDir();
       case "DOCUMENTS":
-        return c.getFilesDir();
+        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
       case "DATA":
         return c.getFilesDir();
       case "CACHE":
@@ -173,45 +179,107 @@ public class Filesystem extends Plugin {
 
   @PluginMethod()
   public void writeFile(PluginCall call) {
-    String file = call.getString("path");
+    String path = call.getString("path");
     String data = call.getString("data");
-    String directory = call.getString("directory");
-    String encoding = call.getString("encoding");
-    boolean append = call.getBoolean("append", false).booleanValue();
 
-    File fileObject = getFileObject(file, directory);
+    if (path == null) {
+      Log.e(getLogTag(), "No path or filename retrieved from call");
+      call.error("NO_PATH");
+      return;
+    }
+
+    if (data == null) {
+      Log.e(getLogTag(), "No data retrieved from call");
+      call.error("NO_DATA");
+      return;
+    }
+
+    String directory = getDirectoryParameter(call);
+    if (directory != null) {
+      if (!isExternalDirectory(directory)
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        // create directory because it might not exist
+        File androidDir = getDirectory(directory);
+        if (androidDir != null) {
+          if (androidDir.exists() || androidDir.mkdirs()) {
+            // path might include directories as well
+            File fileObject = new File(androidDir, path);
+            if (fileObject.getParentFile().exists() || fileObject.getParentFile().mkdirs()) {
+              saveFile(call, fileObject, data);
+            }
+          } else {
+            Log.e(getLogTag(), "Not able to create '"+directory+"'!");
+            call.error("NOT_CREATED_DIR");
+          }
+        } else {
+          Log.e(getLogTag(), "Directory ID '"+directory+"' is not supported by plugin");
+          call.error("INVALID_DIR");
+        }
+      }
+    } else {
+      // check if file://
+      Uri u = Uri.parse(path);
+      if ("file".equals(u.getScheme())) {
+        File fileObject = new File(u.getPath());
+        // do not know where the file is being store so checking the permission to be secure
+        // TODO to prevent permission checking we need a property from the call
+        if (isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          if (fileObject.getParentFile().exists() || fileObject.getParentFile().mkdirs()) {
+            saveFile(call, fileObject, data);
+          }
+        }
+      }
+    }
+  }
+
+  private void saveFile(PluginCall call, File file, String data) {
+    String encoding = call.getString("encoding");
+    boolean append = call.getBoolean("append", false);
 
     Charset charset = this.getEncoding(encoding);
-    if(encoding != null && charset == null) {
+    if (encoding != null && charset == null) {
       call.error("Unsupported encoding provided: " + encoding);
       return;
     }
-    if(fileObject == null) {
-      call.error("Invalid file path");
-      return;
+
+    // if charset is not null assume its a plain text file the user wants to save
+    boolean success = false;
+    if (charset != null) {
+      try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+        new FileOutputStream(file, append), charset))) {
+        writer.write(data);
+        success = true;
+      } catch (IOException e) {
+        Log.e(getLogTag(), "Creating text file '"+file.getPath()+"' with charset '"+charset+"' failed. Error: "+e.getMessage(), e);
+      }
+    } else {
+      try (FileOutputStream fos = new FileOutputStream(file, append)) {
+        fos.write(Base64.decode(data, Base64.NO_WRAP));
+        success = true;
+      } catch (IOException e) {
+        Log.e(getLogTag(), "Creating binary file '"+file.getPath()+"' failed. Error: "+e.getMessage(), e);
+      }
     }
 
-    try {
-      if (charset != null) {
-        BufferedWriter bw = new BufferedWriter(
-            new OutputStreamWriter(
-                new FileOutputStream(fileObject, append),
-                charset
-            )
-        );
-
-        bw.write(data);
-
-        bw.close();
-      } else {
-        FileOutputStream fos = new FileOutputStream(fileObject);
-        fos.write(Base64.decode(data, Base64.NO_WRAP));
-        fos.close();
+    if (success) {
+      // update mediaStore index only if file was written to external storage
+      if (isExternalDirectory(getDirectoryParameter(call))) {
+        MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
       }
-
       call.success();
-    } catch (IOException ex) {
-      call.error("Unable to write file", ex);
+    } else {
+      call.error("FILE_NOTCREATED");
+    }
+  }
+
+  @Override
+  protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    switch (requestCode) {
+      case PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_PERMISSIONS: {
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+          Log.d(getLogTag(), "User granted write permission.");
+        }
+      }
     }
   }
 
@@ -346,5 +414,44 @@ public class Filesystem extends Plugin {
     data.put("uri", Uri.fromFile(fileObject).toString());
     call.success(data);
   }
+
+  /**
+   * Checks the the given permission and requests them if they are not already granted.
+   * @param permissionRequestCode the request code see {@link PluginRequestCodes}
+   * @param permission the permission string
+   * @return Returns true if the permission is granted and false if it is denied.
+   */
+  private boolean isStoragePermissionGranted(int permissionRequestCode, String permission) {
+    if (Build.VERSION.SDK_INT >= 23) {
+      if (ContextCompat.checkSelfPermission(getContext(), permission) == PackageManager.PERMISSION_GRANTED) {
+        Log.v(getLogTag(),"Permission '"+permission+"' is granted");
+        return true;
+      } else {
+        Log.v(getLogTag(),"Permission '"+permission+"' denied. Asking user for it.");
+        ActivityCompat.requestPermissions(getActivity(), new String[]{permission}, permissionRequestCode);
+        return false;
+      }
+    } else { //permission is automatically granted on sdk<23 upon installation
+      Log.v(getLogTag(),"Permission '"+permission+"' is granted");
+      return true;
+    }
+  }
+
+  /**
+   * Reads the directory parameter from the plugin call
+   * @param call the plugin call
+   */
+  private String getDirectoryParameter(PluginCall call) {
+    return call.getString("directory");
+  }
+
+  /**
+   * True if the given directory string is a (public) external storage
+   * @param directory the directory string.
+   */
+  private boolean isExternalDirectory(String directory) {
+    return "DOCUMENTS".equals(directory) || "EXTERNAL_STORAGE".equals(directory);
+  }
+
 
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -266,6 +266,7 @@ public class Filesystem extends Plugin {
       if (isExternalDirectory(getDirectoryParameter(call))) {
         MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
       }
+      Log.d(getLogTag(), "File '"+file.getAbsolutePath()+"' saved!");
       call.success();
     } else {
       call.error("FILE_NOTCREATED");

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -208,11 +208,11 @@ public class Filesystem extends Plugin {
               saveFile(call, fileObject, data);
             }
           } else {
-            Log.e(getLogTag(), "Not able to create '"+directory+"'!");
+            Log.e(getLogTag(), "Not able to create '" + directory + "'!");
             call.error("NOT_CREATED_DIR");
           }
         } else {
-          Log.e(getLogTag(), "Directory ID '"+directory+"' is not supported by plugin");
+          Log.e(getLogTag(), "Directory ID '" + directory + "' is not supported by plugin");
           call.error("INVALID_DIR");
         }
       }
@@ -250,14 +250,14 @@ public class Filesystem extends Plugin {
         writer.write(data);
         success = true;
       } catch (IOException e) {
-        Log.e(getLogTag(), "Creating text file '"+file.getPath()+"' with charset '"+charset+"' failed. Error: "+e.getMessage(), e);
+        Log.e(getLogTag(), "Creating text file '" + file.getPath() + "' with charset '" + charset + "' failed. Error: " + e.getMessage(), e);
       }
     } else {
       try (FileOutputStream fos = new FileOutputStream(file, append)) {
         fos.write(Base64.decode(data, Base64.NO_WRAP));
         success = true;
       } catch (IOException e) {
-        Log.e(getLogTag(), "Creating binary file '"+file.getPath()+"' failed. Error: "+e.getMessage(), e);
+        Log.e(getLogTag(), "Creating binary file '" + file.getPath() + "' failed. Error: " + e.getMessage(), e);
       }
     }
 
@@ -266,7 +266,7 @@ public class Filesystem extends Plugin {
       if (isExternalDirectory(getDirectoryParameter(call))) {
         MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
       }
-      Log.d(getLogTag(), "File '"+file.getAbsolutePath()+"' saved!");
+      Log.d(getLogTag(), "File '" + file.getAbsolutePath() + "' saved!");
       call.success();
     } else {
       call.error("FILE_NOTCREATED");
@@ -425,15 +425,15 @@ public class Filesystem extends Plugin {
   private boolean isStoragePermissionGranted(int permissionRequestCode, String permission) {
     if (Build.VERSION.SDK_INT >= 23) {
       if (ContextCompat.checkSelfPermission(getContext(), permission) == PackageManager.PERMISSION_GRANTED) {
-        Log.v(getLogTag(),"Permission '"+permission+"' is granted");
+        Log.v(getLogTag(),"Permission '" + permission + "' is granted");
         return true;
       } else {
-        Log.v(getLogTag(),"Permission '"+permission+"' denied. Asking user for it.");
+        Log.v(getLogTag(),"Permission '" + permission + "' denied. Asking user for it.");
         ActivityCompat.requestPermissions(getActivity(), new String[]{permission}, permissionRequestCode);
         return false;
       }
     } else { //permission is automatically granted on sdk<23 upon installation
-      Log.v(getLogTag(),"Permission '"+permission+"' is granted");
+      Log.v(getLogTag(),"Permission '" + permission + "' is granted");
       return true;
     }
   }


### PR DESCRIPTION
Hello,

Use Case: My app needs to save document files like PDF, Excel, ... to the public "Documents" directory so a normal user can discover the file using the buildin file explorer on Android devices.

There were a few problems to solve

* `FilesystemDirectory.Documents` points to the wrong directory
* Runtime permission are missing. Starting with Android 6 (API Level 23) Android supports runtime permissions see https://developer.android.com/training/permissions/requesting. Therefore configuring all permissions upfront in the manifest is not required anymore, except you targeting Android 5 of course.
* Create intermediate directories if they not exists.

I tested on Android 5-8 (Level 22, 23, 24, 25, 27) and writing files works on every device and the changes are immediately visible in the files app.

I have only rewritten the `writeFile()` method but at least `readFile` would need permission support as well but lets do that in another PR. 

My next task is uploading files anyway, so maybe I do the reading part during that should it be necessary.

BR, Michael


