### PR TITLE
Send error on photo cancel

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -160,6 +160,11 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
   
   public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
     picker.dismiss(animated: true)
+    self.call?.error("User cancelled photos app")
+  }
+
+  public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+    self.call?.error("User cancelled photos app")
   }
   
   public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
@@ -192,7 +197,6 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }
     
     guard let jpeg = UIImageJPEGRepresentation(image!, CGFloat(settings.quality/100)) else {
-      print("Unable to convert image to jpeg")
       self.call?.error("Unable to convert image to jpeg")
       return
     }


### PR DESCRIPTION
Send error when the photo capture is canceled with cancel button (iPhone) or when the popover is dismissed (iPad)