### PR TITLE
[Android] Incorrect status-bar style

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -32,9 +32,9 @@ public class StatusBar extends Plugin {
         int visibilityFlags = decorView.getSystemUiVisibility();
 
         if (style.equals("DARK")) {
-           decorView.setSystemUiVisibility(visibilityFlags | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-        } else {
           decorView.setSystemUiVisibility(visibilityFlags & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        } else {
+          decorView.setSystemUiVisibility(visibilityFlags | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
         }
         call.success();
       }


### PR DESCRIPTION
The statusbar was setting the style incorrectly for android, meaning that it would draw white icons when asking for a light statusbar, instead of dark ones, same goes for the dark style.

When setting the statusbar to either a dark or light style, I was forced to do this trick in order to get it working properly for both android and iOS:

```js
StatusBar.setStyle({ style: this.$isIOS ? StatusBarStyle.Light : StatusBarStyle.Dark }).catch(
      this.$helpers.err
)
```

From what I was able to research, the iOS implementation is correct and only the android version of the plugin was displaying these issues, as per [this stackoverflow answer](https://stackoverflow.com/a/39596725/426540) setting a statusbar with a light style is done like so:

```java
...
flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
view.setSystemUiVisibility(flags);
...
```

The above flags flags are currently used for the dark style, so the solution is quite easy, just switch the flags.