### PR TITLE
Detect installed dependencies for other platforms

### DIFF
--- a/cli/src/android/common.ts
+++ b/cli/src/android/common.ts
@@ -22,7 +22,7 @@ export async function resolvePlugin(config: Config, plugin: Plugin): Promise<Plu
       throw 'capacitor.android.src is missing';
     }
     androidPath = plugin.manifest.android.src;
-  } else if (plugin.xml && getPluginPlatform(plugin, 'android')) {
+  } else if (plugin.xml) {
     androidPath = 'src/android';
   } else {
     return null;
@@ -32,7 +32,7 @@ export async function resolvePlugin(config: Config, plugin: Plugin): Promise<Plu
     type: PluginType.Core,
     path: androidPath
   };
-  if(getIncompatibleCordovaPlugins().includes(plugin.id)) {
+  if(getIncompatibleCordovaPlugins().includes(plugin.id) || !getPluginPlatform(plugin, 'android')) {
     plugin.android.type = PluginType.Incompatible;
   } else if (plugin.xml) {
     plugin.android.type = PluginType.Cordova;

--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -13,12 +13,9 @@ export async function updateAndroid(config: Config) {
 
   const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Core);
 
-  let cordovaPlugins: Array<Plugin> = [];
   let needsPluginUpdate = true;
   while (needsPluginUpdate) {
-    cordovaPlugins = plugins
-      .filter(p => getPluginType(p, platform) === PluginType.Cordova);
-    needsPluginUpdate = await checkAndInstallDependencies(config, cordovaPlugins, platform);
+    needsPluginUpdate = await checkAndInstallDependencies(config, plugins, platform);
     if (needsPluginUpdate) {
       plugins = await getPluginsTask(config);
     }
@@ -27,6 +24,8 @@ export async function updateAndroid(config: Config) {
   printPlugins(capacitorPlugins, 'android');
 
   removePluginsNativeFiles(config);
+  const cordovaPlugins = plugins
+      .filter(p => getPluginType(p, platform) === PluginType.Cordova);
   if (cordovaPlugins.length > 0) {
     copyPluginsNativeFiles(config, cordovaPlugins);
   }

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -48,7 +48,7 @@ export async function resolvePlugin(config: Config, plugin: Plugin): Promise<Plu
     if (!plugin.manifest.ios.src) {
       iosPath = 'ios';
     }
-  } else if (plugin.xml && getPluginPlatform(plugin, 'ios')) {
+  } else if (plugin.xml) {
     iosPath = 'src/ios';
   } else {
     return null;
@@ -60,7 +60,7 @@ export async function resolvePlugin(config: Config, plugin: Plugin): Promise<Plu
       type: PluginType.Core,
       path: iosPath
     };
-    if(getIncompatibleCordovaPlugins().includes(plugin.id)) {
+    if(getIncompatibleCordovaPlugins().includes(plugin.id) || !getPluginPlatform(plugin, 'ios')) {
       plugin.ios.type = PluginType.Incompatible;
     } else if (plugin.xml) {
       plugin.ios.type = PluginType.Cordova;

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -40,18 +40,17 @@ export async function updateIOS(config: Config) {
 
   printPlugins(capacitorPlugins, 'ios');
 
-  let cordovaPlugins: Array<Plugin> = [];
   let needsPluginUpdate = true;
   while (needsPluginUpdate) {
-    cordovaPlugins = plugins
-      .filter(p => getPluginType(p, platform) === PluginType.Cordova);
-    needsPluginUpdate = await checkAndInstallDependencies(config, cordovaPlugins, platform);
+    needsPluginUpdate = await checkAndInstallDependencies(config, plugins, platform);
     if (needsPluginUpdate) {
       plugins = await getPluginsTask(config);
     }
   }
 
   removePluginsNativeFiles(config);
+  const cordovaPlugins = plugins
+      .filter(p => getPluginType(p, platform) === PluginType.Cordova);
   if (cordovaPlugins.length > 0) {
     copyPluginsNativeFiles(config, cordovaPlugins);
   }


### PR DESCRIPTION
Mark Cordova plugins with no platform tag as incompatible for that platform.
Avoids infinite loops when a plugin dependency doesn't have a platform tag for the one running update.

Closes #875