### PR TITLE
Make camera full screen and allow presentationStyle

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -297,6 +297,11 @@ export interface CameraOptions {
    * Default: CameraSource.Prompt
    */
   source?: CameraSource;
+
+  /**
+   * iOS only: The presentation style of the Camera. Defaults to fullscreen.
+   */
+  presentationStyle?: 'fullscreen' | 'popover';
 }
 
 export enum CameraSource {


### PR DESCRIPTION
Make camera full screen as recommended, but allow presentationStyle option to show as popover if desired.
This is only for Camera source, for Photos it should still use popover despite the setting.

Closes #819