### PR TITLE
Add Support for Swift 4.0 in Cocoapods 1.5 and higher

### DIFF
--- a/Capacitor.podspec
+++ b/Capacitor.podspec
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.dependency 'CapacitorCordova', '1.0.0-beta.8'
   s.dependency 'GCDWebServer', '~> 3.0'
+  s.swift_version = '4.0'
 end


### PR DESCRIPTION
This updates the podspec of the Capacitor target to use the `swift_version` syntax required by current versions of cocoapods. Without it there would be build errors as described in #920.