### PR TITLE
Fix content url handling

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
@@ -73,8 +73,14 @@ public class AndroidProtocolHandler {
     return new FileInputStream(localFile);
   }
 
-  public InputStream openContentUrl(String contentUrl)  throws IOException {
-    return context.getContentResolver().openInputStream(Uri.parse("content:/" + contentUrl.replace(":", "%3A")));
+  public InputStream openContentUrl(Uri uri)  throws IOException {
+    InputStream stream = null;
+    try {
+      stream = context.getContentResolver().openInputStream(Uri.parse(uri.toString().replace(Bridge.CAPACITOR_CONTENT_SCHEME_NAME + ":///", "content://")));
+    } catch (SecurityException e) {
+      Log.e(LogUtils.getCoreTag(), "Unable to open content URL: " + uri, e);
+    }
+    return stream;
   }
 
   private static int getValueType(Context context, int fieldId) {

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -503,7 +503,7 @@ public class WebViewLocalServer {
           } else if (url.getScheme().equals(capacitorFileScheme) || !isAsset) {
             stream = protocolHandler.openFile(path);
           } else if (url.getScheme().equals(capacitorContentScheme)) {
-            stream = protocolHandler.openContentUrl(path);
+            stream = protocolHandler.openContentUrl(url);
           }
         } catch (IOException e) {
           Log.e(LogUtils.getCoreTag(), "Unable to open asset URL: " + url);


### PR DESCRIPTION
Some content urls weren't handled properly if they had `:` instead of `%3A` and `/` instead of `%2F` in some places. Use url instead of path as path is encoding the existing `%2F` and `%3A` and causes security exception when you use the encoded url. 