### PR TITLE
remove intrinsicContentSize override from UILabel. Fixes #883

### DIFF
--- a/ios/Capacitor/Capacitor/UILabel.swift
+++ b/ios/Capacitor/Capacitor/UILabel.swift
@@ -21,25 +21,4 @@ extension UILabel {
       self.drawText(in: rect)
     }
   }
-  
-  override open var intrinsicContentSize: CGSize {
-    guard let text = self.text else { return super.intrinsicContentSize }
-    
-    var contentSize = super.intrinsicContentSize
-    var textWidth: CGFloat = frame.size.width
-    var insetsHeight: CGFloat = 0.0
-    
-    if let insets = padding {
-      textWidth -= insets.left + insets.right
-      insetsHeight += insets.top + insets.bottom
-    }
-    
-    let newSize = text.boundingRect(with: CGSize(width: textWidth, height: CGFloat.greatestFiniteMagnitude),
-                                    options: NSStringDrawingOptions.usesLineFragmentOrigin,
-                                    attributes: [NSAttributedStringKey.font: self.font], context: nil)
-    
-    contentSize.height = ceil(newSize.size.height) + insetsHeight
-    
-    return contentSize
-  }
 }


### PR DESCRIPTION
This fixes #883. Looking at the commit history, it looks like this `UILabel` extension was added for the iOS Toast plugin. The extension was also affecting the native status bar labels. I determined that removing the intrinsicContentSize override fixed that issue and it appears that the Toast plugin still works as expected. I'm not sure the context of why it was needed in the first place so @mlynch will have to confirm, but at least the source of that bug has been found.