### PR TITLE
Fix passing ArrayBuf arguments to Cordova plugins

### DIFF
--- a/core/cordova.js
+++ b/core/cordova.js
@@ -931,6 +931,8 @@
                     { success: successCallback, fail: failCallback };
             }
 
+            // Properly encode ArrayBuf action arguments
+            actionArgs = massageArgsJsToNative(actionArgs);
             actionArgs = JSON.parse(JSON.stringify(actionArgs));
             var command = {
                 type: 'cordova',


### PR DESCRIPTION
Added call to massageArgsJsToNative as was in original Cordova implementation, which fixes broken passing of ArrayBuf arguments to legacy Cordova plugins.