### PR TITLE
Fix base64 write problems on Filesystem.writeFile

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -108,6 +108,13 @@ public class CAPFilesystemPlugin : CAPPlugin {
         try data.write(to: fileUrl, atomically: false, encoding: .utf8)
       } else {
         try Data(base64Encoded: data)?.write(to: fileUrl)
+        let dataParts = data.split(separator: ",")
+        if let base64Data = Data(base64Encoded: String(dataParts.last!)) {
+          try base64Data.write(to: fileUrl)
+        } else {
+          handleError(call, "Unable to save file")
+          return
+        }
       }
       call.success()
     } catch let error as NSError {


### PR DESCRIPTION
If the base64 string have the `data:type/ext;base64,` it silently fails to write.
With this change it will strip that part, and also return an error if the base64 data is not valid.

Closes #891