### PR TITLE
Config param to disable web content debugging

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -50,7 +50,7 @@ public class BridgeActivity extends AppCompatActivity {
     getApplication().setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
     setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
     setTheme(R.style.AppTheme_NoActionBar);
-    WebView.setWebContentsDebuggingEnabled(true);
+    WebView.setWebContentsDebuggingEnabled(Config.getBoolean("android.webContentsDebuggingEnabled", true));
 
     setContentView(R.layout.bridge_layout_main);
 

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -51,7 +51,12 @@ The current ones you might configure are:
     // Android's default keyboard doesn't allow proper JS key capture
     // You can use a simpler keyboard enabling this preference
     // Be aware that this keyboard has some problems and limitations
-    "captureInput": true
+    "captureInput": true,
+    // Enables debugging of web contents (HTML / CSS / JavaScript) loaded into
+    // any WebViews of this application.
+    // This flag can be enabled in order to facilitate debugging of web layouts
+    // and JavaScript code running inside WebViews.
+    "webContentsDebuggingEnabled": true
   },
   "ios": {
     // Configure the Swift version to be used for Cordova plugins.


### PR DESCRIPTION
I hope to get better performance, if this debugging could be disabled by a config parameter.

According to the docs `https://developer.android.com/reference/android/webkit/WebView#setWebContentsDebuggingEnabled(boolean)` it defaults to false.

BR
