### PR TITLE
Add Navigator.getUserMedia permissions to default template

### DIFF
--- a/android-template/app/src/main/AndroidManifest.xml
+++ b/android-template/app/src/main/AndroidManifest.xml
@@ -44,8 +44,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Camera, Photos -->
-    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Camera, Photos, input file -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Geolocation API -->
@@ -54,4 +53,10 @@
     <uses-feature android:name="android.hardware.location.gps" />
     <!-- Network API -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Navigator.getUserMedia -->
+    <!-- Video -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Audio -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 </manifest>


### PR DESCRIPTION
Added permissions required by `Navigator.getUserMedia` to default template.
Moved Camera permission there as it's not really required for Camera plugin, but it's required for `getUserMedia`