### PR TITLE
Make window.open to launch safari

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -365,6 +365,13 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     self.present(alertController, animated: true, completion: nil)
   }
 
+  public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+    if (navigationAction.request.url != nil) {
+      UIApplication.shared.open(navigationAction.request.url!, options: [:], completionHandler: nil)
+    }
+    return nil
+  }
+
   public func getWebView() -> WKWebView {
     return self.webView!
   }


### PR DESCRIPTION
This method is needed to make window.open work.

The code will make window.open to open Safari (or other apps based on the url scheme)

Closes #798