### PR TITLE
Update web.html

### DIFF
--- a/site/src/assets/docs-content/plugins/web.html
+++ b/site/src/assets/docs-content/plugins/web.html
@@ -21,7 +21,6 @@ more explanation:</p>
 
   <span class="hljs-keyword">async</span> echo(options: { value: <span class="hljs-built_in">string</span> }) {
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'ECHO'</span>, options);
-    <span class="hljs-keyword">return</span> <span class="hljs-built_in">Promise</span>.resolve();
   }
 }
 


### PR DESCRIPTION
maybe I don’t understand something, but why return "Promise.resolve" if the `async` function returns `Promise.resolve` by itself? (if there are no `throw`).