### PR TITLE
Update docs setStyle method (StatusBar)

### DIFF
--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -38,7 +38,7 @@ export class StatusBarExample {
   changeStatusBar() {
     StatusBar.setStyle({
       style: this.isStatusBarLight ? StatusBarStyle.Dark : StatusBarStyle.Light
-    }, () => {});
+    });
     this.isStatusBarLight = !this.isStatusBarLight;
   }
 


### PR DESCRIPTION
I have version @capacitor/core 1.0.0-beta.13, in this version the method has this structure (no second parameter):

```js
setStyle(options: StatusBarStyleOptions): Promise<void>;
```