### PR TITLE
Add more incompatible plugins to the list

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -288,5 +288,7 @@ export async function checkAndInstallDependencies(config: Config, plugins: Plugi
 }
 
 export function getIncompatibleCordovaPlugins(){
-  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview", "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console", "cordova-plugin-compat"];
+  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
+  "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console",
+  "cordova-plugin-compat", "cordova-plugin-music-controls", "cordova-plugin-add-swift-support"];
 }


### PR DESCRIPTION
Added `cordova-plugin-music-controls` and `cordova-plugin-add-swift-support` to the incompatible list to skip the install.

Closes #874