### PR TITLE
Remove script tags from plugins code

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -89,6 +89,7 @@ export async function copyPluginsJS(config: Config, cordovaPlugins: Plugin[], pl
       let data = await readFileAsync(filePath, 'utf8');
       data = data.trim();
       data = `cordova.define("${pluginId}.${jsModule.$.name}", function(require, exports, module) { \n${data}\n});`;
+      data = data.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script\s*>/gi, "")
       await writeFileAsync(filePath, data, 'utf8');
     });
   }));


### PR DESCRIPTION
If a plugin have a script tag in the .js code, even if it's a comment as on cordova-plugin-buildinfo, it breaks the js injection.
Remove any script tag and it's content from the plugin's .js files