### PR TITLE
Add documentation on running screens on the main thread from Capacito…

### DIFF
--- a/site/docs-md/plugins/ios.md
+++ b/site/docs-md/plugins/ios.md
@@ -99,7 +99,13 @@ To access the Capacitor's View Controller, we have to use the `CAPBridge` object
 
 We can use the `UIViewController` to present Native View Controllers over it like this:
 
-`self.bridge.viewController.present(ourCustomViewController, animated: true, completion: nil)`
+```swift
+DispatchQueue.main.async {
+  self.bridge.viewController.present(ourCustomViewController, animated: true, completion: nil)
+}
+```
+
+Using `DispatchQueue.main.async` makes your view render from the main thread instead of a background thread. Removing this can cause unexpected results.
 
 On iPad devices you can also present `UIPopovers`, to do so, we provide a helper function to show it centered.
 

--- a/site/src/assets/docs-content/plugins/ios.html
+++ b/site/src/assets/docs-content/plugins/ios.html
@@ -66,7 +66,11 @@ options using <code>guard</code>.</p>
 <p>To present a Native Screen over the Capacitor screen we need to acces the Capacitor&#39;s View Controller.
 To access the Capacitor&#39;s View Controller, we have to use the <code>CAPBridge</code> object available on <code>CAPPlugin</code> class.</p>
 <p>We can use the <code>UIViewController</code> to present Native View Controllers over it like this:</p>
-<p><code>self.bridge.viewController.present(ourCustomViewController, animated: true, completion: nil)</code></p>
+<pre><code class="lang-swift"><span class="hljs-type">DispatchQueue</span>.main.async {
+  <span class="hljs-keyword">self</span>.bridge.viewController.present(ourCustomViewController, animated: <span class="hljs-literal">true</span>, completion: <span class="hljs-literal">nil</span>)
+}
+</code></pre>
+<p>Using <code>DispatchQueue.main.async</code> makes your view render from the main thread instead of a background thread. Removing this can cause unexpected results.</p>
 <p>On iPad devices you can also present <code>UIPopovers</code>, to do so, we provide a helper function to show it centered.</p>
 <pre><code class="lang-swift"><span class="hljs-keyword">self</span>.setCenteredPopover(ourCustomViewController)
 <span class="hljs-keyword">self</span>.bridge.viewController.present(ourCustomViewController, animated: <span class="hljs-literal">true</span>, completion: <span class="hljs-literal">nil</span>)


### PR DESCRIPTION
…r Plugins.

Just adding some documentation as discussed over in #841.

Running build locally produced way more changed files than just these two (`.html` files), but since these are the relevant ones I just included them.