### PR TITLE
Add permission check for mkdir

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -12,5 +12,6 @@ public class PluginRequestCodes {
   public static final int FILE_CHOOSER_VIDEO_CAPTURE = 9009;
   public static final int FILE_CHOOSER_CAMERA_PERMISSION = 9010;
   public static final int GET_USER_MEDIA_PERMISSIONS = 9011;
-  public static final int FILESYSTEM_REQUEST_WRITE_PERMISSIONS = 9012;
+  public static final int FILESYSTEM_REQUEST_WRITE_FILE_PERMISSIONS = 9012;
+  public static final int FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS = 9013;
 }


### PR DESCRIPTION
mkdir can't create folders on Documents directory because it needs permissions but they weren't requested.

Added permission checking and improved the flow as the first write of file or folder was failing as didn't continue after the user accepted the permission, so it was silently failing. 