### PR TITLE
Fix android paths

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -191,7 +191,9 @@ export class Config implements CliConfig {
   }
 
   private initLinuxConfig() {
-    this.linux.androidStudioPath = this.app.linuxAndroidStudioPath && this.app.linuxAndroidStudioPath;
+    if (this.app.linuxAndroidStudioPath) {
+      this.linux.androidStudioPath = this.app.linuxAndroidStudioPath;
+    }
   }
 
   private initPluginsConfig() {


### PR DESCRIPTION
If `linuxAndroidStudioPath` key is not set in `capacitor.config.json` the `npx cap open android` command fails due to the fact that the path to the binary is an empty string:
```js
this.linux.androidStudioPath = this.app.linuxAndroidStudioPath && this.app.linuxAndroidStudioPath;
// which is equates to:
const foo = '' && '';
```

By changing the way `this.linux.androidStudioPath` is set the issue is fixed, however we could also set the `linuxAndroidStudioPath` key in `app` same as the windows equivalent is:
```js
app = {
...
    windowsAndroidStudioPath: 'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe',
    linuxAndroidStudioPath: '', // this can be set to the default /usr/local/android-studio/bin/studio.sh
...
}
```