### PR TITLE
Fix Keyboard.setAccessoryBarVisible() on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Keyboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Keyboard.java
@@ -118,7 +118,7 @@ public class Keyboard extends Plugin {
   }
 
   @PluginMethod()
-  public void hideKeyboardAccessoryBar(PluginCall call) {
+  public void setAccessoryBarVisible(PluginCall call) {
     call.unimplemented();
   }
 }


### PR DESCRIPTION
Closes #993.