### PR TITLE
Add some splash screen startup improvements

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -53,18 +53,9 @@ enum BridgeError: Error {
     self.notificationsDelegate.bridge = self;
     localUrl = "\(CAPBridge.CAP_SCHEME)://\(CAPConfig.getString("server.hostname") ?? "localhost")"
     exportCoreJS(localUrl: localUrl!)
-    setupCordovaCompatibility()
     registerPlugins()
+    setupCordovaCompatibility()
     bindObservers()
-  }
-  
-  public func willAppear() {
-  }
-
-  public func didLoad() {
-    if let splash = getOrLoadPlugin(pluginName: "SplashScreen") as? CAPSplashScreenPlugin {
-      splash.showOnLaunch()
-    }
   }
   
   public func setStatusBarVisible(_ isStatusBarVisible: Bool) {

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -70,13 +70,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   override public func viewDidLoad() {
     super.viewDidLoad()
     self.becomeFirstResponder()
-    
     loadWebView()
-    bridge!.didLoad()
-  }
-  
-  public override func viewWillAppear(_ animated: Bool) {
-    bridge!.willAppear()
   }
   
   func loadWebView() {

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -19,6 +19,7 @@ public class CAPSplashScreenPlugin : CAPPlugin {
   
   public override func load() {
     buildViews()
+    showOnLaunch()
   }
   
   // Show the splash screen
@@ -83,8 +84,6 @@ public class CAPSplashScreenPlugin : CAPPlugin {
       bridge.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
       return
     }
-    
-    imageView.alpha = 0
     imageView.image = image
     imageView.frame = CGRect.init(origin: CGPoint.init(x: 0, y: 0), size: window.bounds.size)
     imageView.contentMode = .scaleAspectFill
@@ -98,7 +97,6 @@ public class CAPSplashScreenPlugin : CAPPlugin {
     let launchShowDurationConfig = getConfigValue("launchShowDuration") as? Int ?? launchShowDuration
     let launchAutoHideConfig = getConfigValue("launchAutoHide") as? Bool ?? launchAutoHide
     showSplash(showDuration: launchShowDurationConfig, fadeInDuration: 0, fadeOutDuration: defaultFadeOutDuration, autoHide: launchAutoHideConfig, completion: {
-      
     }, isLaunchSplash: true)
   }
   


### PR DESCRIPTION
List of improvements:

1. Startup Capacitor plugins before Cordova plugins
1. Call `showOnLaunch` as soon as the plugin is ready instead of waiting for `didLoad`
1. Don't set initial alpha value to 0 as we want it to be present from the beginning and even with a 0 time animation it still takes a few ms to animate. And it also fixes a bug where the splash disappear on rotation.


