### PR TITLE
feat(statusBar): set default ios status bar options based on plist

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -163,9 +163,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   }
 
   public func setStatusBarDefaults() {
-    if let url = Bundle.main.url(forResource:"Info", withExtension: "plist"),
-      let plist = NSDictionary(contentsOf: url) as? [String:Any] {
-        
+    if let plist = Bundle.main.infoDictionary {
       if let statusBarHidden = plist["UIStatusBarHidden"] as? Bool {
         if (statusBarHidden) {
           self.isStatusBarVisible = false

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -34,6 +34,8 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   
   
   override public func loadView() {
+    setStatusBarDefaults()
+    
     let webViewConfiguration = WKWebViewConfiguration()
     
     let o = WKUserContentController()
@@ -158,6 +160,24 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
      startServer()
     }
 
+  }
+
+  public func setStatusBarDefaults() {
+    if let url = Bundle.main.url(forResource:"Info", withExtension: "plist"),
+      let plist = NSDictionary(contentsOf: url) as? [String:Any] {
+        
+      if let statusBarHidden = plist["UIStatusBarHidden"] as? Bool {
+        if (statusBarHidden) {
+          self.isStatusBarVisible = false
+        }
+      }
+        
+      if let statusBarStyle = plist["UIStatusBarStyle"] as? String {
+        if (statusBarStyle != "UIStatusBarStyleDefault") {
+          self.statusBarStyle = .lightContent
+        }
+      }
+    }
   }
 
   public func configureWebView(configuration: WKWebViewConfiguration) {

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -10,6 +10,8 @@ The StatusBar API Provides methods for configuring the style of the Status Bar, 
 
 This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](../ios/configuration) for help.
 
+The status bar visibility defaults to visible and the style defaults to `StatusBarStyle.Dark`. You can change these defaults by modifying the `UIStatusBarHidden` and `UIStatusBarStyle` in the `Info.plist`.
+
 ## Events
 
 * statusTap

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -10,7 +10,7 @@ The StatusBar API Provides methods for configuring the style of the Status Bar, 
 
 This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](../ios/configuration) for help.
 
-The status bar visibility defaults to visible and the style defaults to `StatusBarStyle.Dark`. You can change these defaults by modifying the `UIStatusBarHidden` and `UIStatusBarStyle` in the `Info.plist`.
+The status bar visibility defaults to visible and the style defaults to `StatusBarStyle.Light`. You can change these defaults by adding `UIStatusBarHidden` and or `UIStatusBarStyle` in the `Info.plist`.
 
 ## Events
 


### PR DESCRIPTION
This will allow the app to either hide the status bar by default or use the light content style by default based on the `Info.plist`, which prevents the status bar flashing an undesired state from the bridge view controller's defaults.