### PR TITLE
Disable SplashScreen plugin using config param

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -76,7 +76,9 @@ public class BridgeActivity extends AppCompatActivity {
     cordovaInterface.onCordovaInit(pluginManager);
     bridge = new Bridge(this, webView, initialPlugins, cordovaInterface, pluginManager);
 
-    Splash.showOnLaunch(this);
+    if (Config.getBoolean("plugins.SplashScreen.enabled", true)) {
+      Splash.showOnLaunch(this);
+    }
 
     if (savedInstanceState != null) {
       bridge.restoreInstanceState(savedInstanceState);


### PR DESCRIPTION
My pure Angular app uses a splashscreen `div` in `index.html`, which is removed after the initial routing is done in my AppComponent.

This is not better than using the SplashScreen plugin, its only different. I only would need a way to disable the SplashScreen plugin, because I don't need it.

```
// remove the splashscreen
    const splash = this.document.body.querySelector('#splash');
    this.router.events.subscribe((event) => {
        if (event instanceof NavigationEnd) {
          if (splash) {
            splash.remove();
          }
        }
      }
    );
```

A new config parameter `plugins.SplashScreen.enabled`, which defaults to `true` would allow me to disable the plugin.

BR