### PR TITLE
Send activity events to Cordova plugins

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
@@ -1,0 +1,18 @@
+package com.getcapacitor.cordova;
+
+import android.app.Activity;
+
+import org.apache.cordova.CordovaInterfaceImpl;
+import org.apache.cordova.CordovaPlugin;
+
+import java.util.concurrent.Executors;
+
+public class MockCordovaInterfaceImpl extends CordovaInterfaceImpl {
+  public MockCordovaInterfaceImpl(Activity activity) {
+    super(activity, Executors.newCachedThreadPool());
+  }
+
+  public CordovaPlugin getActivityResultCallback(){
+    return this.activityResultCallback;
+  }
+}

--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -83,7 +83,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
 
   @Override
   public boolean isInitialized() {
-    return false;
+    return cordova != null;
   }
 
   @Override
@@ -128,32 +128,56 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
 
   @Override
   public void handlePause(boolean keepRunning) {
+    if (!isInitialized()) {
+      return;
+    }
+    pluginManager.onPause(keepRunning);
 
+    // If app doesn't want to run in background
+    if (!keepRunning) {
+      // Pause JavaScript timers. This affects all webviews within the app!
+      this.setPaused(true);
+    }
   }
 
   @Override
   public void onNewIntent(Intent intent) {
-
+    if (this.pluginManager != null) {
+      this.pluginManager.onNewIntent(intent);
+    }
   }
 
   @Override
   public void handleResume(boolean keepRunning) {
-
+    if (!isInitialized()) {
+      return;
+    }
+    this.setPaused(false);
+    this.pluginManager.onResume(keepRunning);
   }
 
   @Override
   public void handleStart() {
-
+    if (!isInitialized()) {
+      return;
+    }
+    pluginManager.onStart();
   }
 
   @Override
   public void handleStop() {
-
+    if (!isInitialized()) {
+      return;
+    }
+    pluginManager.onStop();
   }
 
   @Override
   public void handleDestroy() {
-
+    if (!isInitialized()) {
+      return;
+    }
+    this.pluginManager.onDestroy();
   }
 
   @Override
@@ -239,5 +263,15 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
   @Override
   public Object postMessage(String id, Object data) {
     return pluginManager.postMessage(id, data);
+  }
+
+  public void setPaused(boolean value) {
+    if (value) {
+      webView.onPause();
+      webView.pauseTimers();
+    } else {
+      webView.onResume();
+      webView.resumeTimers();
+    }
   }
 }


### PR DESCRIPTION
While looking into #787, one of the problems was the plugin wasn't getting the onResume event.
I noticed we weren't sending activity events to Cordova plugins (onPause, onResume, stop, start, destroy, onNewIntent)
Added all of them.

It fixes #787, but sadly the plugin doesn't properly work yet, `set` is not able to encrypt the value. 