### PR TITLE
[Android] Remove correct call

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -399,8 +399,8 @@ public class Plugin {
     String callbackId = call.getString("callbackId");
     PluginCall savedCall = bridge.getSavedCall(callbackId);
     if (savedCall != null) {
-      removeEventListener(eventName, call);
-      bridge.releaseCall(call);
+      removeEventListener(eventName, savedCall);
+      bridge.releaseCall(savedCall);
     }
   }
 


### PR DESCRIPTION
I won't pretend to be a Java guru, but while trying to fiddle with the backButton events, I noticed that you could not remove the created event listener, after hours of debugging I was able to fix it. Here's the JS example:

```js
...
  created() {
    this.backEvent = App.addListener('backButton', this.handleHardwareBackButton)
  },
  destroyed() {
    this.backEvent.remove()
  },
```

Given the above code, the removeListener method was trying to remove a non-existent `call` object even though the `savedCall` condition was passing.

In fact, looks like this is how it's done for the [iOS counterpart](https://github.com/ionic-team/capacitor/blob/aaa301a5874b37bdf18d305f1e9e26cc5092dd7c/ios/Capacitor/Capacitor/CAPPlugin.m#L101)