### PR TITLE
Enable Mixed content mode by default

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -313,7 +313,7 @@ public class Bridge {
     settings.setGeolocationEnabled(true);
     settings.setDatabaseEnabled(true);
     settings.setAppCacheEnabled(true);
-    if (Config.getBoolean("android.allowMixedContent", false)) {
+    if (Config.getBoolean("android.allowMixedContent", true)) {
       settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
     }
   }

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -51,10 +51,11 @@ The current ones you might configure are:
     ]
   },
   "android": {
-    // On Android, Capacitor loads your local assets using https
-    // Chrome by default prevents loading files from a different scheme (i.e. from http)
-    // This setting allows to mix content from different schemes
-    "allowMixedContent": true,
+    // On Android, Capacitor enables mixed content mode
+    // to allow the WebView to load  files from schemes different
+    // than https://  (such as http:// or capacitor-file://)
+    // You can disable mixed content mode with this setting
+    "allowMixedContent": false,
     // Android's default keyboard doesn't allow proper JS key capture
     // You can use a simpler keyboard enabling this preference
     // Be aware that this keyboard has some problems and limitations


### PR DESCRIPTION
To allow loading from capacitor-file, capacitor-content and http by default, but still allow to disable it if desired. 