### PR TITLE
Make cordova.js es5

### DIFF
--- a/core/cordova.js
+++ b/core/cordova.js
@@ -934,10 +934,10 @@
             actionArgs = JSON.parse(JSON.stringify(actionArgs));
             var command = {
                 type: 'cordova',
-                callbackId,
-                service,
-                action,
-                actionArgs
+                callbackId: callbackId,
+                service: service,
+                action: action,
+                actionArgs: actionArgs
             };
             if (window.androidBridge) {
                 window.androidBridge.postMessage(JSON.stringify(command));


### PR DESCRIPTION
cordova.js still had problems on android emulator with old webview because of not being es5