### PR TITLE
Android: Intercept proxyied requests in handleProxyRequest for GET method only

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -316,52 +316,54 @@ public class WebViewLocalServer {
    */
   private WebResourceResponse handleProxyRequest(WebResourceRequest request, PathHandler handler) {
     final String method = request.getMethod();
-    if (method.equals("GET")) try {
-      String path = request.getUrl().getPath();
-      URL url = new URL(request.getUrl().toString());
-      Map<String, String> headers = request.getRequestHeaders();
-      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      for (Map.Entry<String, String> header : headers.entrySet()) {
-        conn.setRequestProperty(header.getKey(), header.getValue());
-      }
-      conn.setRequestMethod(method);
-      conn.setReadTimeout(30 * 1000);
-      conn.setConnectTimeout(30 * 1000);
+    if (method.equals("GET")) {
+      try {
+        String path = request.getUrl().getPath();
+        URL url = new URL(request.getUrl().toString());
+        Map<String, String> headers = request.getRequestHeaders();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+          conn.setRequestProperty(header.getKey(), header.getValue());
+        }
+        conn.setRequestMethod(method);
+        conn.setReadTimeout(30 * 1000);
+        conn.setConnectTimeout(30 * 1000);
 
-      InputStream stream = conn.getInputStream();
+        InputStream stream = conn.getInputStream();
 
-      if (path.equals("/") || (!request.getUrl().getLastPathSegment().contains(".") && html5mode)) {
-        stream = jsInjector.getInjectedStream(stream);
-
-        bridge.reset();
-
-        return new WebResourceResponse("text/html", handler.getEncoding(),
-            handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), stream);
-      }
-
-      int periodIndex = path.lastIndexOf(".");
-      if (periodIndex >= 0) {
-        String ext = path.substring(path.lastIndexOf("."), path.length());
-
-        // TODO: Conjure up a bit more subtlety than this
-        if (ext.equals(".html")) {
+        if (path.equals("/") || (!request.getUrl().getLastPathSegment().contains(".") && html5mode)) {
           stream = jsInjector.getInjectedStream(stream);
+
           bridge.reset();
+
+          return new WebResourceResponse("text/html", handler.getEncoding(),
+              handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), stream);
         }
 
-        String mimeType = getMimeType(path, stream);
+        int periodIndex = path.lastIndexOf(".");
+        if (periodIndex >= 0) {
+          String ext = path.substring(path.lastIndexOf("."), path.length());
 
-        return new WebResourceResponse(mimeType, handler.getEncoding(),
-            handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), stream);
+          // TODO: Conjure up a bit more subtlety than this
+          if (ext.equals(".html")) {
+            stream = jsInjector.getInjectedStream(stream);
+            bridge.reset();
+          }
+
+          String mimeType = getMimeType(path, stream);
+
+          return new WebResourceResponse(mimeType, handler.getEncoding(),
+              handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), stream);
+        }
+
+        return new WebResourceResponse("", handler.getEncoding(),
+            handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), conn.getInputStream());
+
+      } catch (SocketTimeoutException ex) {
+        bridge.handleAppUrlLoadError(ex);
+      } catch (Exception ex) {
+        bridge.handleAppUrlLoadError(ex);
       }
-
-      return new WebResourceResponse("", handler.getEncoding(),
-          handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), conn.getInputStream());
-
-    } catch (SocketTimeoutException ex) {
-      bridge.handleAppUrlLoadError(ex);
-    } catch (Exception ex) {
-      bridge.handleAppUrlLoadError(ex);
     }
     return null;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -315,8 +315,8 @@ public class WebViewLocalServer {
    * @return
    */
   private WebResourceResponse handleProxyRequest(WebResourceRequest request, PathHandler handler) {
-    try {
-      final String method = request.getMethod();
+    final String method = request.getMethod();
+    if (method.equals("GET")) try {
       String path = request.getUrl().getPath();
       URL url = new URL(request.getUrl().toString());
       Map<String, String> headers = request.getRequestHeaders();


### PR DESCRIPTION
Related to #951 and #955.

Turned out, there is a lifelong known [issue](https://issuetracker.google.com/issues/36918490) that `POST` requests can't be intercepted with `WebViewClient.shouldInterceptRequest(WebView, WebResourceRequest)` method. In my case this resulted in all GraphQL queries became duplicated – the first one is broken, with `Content-Length: 0` and an empty body, then the second normal one comes. I didn't came up with any better solution than to execute `handleProxyRequest` for `GET` requests only.

@jcesarmobile what do you think?