### PR TITLE
feat: set splash screen scale per default to FIT_XY on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -52,7 +52,7 @@ public class Splash {
     // https://stackoverflow.com/a/21847579/32140
     splashImage.setDrawingCacheEnabled(true);
 
-    splashImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
+    splashImage.setScaleType(ImageView.ScaleType.FIT_XY);
     splashImage.setImageDrawable(splash);
   }
 


### PR DESCRIPTION
Following https://github.com/ionic-team/capacitor/issues/226 I suggest this PR in order to set per default the splash screen image on Android to FIT_XY instead of CENTER_CROP