### PR TITLE
Only request permission on Android 6+

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -44,6 +44,8 @@ public class BridgeWebChromeClient extends WebChromeClient {
 
   @Override
   public void onPermissionRequest(final PermissionRequest request) {
+    boolean isRequestPermissionRequired = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M;
+
     List<String> permissionList = new ArrayList<String>();
     if (Arrays.asList(request.getResources()).contains("android.webkit.resource.VIDEO_CAPTURE")) {
       permissionList.add(Manifest.permission.CAMERA);
@@ -52,7 +54,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
       permissionList.add(Manifest.permission.MODIFY_AUDIO_SETTINGS);
       permissionList.add(Manifest.permission.RECORD_AUDIO);
     }
-    if (!permissionList.isEmpty()) {
+    if (!permissionList.isEmpty() && isRequestPermissionRequired) {
       String [] permissions = permissionList.toArray(new String[0]);;
       bridge.cordovaInterface.requestPermissions(new CordovaPlugin(){
         @Override


### PR DESCRIPTION
Cordova requestPermissions method doesn't handle the Android < 6 case, so it crash. 
Avoid to request the permission on Android < 6 as it's not needed and makes the app crash.