### PR TITLE
Fix: added accuracy to GeolocationPosition object

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
@@ -218,6 +218,7 @@ public class Geolocation extends Plugin {
     ret.put("coords", coords);
     coords.put("latitude", location.getLatitude());
     coords.put("longitude", location.getLongitude());
+    coords.put("accuracy", location.getAccuracy());
     coords.put("altitude", location.getAltitude());
     coords.put("speed", location.getSpeed());
     coords.put("heading", location.getBearing());


### PR DESCRIPTION
Using Capacitor on Android, no accuracy is recieved on the Geolocation plugin. This fix adds the property to the GeolocationPosition object.