### PR TITLE
Update bintray-release to make it work with latest gradle

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.1'
-        classpath 'com.novoda:bintray-release:0.8.0'
+        classpath 'com.novoda:bintray-release:0.9'
     }
 }
 


### PR DESCRIPTION
bintray-release script 0.8.0 prevents the project from building when using latest gradle on android studio 3.2.1
This updates bintray-release to 0.9 that has the problem solved

Closes #863