### PR TITLE
Make input file capture ask for permission if not granted

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -680,7 +680,7 @@ public class Bridge {
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
-    if (plugin == null) {
+    if (plugin == null || requestCode == 0) {
       Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle requestCode, try with Cordova plugins " + requestCode);
       try {
         cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -10,4 +10,5 @@ public class PluginRequestCodes {
   public static final int FILE_CHOOSER = 9007;
   public static final int FILE_CHOOSER_IMAGE_CAPTURE = 9008;
   public static final int FILE_CHOOSER_VIDEO_CAPTURE = 9009;
+  public static final int FILE_CHOOSER_CAMERA_PERMISSION = 9010;
 }


### PR DESCRIPTION
At the moment, an input file with capture (`<input type="file" accept="image/*" capture>`) won't show the camera if the permission is not granted beforehand, which is most likely. 
This PR will make the input file request the permission if it wasn't granted and continue the flow if granted. 

@vially as you sent the previous PR that added capture support, can you give it a try?