### PR TITLE
Add support for media capture using input fields on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -1,9 +1,11 @@
 package com.getcapacitor;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.util.Log;
 import android.webkit.ConsoleMessage;
 import android.webkit.GeolocationPermissions;
@@ -14,7 +16,12 @@ import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 
+import com.getcapacitor.plugin.camera.CameraUtils;
+
 import org.apache.cordova.CordovaPlugin;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Custom WebChromeClient handler, required for showing dialogs, confirms, etc. in our
@@ -23,6 +30,8 @@ import org.apache.cordova.CordovaPlugin;
 public class BridgeWebChromeClient extends WebChromeClient {
   private Bridge bridge;
   static final int FILE_CHOOSER = PluginRequestCodes.FILE_CHOOSER;
+  static final int FILE_CHOOSER_IMAGE_CAPTURE = PluginRequestCodes.FILE_CHOOSER_IMAGE_CAPTURE;
+  static final int FILE_CHOOSER_VIDEO_CAPTURE = PluginRequestCodes.FILE_CHOOSER_VIDEO_CAPTURE;
 
   public BridgeWebChromeClient(Bridge bridge) {
     this.bridge = bridge;
@@ -141,6 +150,102 @@ public class BridgeWebChromeClient extends WebChromeClient {
 
   @Override
   public boolean onShowFileChooser(WebView webView, final ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
+    List<String> acceptTypes = Arrays.asList(fileChooserParams.getAcceptTypes());
+    boolean captureEnabled = fileChooserParams.isCaptureEnabled();
+    boolean capturePhoto = captureEnabled && acceptTypes.contains("image/*");
+    boolean captureVideo = captureEnabled && acceptTypes.contains("video/*");
+
+    if ((capturePhoto || captureVideo) && isMediaCaptureSupported()) {
+      boolean didShowMediaCapturePicker = showMediaCapturePicker(filePathCallback, captureVideo);
+      if (!didShowMediaCapturePicker) {
+        Log.w(LogUtils.getCoreTag("FileChooser"), "Media capture intent could not be launched. Falling back to default file picker.");
+        showFilePicker(filePathCallback, fileChooserParams);
+      }
+    } else {
+      showFilePicker(filePathCallback, fileChooserParams);
+    }
+
+    return true;
+  }
+
+  private boolean isMediaCaptureSupported() {
+    // Launching the camera while the app has defined the "android.permission.CAMERA" in the
+    // manifest file will crash the app if the permission hasn't been granted.
+    //
+    // More info: https://developer.android.com/reference/android/provider/MediaStore#ACTION_IMAGE_CAPTURE
+    //            https://stackoverflow.com/q/32789027
+    Plugin camera = bridge.getPlugin("Camera").getInstance();
+    boolean isSupported = camera.hasPermission(Manifest.permission.CAMERA) || !camera.hasDefinedPermission(Manifest.permission.CAMERA);
+    if (!isSupported) {
+      Log.w(LogUtils.getCoreTag("FileChooser"), "Unable to launch media capture: android.permission.CAMERA was defined in the manifest but hasn't been granted.");
+    }
+    return isSupported;
+  }
+
+  private boolean showMediaCapturePicker(ValueCallback<Uri[]> filePathCallback, boolean isVideo) {
+    // TODO: add support for video capture on Android M and older
+    // On Android M and lower the VIDEO_CAPTURE_INTENT (e.g.: intent.getData())
+    // returns a file:// URI instead of the expected content:// URI.
+    // So we disable it for now because it requires a bit more work
+    boolean isVideoCaptureSupported = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N;
+
+    if (isVideo && isVideoCaptureSupported) {
+      return showVideoCapturePicker(filePathCallback);
+    } else {
+      return showImageCapturePicker(filePathCallback);
+    }
+  }
+
+  private boolean showImageCapturePicker(final ValueCallback<Uri[]> filePathCallback) {
+    Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+    if (takePictureIntent.resolveActivity(bridge.getActivity().getPackageManager()) == null) {
+      return false;
+    }
+
+    final Uri imageFileUri;
+    try {
+      imageFileUri = CameraUtils.createImageFileUri(bridge.getActivity(), bridge.getContext().getPackageName());
+    } catch (Exception ex) {
+      Log.e(LogUtils.getCoreTag(), "Unable to create temporary media capture file: " + ex.getMessage());
+      return false;
+    }
+    takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageFileUri);
+
+    bridge.cordovaInterface.startActivityForResult(new CordovaPlugin() {
+      @Override
+      public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        Uri[] result = null;
+        if (resultCode == Activity.RESULT_OK) {
+          result = new Uri[]{imageFileUri};
+        }
+        filePathCallback.onReceiveValue(result);
+      }
+    }, takePictureIntent, FILE_CHOOSER_IMAGE_CAPTURE);
+
+    return true;
+  }
+
+  private boolean showVideoCapturePicker(final ValueCallback<Uri[]> filePathCallback) {
+    Intent takeVideoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+    if (takeVideoIntent.resolveActivity(bridge.getActivity().getPackageManager()) == null) {
+      return false;
+    }
+
+    bridge.cordovaInterface.startActivityForResult(new CordovaPlugin() {
+      @Override
+      public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        Uri[] result = null;
+        if (resultCode == Activity.RESULT_OK) {
+          result = new Uri[]{intent.getData()};
+        }
+        filePathCallback.onReceiveValue(result);
+      }
+    }, takeVideoIntent, FILE_CHOOSER_VIDEO_CAPTURE);
+
+    return true;
+  }
+
+  private void showFilePicker(final ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
     Intent intent = fileChooserParams.createIntent();
     if (fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
       intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
@@ -166,7 +271,6 @@ public class BridgeWebChromeClient extends WebChromeClient {
     } catch (ActivityNotFoundException e) {
       filePathCallback.onReceiveValue(null);
     }
-    return true;
   }
 
   @Override

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -8,4 +8,6 @@ public class PluginRequestCodes {
   public static final int CAMERA_IMAGE_EDIT = 9005;
   public static final int NOTIFICATION_OPEN = 9006;
   public static final int FILE_CHOOSER = 9007;
+  public static final int FILE_CHOOSER_IMAGE_CAPTURE = 9008;
+  public static final int FILE_CHOOSER_VIDEO_CAPTURE = 9009;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -23,6 +23,7 @@ import com.getcapacitor.PluginRequestCodes;
 import com.getcapacitor.plugin.camera.CameraResultType;
 import com.getcapacitor.plugin.camera.CameraSettings;
 import com.getcapacitor.plugin.camera.CameraSource;
+import com.getcapacitor.plugin.camera.CameraUtils;
 import com.getcapacitor.plugin.camera.ExifWrapper;
 import com.getcapacitor.plugin.camera.ImageUtils;
 
@@ -192,7 +193,7 @@ public class Camera extends Plugin {
       // If we will be saving the photo, send the target file along
       try {
         String appId = getAppId();
-        File photoFile = createImageFile(saveToGallery);
+        File photoFile = CameraUtils.createImageFile(getActivity(), saveToGallery);
         imageFileSavePath = photoFile.getAbsolutePath();
         // TODO: Verify provider config exists
         imageFileUri = FileProvider.getUriForFile(getActivity(), appId + ".fileprovider", photoFile);
@@ -405,27 +406,6 @@ public class Camera extends Plugin {
     call.resolve(data);
   }
 
-  private File createImageFile(boolean saveToGallery) throws IOException {
-    // Create an image file name
-    String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-    String imageFileName = "JPEG_" + timeStamp + "_";
-    File storageDir;
-    if(saveToGallery) {
-      Log.d(getLogTag(), "Trying to save image to public external directory");
-      storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-    }  else {
-      storageDir = getActivity().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-    }
-
-    File image = File.createTempFile(
-        imageFileName,  /* prefix */
-        ".jpg",         /* suffix */
-        storageDir      /* directory */
-    );
-
-    return image;
-  }
-
   @Override
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
@@ -482,7 +462,7 @@ public class Camera extends Plugin {
       }
       Intent editIntent = new Intent(Intent.ACTION_EDIT);
       editIntent.setDataAndType(origPhotoUri, "image/*");
-      File editedFile = createImageFile(false);
+      File editedFile = CameraUtils.createImageFile(getActivity(), false);
       Uri editedUri = Uri.fromFile(editedFile);
       editIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
       editIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
@@ -1,0 +1,46 @@
+package com.getcapacitor.plugin.camera;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Environment;
+import android.support.v4.content.FileProvider;
+import android.util.Log;
+
+import com.getcapacitor.LogUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class CameraUtils {
+    public static Uri createImageFileUri(Activity activity, String appId) throws IOException{
+        File photoFile = CameraUtils.createImageFile(activity, false);
+        return FileProvider.getUriForFile(activity, appId + ".fileprovider", photoFile);
+    }
+
+    public static File createImageFile(Activity activity, boolean saveToGallery) throws IOException {
+        // Create an image file name
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String imageFileName = "JPEG_" + timeStamp + "_";
+        File storageDir;
+        if(saveToGallery) {
+            Log.d(getLogTag(), "Trying to save image to public external directory");
+            storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        }  else {
+            storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        }
+
+        File image = File.createTempFile(
+                imageFileName,  /* prefix */
+                ".jpg",         /* suffix */
+                storageDir      /* directory */
+        );
+
+        return image;
+    }
+
+    protected static String getLogTag() {
+        return LogUtils.getCoreTag("CameraUtils");
+    }
+}


### PR DESCRIPTION
By default, the Android webview does **not** open the camera for inputs like:
```html
<input type="file" accept="image/*" capture>
```
This pull-request fixes that. The motivation for this functionality is that it might replace the need for using the *native* [Camera](https://capacitor.ionicframework.com/docs/apis/camera) plugin with purely *browser* APIs. Obviously, the native camera plugin will still be needed for more advanced use-cases, but if all you need is to take a picture with the camera you will now be able to do so without any native plugin (and the same code will also work in browsers).

This functionality was previously requested in #540 and it was [supposedly](https://github.com/ionic-team/capacitor/issues/540#issuecomment-388920583) already [fixed](https://github.com/ionic-team/capacitor/commit/733d7971f8cb64a9e4c9f85196c9ea59bbf24d2b). But the [current code](https://github.com/ionic-team/capacitor/blob/46cc2083dd106f217fe2ab154a2b64d15f51d452/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java#L142-L170) doesn't seem to contain the logic needed for handling it.

# Limitations

This initial implementation only covers some very basic cases and it has some limitations that could be improved in the future:

- an [Action Chooser](https://developer.android.com/reference/android/content/Intent.html#ACTION_CHOOSER) should be shown when both `image/*` and `video/*` are present in the `accept` array. The current implementations defaults to showing the camcorder in this case.
- video capture is currently disabled on Android M and older because it looks like its [Intent](https://developer.android.com/reference/android/provider/MediaStore#ACTION_VIDEO_CAPTURE) is returning a `file://` URI on those devices (instead of the expected `content://` URI)
- if the app contains `<uses-permission android:name="android.permission.CAMERA" />` in its merged manifest file and the permission is not granted, we don't show the camera/camcorder and fallback to the default file chooser (more info [here](https://developer.android.com/reference/android/provider/MediaStore#ACTION_IMAGE_CAPTURE) and [here](https://stackoverflow.com/q/32789027))
 
***Note:*** This is already working as expected on iOS because it's handled automatically by `WKWebView`.
