### PR TITLE
Fix casing in ios/Capacitor/Capacitor/CAPBridgedPlugin.m

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgedPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPBridgedPlugin.m
@@ -1,4 +1,4 @@
-#import <foundation/foundation.h>
+#import <Foundation/Foundation.h>
 #import <Capacitor/Capacitor-Swift.h>
 
 static NSMutableArray<Class> *CapacitorPluginClasses;


### PR DESCRIPTION
The Foundation header include is incorrectly cased which means builds will fail on case sensitive systems.