### PR TITLE
Fix ios tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,7 @@
     "lint": "tslint --project tsconfig.json",
     "assets": "node scripts/copy-assets.js",
     "prepublishOnly": "npm run build",
-    "test": "jest",
+    "test": "jest -i",
     "watch": "npm run assets && tsc -w"
   },
   "files": [

--- a/cli/test/add.ios.spec.ts
+++ b/cli/test/add.ios.spec.ts
@@ -1,13 +1,13 @@
 import { APP_ID, APP_NAME, run, makeAppDir, MappedFS } from './util';
 
-describe('Add: iOS', () => {
+describe.each([false, true])('Add: iOS (monoRepoLike: %p)', (monoRepoLike) => {
   let appDirObj;
   let FS;
 
   beforeAll(async () => {
     // These commands are slowww...
     jest.setTimeout(20000);
-    appDirObj = await makeAppDir();
+    appDirObj = await makeAppDir(monoRepoLike);
     const appDir = appDirObj.appDir;
     // Init in this directory so we can test add
     await run(appDir, `init "${APP_NAME}" "${APP_ID}"`);

--- a/cli/test/update.ios.spec.ts
+++ b/cli/test/update.ios.spec.ts
@@ -1,7 +1,7 @@
 import { APP_ID, APP_NAME, CORDOVA_PLUGIN_ID, MappedFS, makeAppDir, makeConfig, run } from './util';
 import { updateCommand } from '../src/tasks/update';
 
-describe('Update: iOS', () => {
+describe.each([false, true])('Update: iOS (monoRepoLike: %p)', (monoRepoLike) => {
   let appDirObj;
   let appDir;
   let FS;
@@ -9,7 +9,7 @@ describe('Update: iOS', () => {
   beforeAll(async () => {
     // These commands are slowww...
     jest.setTimeout(120000);
-    appDirObj = await makeAppDir();
+    appDirObj = await makeAppDir(monoRepoLike);
     appDir = appDirObj.appDir;
     // Init in this directory so we can test add
     await run(appDir, `init "${APP_NAME}" "${APP_ID}"`);

--- a/cli/test/util.ts
+++ b/cli/test/util.ts
@@ -192,10 +192,6 @@ async function makeCordovaPlugin(appDir: string) {
   await mkdirs(androidPath);
   await writeFileAsync(join(iosPath, 'CoolPlugin.m'), '');
   await writeFileAsync(join(androidPath, 'CoolPlugin.java'), '');
-  const cliAssetsCordova = join(appDir, 'ios', 'capacitor-cordova-ios-plugins');
-  await mkdirs(cliAssetsCordova);
-  await writeFileAsync(join(cliAssetsCordova, 'CordovaPlugins.podspec'), CORDOVA_PLUGINS_PODSPEC);
-  await writeFileAsync(join(cliAssetsCordova, 'CordovaPluginsResources.podspec'), CORDOVA_PLUGINS_RESOURCES_PODSPEC);
 }
 
 class MappedFS {


### PR DESCRIPTION
As for Android:
- removes the lines that copies the cordova assets as I believe they are now copied by `cap add` as for Android
- use `describe.each` to `add.ios.spec.ts` and `update.ios.spec.ts` to also test for the monorepo-like project layout
- add `-i` (aka. `--runInBand`) to `test` script in `package.json`

Under MacOS (Pod is required for the iOS part), all tests passes with `npm run test`! 🎉
Ready to be added to Circle CI.