### PR TITLE
Handle empty url string

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
@@ -35,7 +35,12 @@ public class Browser extends Plugin {
     String toolbarColor = call.getString("toolbarColor");
 
     if (url == null) {
-      call.error("Must provide a URL");
+      call.error("Must provide a URL to open");
+      return;
+    }
+
+    if (url.isEmpty()) {
+      call.error("URL must not be empty");
       return;
     }
 

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -10,7 +10,12 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
       call.error("Must provide a URL to open")
       return
     }
-    
+
+    if urlString.isEmpty {
+      call.error("URL must not be empty")
+      return
+    }
+
     let toolbarColor = call.getString("toolbarColor")
     let url = URL(string: urlString)
     


### PR DESCRIPTION
App crash is an empty string is used as url, return an error if the url is empty