### PR TITLE
Fix: execute `notifyListeners` before `addListener` causes JS error

### DIFF
--- a/core/src/web/index.ts
+++ b/core/src/web/index.ts
@@ -130,7 +130,9 @@ export class WebPlugin {
 
   notifyListeners(eventName: string, data: any): void {
     let listeners = this.listeners[eventName];
-    listeners.forEach(listener => listener(data));
+    if (listeners) {
+      listeners.forEach(listener => listener(data));
+    }
   }
 
   hasListeners(eventName: string): boolean {


### PR DESCRIPTION
```typescript

export class TestWeb extends WebPlugin implements TestPlugin {

  constructor() {
    super({
      name: 'TestWeb',
      platforms: ['web']
    });
 }

 testMethod: void {
   this.notifyListeners('testEvent', null);

   this.addLisener('testEvent', () => {
     console.log('testEvent!!');
   });
 }
}
```

This code causes the `TypeError: Cannot read property 'forEach' of undefined` JS error, because `let listeners = this.listeners[eventName];` returns undefined.

```typescript
  notifyListeners(eventName: string, data: any): void {
    let listeners = this.listeners[eventName];
    listeners.forEach(listener => listener(data));
  }
```
https://github.com/ionic-team/capacitor/blob/de8e66c/core/src/web/index.ts#L131-L134