### PR TITLE
Use https as scheme on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -83,8 +83,8 @@ public class Bridge {
 
   // The name of the directory we use to look for index.html and the rest of our web assets
   public static final String DEFAULT_WEB_ASSET_DIR = "public";
-  public static final String CAPACITOR_SCHEME_NAME = "capacitor";
-  public static final String CAPACITOR_ASSET_SCHEME_NAME = "capacitor-asset";
+  public static final String CAPACITOR_SCHEME_NAME = "https";
+  public static final String CAPACITOR_FILE_SCHEME_NAME = "capacitor-file";
   public static final String CAPACITOR_CONTENT_SCHEME_NAME = "capacitor-content";
 
   // Loaded Capacitor config

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -42,7 +42,7 @@ import java.io.File;
  */
 public class FileUtils {
 
-  private static String CapacitorAssetScheme = Bridge.CAPACITOR_ASSET_SCHEME_NAME + "://";
+  private static String CapacitorFileScheme = Bridge.CAPACITOR_FILE_SCHEME_NAME + "://";
 
   public enum Type {
     IMAGE("image");
@@ -55,9 +55,9 @@ public class FileUtils {
   public static String getPortablePath(Context c, Uri u) {
     String path = getFileUrlForUri(c, u);
     if (path.startsWith("file://")) {
-      path = path.replace("file://", CapacitorAssetScheme);
+      path = path.replace("file://", CapacitorFileScheme);
     } else if (path.startsWith("/")) {
-      path = CapacitorAssetScheme + path;
+      path = CapacitorFileScheme + path;
     }
     return path;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -36,8 +36,8 @@ import java.util.Map;
 
 /**
  * Helper class meant to be used with the android.webkit.WebView class to enable hosting assets,
- * resources and other data on 'virtual' capacitor:// URL.
- * Hosting assets and resources on capacitor:// URLs is desirable as it is compatible with the
+ * resources and other data on 'virtual' https:// URL.
+ * Hosting assets and resources on https:// URLs is desirable as it is compatible with the
  * Same-Origin policy.
  * <p>
  * This class is intended to be used from within the
@@ -49,7 +49,7 @@ import java.util.Map;
 public class WebViewLocalServer {
 
   private final static String capacitorScheme = Bridge.CAPACITOR_SCHEME_NAME;
-  private final static String capacitorAssetsScheme = Bridge.CAPACITOR_ASSET_SCHEME_NAME;
+  private final static String capacitorFileScheme = Bridge.CAPACITOR_FILE_SCHEME_NAME;
   private final static String capacitorContentScheme = Bridge.CAPACITOR_CONTENT_SCHEME_NAME;
   private String basePath;
 
@@ -197,7 +197,7 @@ public class WebViewLocalServer {
           handler.getStatusCode(), handler.getReasonPhrase(), handler.getResponseHeaders(), null);
     }
 
-    if (request.getUrl().getScheme().equals(capacitorContentScheme)) {
+    if (request.getUrl().getScheme().equals(capacitorContentScheme) || request.getUrl().getScheme().equals(capacitorFileScheme)) {
       InputStream responseStream = new LollipopLazyInputStream(handler, request);
       InputStream stream = responseStream;
       String mimeType = getMimeType(path, stream);
@@ -387,9 +387,9 @@ public class WebViewLocalServer {
   }
 
   /**
-   * Hosts the application's assets on an capacitor:// URL. Assets from the local path
+   * Hosts the application's assets on an https:// URL. Assets from the local path
    * <code>assetPath/...</code> will be available under
-   * <code>capacitor://{uuid}.androidplatform.net/assets/...</code>.
+   * <code>https://{uuid}.androidplatform.net/assets/...</code>.
    *
    * @param assetPath the local path in the application's asset folder which will be made
    *                  available by the server (for example "/www").
@@ -403,8 +403,8 @@ public class WebViewLocalServer {
 
 
   /**
-   * Hosts the application's resources on an capacitor:// URL. Resources
-   * <code>capacitor://{uuid}.androidplatform.net/res/{resource_type}/{resource_name}</code>.
+   * Hosts the application's resources on an https:// URL. Resources
+   * <code>https://{uuid}.androidplatform.net/res/{resource_type}/{resource_name}</code>.
    *
    * @return prefixes under which the resources are hosted.
    */
@@ -413,8 +413,8 @@ public class WebViewLocalServer {
   }
 
   /**
-   * Hosts the application's resources on an capacitor:// URL. Resources
-   * <code>capacitor://{domain}/{virtualResourcesPath}/{resource_type}/{resource_name}</code>.
+   * Hosts the application's resources on an https:// URL. Resources
+   * <code>https://{domain}/{virtualResourcesPath}/{resource_type}/{resource_name}</code>.
    *
    * @param virtualResourcesPath the path on the local server under which the resources
    *                             should be hosted.
@@ -454,9 +454,9 @@ public class WebViewLocalServer {
   }
 
   /**
-   * Hosts the application's files on an capacitor:// URL. Files from the basePath
+   * Hosts the application's files on an https:// URL. Files from the basePath
    * <code>basePath/...</code> will be available under
-   * <code>capacitor://{uuid}.androidplatform.net/...</code>.
+   * <code>https://{uuid}.androidplatform.net/...</code>.
    *
    * @param basePath the local path in the application's data folder which will be made
    *                  available by the server (for example "/www").
@@ -488,7 +488,7 @@ public class WebViewLocalServer {
         try {
           if (url.getScheme().equals(capacitorScheme) && isAsset) {
             stream = protocolHandler.openAsset(assetPath + path);
-          } else if (url.getScheme().equals(capacitorAssetsScheme) || !isAsset) {
+          } else if (url.getScheme().equals(capacitorFileScheme) || !isAsset) {
             stream = protocolHandler.openFile(path);
           } else if (url.getScheme().equals(capacitorContentScheme)) {
             stream = protocolHandler.openContentUrl(path);
@@ -503,7 +503,7 @@ public class WebViewLocalServer {
     };
 
     registerUriForScheme(capacitorScheme, handler, authority);
-    registerUriForScheme(capacitorAssetsScheme, handler, "");
+    registerUriForScheme(capacitorFileScheme, handler, "");
     registerUriForScheme(capacitorContentScheme, handler, "");
 
   }


### PR DESCRIPTION
Use `https` instead of `capacitor` as scheme on Android 

Also renamed `capacitor-asset` to `capacitor-file` for handling file:// urls