### PR TITLE
Add `allowNavigation` option that allows Capacitor to open certain URLs in its WebView.

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Config.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Config.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONArray;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -128,5 +129,29 @@ public class Config {
     return null;
   }
 
+  public static String[] getArray(String key) {
+    return getArray(key, null);
+  }
 
+  public static String[] getArray(String key, String[] defaultValue) {
+    String k = getConfigKey(key);
+    try {
+      JSONObject o = getInstance().getConfigObjectDeepest(key);
+
+      JSONArray a = o.getJSONArray(k);
+      if (a == null) {
+        return defaultValue;
+      }
+
+      int l = a.length();
+      String[] value = new String[l];
+
+      for(int i=0; i<l; i++) {
+        value[i] = (String) a.get(i);
+      }
+
+      return value;
+    } catch (Exception ex) {}
+    return defaultValue;
+  }
 }

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -41,7 +41,14 @@ The current ones you might configure are:
     // If you don't configure it, a random port will be assigned and persisted.
     "port": "8787",
     // You can make the app to load an external url (i.e. to live reload)
-    "url": "http://192.168.1.33:8100"
+    "url": "http://192.168.1.33:8100",
+    // Normally all external URLs are opened in the browser. By setting this option, you tell
+    // Capacitor to open URLs belonging to these hosts inside its WebView.
+    "allowNavigation": [
+      "example.org",
+      "*.example.org",
+      "192.0.2.1"
+    ]
   },
   "android": {
     // On Android, Capacitor loads your local assets using https


### PR DESCRIPTION
This PR adds `allowNavigation` option to `capacitor.config.json` that allows to configure additional hosts that Capacitor will open in its WebView.

Ref. https://forum.getcapacitor.com/t/how-to-execute-the-code-before-main-app-is-fully-loaded/200