### PR TITLE
Fix path for local Capacitor plugins

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -57,16 +57,11 @@ export async function resolvePlugin(config: Config, name: string): Promise<Plugi
       return null;
     }
     if (meta.capacitor) {
-      let path = rootPath;
-      let dep = config.app.package.dependencies[name];
-      if (dep && dep.startsWith('file:')) {
-        path = config.app.package.dependencies[name].replace('file:', '../../');
-      }
       return {
         id: name,
         name: fixName(name),
         version: meta.version,
-        rootPath: path,
+        rootPath: rootPath,
         repository: meta.repository,
         manifest: meta.capacitor
       };


### PR DESCRIPTION
As we now get the actual path by calling `resolveNode`, this `file:` replace causes problems and it's not needed, remove it and use the rootPath.

Closes #1011