### PR TITLE
Define a common pod so it can be used in different tagerts

### DIFF
--- a/ios-template/App/Podfile
+++ b/ios-template/App/Podfile
@@ -1,11 +1,14 @@
 platform :ios, '11.0'
 use_frameworks!
 
-target 'App' do
-  # Add your Pods here
-
+def capacitor_pods
   # Automatic Capacitor Pod dependencies, do not delete
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   # Do not delete
+end
+
+target 'App' do
+  capacitor_pods
+  # Add your Pods here
 end


### PR DESCRIPTION
Change Podfile to define `capacitor_pods` that will contain all Capacitor dependencies (and Cordova/Capacitor plugins), so it can be used in multiple targets.

Closes #1121