### PR TITLE
Do Not Merge: Attempt to add moveFile and copyFile for iOS and Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -245,6 +245,66 @@ public class Filesystem extends Plugin {
   }
 
   @PluginMethod()
+  public void moveFile(PluginCall call) {
+    String file = call.getString("path");
+    String directory = call.getString("directory");
+    String destination = call.getString("destination");
+
+    try {
+      InputStream is = getInputStream(file, directory);
+      FileOutputStream fos = new FileOutputStream(getFileObject(file, destination));
+
+      byte[] buffer = new byte[1024];
+      int read;
+      while ((read = is.read(buffer)) != -1) {
+        fos.write(buffer, 0, read);
+      }
+      is.close();
+      is = null;
+
+      fos.flush();
+      fos.close();
+      fos = null;
+
+      getFileObject(file, directory).delete();
+
+      call.success();
+
+    } catch (IOException ex) {
+      call.error("Unable to move file", ex);
+    }
+  }
+
+  @PluginMethod()
+  public void copyFile(PluginCall call) {
+    String file = call.getString("path");
+    String directory = call.getString("directory");
+    String destination = call.getString("destination");
+
+    try {
+      InputStream is = getInputStream(file, directory);
+      FileOutputStream fos = new FileOutputStream(getFileObject(file, destination));
+
+      byte[] buffer = new byte[1024];
+      int read;
+      while ((read = is.read(buffer)) != -1) {
+        fos.write(buffer, 0, read);
+      }
+      is.close();
+      is = null;
+
+      fos.flush();
+      fos.close();
+      fos = null;
+
+      call.success();
+
+    } catch (IOException ex) {
+      call.error("Unable to move file", ex);
+    }
+  }
+
+  @PluginMethod()
   public void mkdir(PluginCall call) {
     String path = call.getString("path");
     String directory = call.getString("directory");

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -85,19 +85,19 @@ export interface AppPlugin extends Plugin {
   /**
    * Force exit the app. This should only be used in conjunction with the `backButton` handler for Android to
    * exit the app when navigation is complete.
-   * 
+   *
    * Ionic handles this itself so you shouldn't need to call this if using Ionic
    */
   exitApp(): never;
   /**
    * Check if an app can be opened with the given URL
    */
-  canOpenUrl(options: { url: string }): Promise<{value: boolean}>;
+  canOpenUrl(options: { url: string }): Promise<{ value: boolean }>;
 
   /**
    * Open an app with the given URL
    */
-  openUrl(options: { url: string }): Promise<{completed: boolean}>;
+  openUrl(options: { url: string }): Promise<{ completed: boolean }>;
 
   /**
    * Get the URL the app was launched with, if any
@@ -180,10 +180,10 @@ export interface BackgroundTaskPlugin extends Plugin {
    * can finish any work your app needs to do (such as finishing an upload
    * or network request). This is especially important on iOS as any operations
    * would normally be suspended without initiating a background task.
-   * 
+   *
    * This method should finish in less than 3 minutes or your app risks
    * being terminated by the OS.
-   * 
+   *
    * When you are finished, this callback _must_ call `BackgroundTask.finish({ taskId })`
    * where `taskId` is the value returned from `BackgroundTask.beforeExit()`
    * @param cb the task to run when the app is backgrounded but before it is terminated
@@ -194,7 +194,7 @@ export interface BackgroundTaskPlugin extends Plugin {
    * Notify the OS that the given task is finished and the OS can continue
    * backgrounding the app.
    */
-  finish(options: {taskId: CallbackID}): void;
+  finish(options: { taskId: CallbackID }): void;
 }
 
 //
@@ -240,9 +240,9 @@ export interface BrowserOpenOptions {
    */
   toolbarColor?: string;
 
-   /**
-   * iOS only: The presentation style of the browser. Defaults to fullscreen.
-   */
+  /**
+  * iOS only: The presentation style of the browser. Defaults to fullscreen.
+  */
   presentationStyle?: 'fullscreen' | 'popover';
 }
 
@@ -458,6 +458,20 @@ export interface FilesystemPlugin extends Plugin {
   deleteFile(options: FileDeleteOptions): Promise<FileDeleteResult>;
 
   /**
+   * Moves a file from a specific location on device to another location
+   * @param options options for the file move
+   * @return a promise that resolves with the moved file data result
+   */
+  moveFile(options: FileMoveOptions): Promise<FileMoveResult>;
+
+  /**
+   * Copies a file from a specific location on device to another location
+   * @param options options for the file copy
+   * @return a promise that resolves with the copied file data result
+   */
+  copyFile(options: FileCopyOptions): Promise<FileCopyResult>;
+
+  /**
    * Create a directory.
    * @param options options for the mkdir
    * @return a promise that resolves with the mkdir result
@@ -592,6 +606,36 @@ export interface FileDeleteOptions {
   directory?: FilesystemDirectory;
 }
 
+export interface FileMoveOptions {
+  /**
+   * the filename to move
+   */
+  path: string;
+  /**
+   * The FilesystemDirectory to move the file from
+   */
+  directory?: FilesystemDirectory;
+  /**
+   * The FilesystemDirectory to move the file to
+   */
+  destination: FilesystemDirectory
+}
+
+export interface FileCopyOptions {
+  /**
+   * the filename to copy
+   */
+  path: string;
+  /**
+   * The FilesystemDirectory to copy the file from
+   */
+  directory?: FilesystemDirectory;
+  /**
+   * The FilesystemDirectory to copy the file to
+   */
+  destination: FilesystemDirectory
+}
+
 export interface MkdirOptions {
   /**
    * The path of the new directory
@@ -659,6 +703,10 @@ export interface FileDeleteResult {
 export interface FileWriteResult {
 }
 export interface FileAppendResult {
+}
+export interface FileMoveResult {
+}
+export interface FileCopyResult {
 }
 export interface MkdirResult {
 }
@@ -842,7 +890,7 @@ export interface LocalNotificationAttachment {
 
 export interface LocalNotificationAttachmentOptions {
   iosUNNotificationAttachmentOptionsTypeHintKey?: string;
-  iosUNNotificationAttachmentOptionsThumbnailHiddenKey?: string; 
+  iosUNNotificationAttachmentOptionsThumbnailHiddenKey?: string;
   iosUNNotificationAttachmentOptionsThumbnailClippingRectKey?: string;
   iosUNNotificationAttachmentOptionsThumbnailTimeKey?: string;
 }
@@ -861,7 +909,7 @@ export interface LocalNotification {
 export interface LocalNotificationSchedule {
   at?: Date;
   repeats?: boolean;
-  every?: 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
+  every?: 'year' | 'month' | 'two-weeks' | 'week' | 'day' | 'hour' | 'minute' | 'second';
   on?: {
     year?: number;
     month?: number;
@@ -1239,8 +1287,8 @@ export interface PushNotificationChannel {
   id: string;
   name: string;
   description: string;
-  importance: 1 | 2 | 3 | 4 | 5;
-  visibility?: -1 | 0 | 1 ;
+  importance: 1 | 2 | 3 |  4 | 5;
+  visibility?: -1 | 0 | 1;
 }
 
 export interface PushNotificationChannelList {

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -190,6 +190,57 @@ public class CAPFilesystemPlugin : CAPPlugin {
   }
   
   /**
+   * Moves the file or directory at the specified path to a new location synchronously.
+   */
+  @objc func moveItem(_ call: CAPPluginCall) {
+    guard let path = call.get("path", String.self) else {
+      handleError(call, "path must be provided and must be a string.")
+      return
+    }
+    
+    let directoryOption = call.get("directory", String.self) ?? DEFAULT_DIRECTORY
+    guard let inputFileUrl = getFileUrl(file, directoryOption) else {
+      handleError(call, "Invalid path")
+      return
+    }
+  
+    guard let destination = call.get("destination", String.self) else {
+      handleError(call, "destination must be provided and must be a string.")
+      return
+    }
+    guard let outputFileUrl = getFileUrl(file, destination) else {
+      handleError(call, "Invalid destination file path")
+      return
+    }
+  
+    do {
+      try FileManager.default.moveItem(atPath: inputFileUrl.path, toPath: outputFileUrl.path)
+      call.success()
+    } catch let error as NSError {
+      handleError(call, error.localizedDescription, error)
+    }
+  }
+  
+  /**
+   * Copies the item at the specified path to a new location synchronously.
+   */
+  @objc funct copyItem(_ call: CAPPluginCall) {
+    guard let path = call.get("path", String.self) else {
+      handleError(call, "path must be provided and must be a string.")
+      return
+    }
+    guard let destination = call.get("destination", Stirng.self) else {
+      handleError(call, "destination must be provided and must be a string.")
+      return
+    }
+    do {
+      try FileManager.default.copyItem(atPath: path, toPath: destination)
+    } catch let error as NSError {
+      handleError(call, error.localizedDescription, error)
+    }
+  }
+  
+  /**
    * Make a new directory, optionally creating parent folders first.
    */
   @objc func mkdir(_ call: CAPPluginCall) {

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -58,6 +58,22 @@ async fileDelete() {
   });
 }
 
+async fileMove() {
+  await Filesystem.moveFile({
+    path: 'secrets/text.txt',
+    directory: FilesystemDirectory.Documents,
+    destination: FilesystemDirectory.Data
+  });
+}
+
+async fileCopy() {
+  await Filesystem.copyFile({
+    path: 'secrets/text.txt',
+    directory: FilesystemDirectory.Documents,
+    destination: FilesystemDirectory.Data
+  });
+}
+
 async mkdir() {
   try {
     let ret = await Filesystem.mkdir({

--- a/site/src/assets/docs-content/apis/filesystem/api-index.html
+++ b/site/src/assets/docs-content/apis/filesystem/api-index.html
@@ -1,6 +1,8 @@
 <div class="avc-code-plugin-index">
 <div class="avc-code-method-name"><anchor-link to="method-appendFile-0">appendFile()</anchor-link></div>
 <div class="avc-code-method-name"><anchor-link to="method-deleteFile-0">deleteFile()</anchor-link></div>
+<div class="avc-code-method-name"><anchor-link to="method-moveFile-0">moveFile()</anchor-link></div>
+<div class="avc-code-method-name"><anchor-link to="method-copyFile-0">copyFile()</anchor-link></div>
 <div class="avc-code-method-name"><anchor-link to="method-getUri-0">getUri()</anchor-link></div>
 <div class="avc-code-method-name"><anchor-link to="method-mkdir-0">mkdir()</anchor-link></div>
 <div class="avc-code-method-name"><anchor-link to="method-readFile-0">readFile()</anchor-link></div>

--- a/site/src/assets/docs-content/apis/filesystem/index.html
+++ b/site/src/assets/docs-content/apis/filesystem/index.html
@@ -49,6 +49,22 @@ fileWrite() {
   });
 }
 
+<span class="hljs-keyword">async</span> fileMove() {
+  <span class="hljs-keyword">await</span> Filesystem.moveFile({
+    path: <span class="hljs-string">'secrets/text.txt'</span>,
+    directory: FilesystemDirectory.Documents,
+    destination: FilesystemDirectory.Data
+  });
+}
+
+<span class="hljs-keyword">async</span> fileCopy() {
+  <span class="hljs-keyword">await</span> Filesystem.copyFile({
+    path: <span class="hljs-string">'secrets/text.txt'</span>,
+    directory: FilesystemDirectory.Documents,
+    destination: FilesystemDirectory.Data
+  });
+}
+
 <span class="hljs-keyword">async</span> mkdir() {
   <span class="hljs-keyword">try</span> {
     <span class="hljs-keyword">let</span> ret = <span class="hljs-keyword">await</span> Filesystem.mkdir({


### PR DESCRIPTION
I'm not as familiar with the Swift (or Obj. C)/Android side of things, need an extra set of eyes here. 

The `Filesystem` API is missing the utility functions for both moving and copying files.

iOS spec: https://developer.apple.com/documentation/foundation/filemanager/1413529-moveitem
Android spec: (File API): https://developer.android.com/reference/java/io/File#renameTo(java.io.File)