### PR TITLE
Add no-cache header

### DIFF
--- a/ios/Capacitor/Capacitor/CAPAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/CAPAssetHandler.swift
@@ -33,7 +33,8 @@ class CAPAssetHandler: NSObject, WKURLSchemeHandler {
             let mimeType = mimeTypeForExtension(pathExtension: url.pathExtension)
             let expectedContentLength = data.count
             let headers =  [
-            "Content-Type": mimeType
+              "Content-Type": mimeType,
+              "Cache-Control": "no-cache"
             ]
             let urlResponse = URLResponse(url: localUrl, mimeType: mimeType, expectedContentLength: expectedContentLength, textEncodingName: nil)
             let httpResponse = HTTPURLResponse(url: localUrl, statusCode: 200, httpVersion: nil, headerFields: headers)


### PR DESCRIPTION
When testing AppFlow on webview plugin, the files were cached sometimes so I added this there to solve the problem.
Back porting it to Capacitor