### PR TITLE
Fix iOS webview bottom space (#337)

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -45,6 +45,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     
     webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
     webView?.scrollView.bounces = false
+    if #available(iOS 11.0, *) {
+        webView?.scrollView.contentInsetAdjustmentBehavior = UIScrollView.ContentInsetAdjustmentBehavior.never
+    }
     webView?.uiDelegate = self
     webView?.navigationDelegate = self
     //If you want to implement the delegate


### PR DESCRIPTION
Possible fix for #337. Until now I have been adding [cordova-plugin-disable-ios11-statusbar](https://github.com/jcesarmobile/cordova-plugin-disable-ios11-statusbar) to my capacitor projects to fix this issue, so this basically applies the same thing to capacitor's webview. Not sure if its the proper way to solve the issue, but it fixes the issue on the native side instead of requiring CSS changes.