### PR TITLE
Removes line terminator characters from plugins code

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -87,6 +87,7 @@ export async function copyPluginsJS(config: Config, cordovaPlugins: Plugin[], pl
       const filePath = join(webDir, 'plugins', pluginId, jsModule.$.src);
       copySync(join(p.rootPath, jsModule.$.src), filePath);
       let data = await readFileAsync(filePath, 'utf8');
+      data = data.trim();
       data = `cordova.define("${pluginId}.${jsModule.$.name}", function(require, exports, module) { \n${data}\n});`;
       await writeFileAsync(filePath, data, 'utf8');
     });


### PR DESCRIPTION
When reading a plugin js file to create the transformed one, if it was generated from windows it can add bad characters. Remove line terminators to avoid such problem.

Closes #823