### PR TITLE
Implement view resizing on keyboard show/hide

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -49,7 +49,7 @@ typedef enum : NSUInteger {
   }
     
   BOOL doesResize = YES;
-  if ([[self getConfigValue:@"resize"] isEqualToString:@"false"]) {
+  if ([[self getConfigValue:@"resize"] isEqualToString:@"none"]) {
     doesResize = NO;
     self.keyboardResizes = ResizeNone;
     NSLog(@"CAPKeyboard: no resize");
@@ -57,20 +57,20 @@ typedef enum : NSUInteger {
 
   if (doesResize) {
     self.keyboardResizes = ResizeNative;
-    NSString * resizeMode = [self getConfigValue:@"resizeMode"];
+    NSString * resizeMode = [self getConfigValue:@"resize"];
     
     if (resizeMode) {
       if ([resizeMode isEqualToString:@"ionic"]) {
         self.keyboardResizes = ResizeIonic;
-        NSLog(@"CAPKeyboard: resize mode ionic");
+        NSLog(@"CAPKeyboard: resize mode - ionic");
       } else if ([resizeMode isEqualToString:@"body"]) {
         self.keyboardResizes = ResizeBody;
-          NSLog(@"CAPKeyboard: resize mode body");
+          NSLog(@"CAPKeyboard: resize mode - body");
       }
     }
       
     if (self.keyboardResize == ResizeNative) {
-      NSLog(@"CAPKeyboard: resize mode native");
+      NSLog(@"CAPKeyboard: resize mode - native");
     }
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -58,7 +58,6 @@ typedef enum : NSUInteger {
   if (doesResize) {
     self.keyboardResizes = ResizeNative;
     NSString * resizeMode = [self getConfigValue:@"resizeMode"];
-    NSLog(@"Resize mode %@", resizeMode);
     
     if (resizeMode) {
       if ([resizeMode isEqualToString:@"ionic"]) {
@@ -68,6 +67,10 @@ typedef enum : NSUInteger {
         self.keyboardResizes = ResizeBody;
           NSLog(@"CAPKeyboard: resize mode body");
       }
+    }
+      
+    if (self.keyboardResize == ResizeNative) {
+      NSLog(@"CAPKeyboard: resize mode native");
     }
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -69,7 +69,7 @@ typedef enum : NSUInteger {
       }
     }
       
-    if (self.keyboardResize == ResizeNative) {
+    if (self.keyboardResizes == ResizeNative) {
       NSLog(@"CAPKeyboard: resize mode - native");
     }
   }

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -42,28 +42,35 @@ typedef enum : NSUInteger {
 - (void)load
 {
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(statusBarDidChangeFrame:) name:UIApplicationDidChangeStatusBarFrameNotification object: nil];
+    
   NSString * style = [self getConfigValue:@"style"];
   if ([style isEqualToString:@"dark"]) {
     [self setKeyboardAppearanceDark];
   }
-  
-  self.keyboardResizes = ResizeNative;
-  BOOL doesResize = YES;
-  if (!doesResize) {
-    self.keyboardResizes = ResizeNone;
-    NSLog(@"CAPIonicKeyboard: no resize");
     
-  } else {
-    NSString *resizeMode = @"ionic";
+  BOOL doesResize = YES;
+  if ([[self getConfigValue:@"resize"] isEqualToString:@"false"]) {
+    doesResize = NO;
+    self.keyboardResizes = ResizeNone;
+    NSLog(@"CAPKeyboard: no resize");
+  }
+
+  if (doesResize) {
+    self.keyboardResizes = ResizeNative;
+    NSString * resizeMode = [self getConfigValue:@"resizeMode"];
+    NSLog(@"Resize mode %@", resizeMode);
+    
     if (resizeMode) {
       if ([resizeMode isEqualToString:@"ionic"]) {
         self.keyboardResizes = ResizeIonic;
+        NSLog(@"CAPKeyboard: resize mode ionic");
       } else if ([resizeMode isEqualToString:@"body"]) {
         self.keyboardResizes = ResizeBody;
+          NSLog(@"CAPKeyboard: resize mode body");
       }
     }
-    // NSLog(@"CAPIonicKeyboard: resize mode %d", self.keyboardResizes);
   }
+
   self.hideFormAccessoryBar = YES;
   
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
@@ -152,6 +159,16 @@ typedef enum : NSUInteger {
   }
 }
 
+- (void)resizeElement:(NSString *)element withPaddingBottom:(int)paddingBottom withScreenHeight:(int)screenHeight
+{
+    int height = -1;
+    if (paddingBottom > 0) {
+        height = screenHeight - paddingBottom;
+    }
+    
+    [self.bridge evalWithJs: [NSString stringWithFormat:@"(function() { var el = %@; var height = %d; if (el) { el.style.height = height > -1 ? height + 'px' : null; } })()", element, height]];
+}
+
 - (void)_updateFrame
 {
   CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
@@ -167,16 +184,12 @@ typedef enum : NSUInteger {
   switch (self.keyboardResizes) {
     case ResizeBody:
     {
-      NSString *js = [NSString stringWithFormat:@"plugin.fireOnResize(%d, %d, document.body);",
-                      _paddingBottom, (int)f.size.height];
-      [self.bridge evalWithPlugin:self js:js];
+      [self resizeElement:@"document.body" withPaddingBottom:_paddingBottom withScreenHeight:(int)f.size.height];
       break;
     }
     case ResizeIonic:
     {
-      NSString *js = [NSString stringWithFormat:@"plugin.fireOnResize(%d, %d, document.querySelector('ion-app'));",
-                      _paddingBottom, (int)f.size.height];
-      [self.bridge evalWithPlugin:self js:js];
+      [self resizeElement:@"document.querySelector('ion-app')" withPaddingBottom:_paddingBottom withScreenHeight:(int)f.size.height];
       break;
     }
     case ResizeNative:


### PR DESCRIPTION
Very simple implementation of view resizing when keyboard showing/hidding. The logic is copied from cordova-plugin-ionic-keyboard. There are two config parameters related to resizing:

- **resize**, allowed value is either `true` or `false`. Default value is `true`.
- **resizeMode**, allowed value is `native`, `ionic` or `body`.  Default value is `native`.