### PR TITLE
Use a single scheme for iOS and Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
@@ -69,14 +69,17 @@ public class AndroidProtocolHandler {
   }
 
   public InputStream openFile(String filePath) throws IOException  {
-    File localFile = new File(filePath);
+    String realPath = filePath.replace(Bridge.CAPACITOR_FILE_START, "");
+    File localFile = new File(realPath);
     return new FileInputStream(localFile);
   }
 
   public InputStream openContentUrl(Uri uri)  throws IOException {
+    String realPath = uri.toString().replace(uri.getScheme() + "://" + uri.getHost() + Bridge.CAPACITOR_CONTENT_START, "content:/");
+
     InputStream stream = null;
     try {
-      stream = context.getContentResolver().openInputStream(Uri.parse(uri.toString().replace(Bridge.CAPACITOR_CONTENT_SCHEME_NAME + ":///", "content://")));
+      stream = context.getContentResolver().openInputStream(Uri.parse(realPath));
     } catch (SecurityException e) {
       Log.e(LogUtils.getCoreTag(), "Unable to open content URL: " + uri, e);
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -42,7 +42,7 @@ import java.io.File;
  */
 public class FileUtils {
 
-  private static String CapacitorFileScheme = Bridge.CAPACITOR_FILE_SCHEME_NAME + "://";
+  private static String CapacitorFileScheme = Bridge.CAPACITOR_FILE_START;
 
   public enum Type {
     IMAGE("image");
@@ -52,14 +52,14 @@ public class FileUtils {
     }
   }
 
-  public static String getPortablePath(Context c, Uri u) {
+  public static String getPortablePath(Context c, String host, Uri u) {
     String path = getFileUrlForUri(c, u);
     if (path.startsWith("file://")) {
-      path = path.replace("file://", CapacitorFileScheme);
+      path = path.replace("file://", "");
     } else if (path.startsWith("/")) {
-      path = CapacitorFileScheme + path;
+      path = path;
     }
-    return path;
+    return host + Bridge.CAPACITOR_FILE_START + path;
   }
 
   public static String getFileUrlForUri(final Context context, final Uri uri) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -353,7 +353,7 @@ public class Camera extends Plugin {
       JSObject ret = new JSObject();
       ret.put("exif", exif.toJson());
       ret.put("path", newUri.toString());
-      ret.put("webPath", FileUtils.getPortablePath(getContext(), newUri));
+      ret.put("webPath", FileUtils.getPortablePath(getContext(), bridge.getLocalUrl(), newUri));
       call.resolve(ret);
     } catch (IOException ex) {
       call.reject(UNABLE_TO_PROCESS_IMAGE, ex);

--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -508,13 +508,13 @@
       return url;
     }
     if (url.startsWith('/')) {
-      return 'capacitor-file://' + url;
+      return window.WEBVIEW_SERVER_URL + '/_capacitor_file_' + url;
     }
     if (url.startsWith('file://')) {
-      return url.replace('file', 'capacitor-file');
+      return window.WEBVIEW_SERVER_URL + url.replace('file://', '/_capacitor_file_');
     }
-    if (url.startsWith('content:')) {
-      return url.replace('content:', 'capacitor-content:/');
+    if (url.startsWith('content://')) {
+      return window.WEBVIEW_SERVER_URL + url.replace('content:/', '/_capacitor_content_');
     }
     return url;
   }

--- a/ios/Capacitor/Capacitor/CAPAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/CAPAssetHandler.swift
@@ -13,12 +13,10 @@ class CAPAssetHandler: NSObject, WKURLSchemeHandler {
             startPath = Bundle.main.path(forResource: "public", ofType: nil)!
             if stringToLoad.isEmpty || url.pathExtension.isEmpty {
                 startPath.append("/index.html")
+            } else if stringToLoad.starts(with: CAPBridge.CAP_FILE_START) {
+                startPath = stringToLoad.replacingOccurrences(of: CAPBridge.CAP_FILE_START, with: "")
             } else {
                 startPath.append(stringToLoad)
-            }
-        } else if scheme == CAPBridge.CAP_FILE_SCHEME {
-            if !stringToLoad.isEmpty {
-                startPath = stringToLoad
             }
         }
 

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -12,7 +12,7 @@ enum BridgeError: Error {
   public static let statusBarTappedNotification = Notification(name: Notification.Name(rawValue: "statusBarTappedNotification"))
   public static var CAP_SITE = "https://getcapacitor.com/"
   public static var CAP_SCHEME = "capacitor"
-  public static var CAP_FILE_SCHEME = "capacitor-file"
+  public static var CAP_FILE_START = "/_capacitor_file_"
 
   // The last URL that caused the app to open
   private static var lastUrl: URL?

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -40,7 +40,6 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     let webViewConfiguration = WKWebViewConfiguration()
 
     webViewConfiguration.setURLSchemeHandler(CAPAssetHandler(), forURLScheme: CAPBridge.CAP_SCHEME)
-    webViewConfiguration.setURLSchemeHandler(CAPAssetHandler(), forURLScheme: CAPBridge.CAP_FILE_SCHEME)
     
     let o = WKUserContentController()
     o.add(self, name: "bridge")

--- a/ios/Capacitor/Capacitor/CAPFile.swift
+++ b/ios/Capacitor/Capacitor/CAPFile.swift
@@ -27,10 +27,10 @@ public class CAPFile {
     return nil
   }
   
-  public static func getPortablePath(uri: URL?) -> String? {
+  public static func getPortablePath(host: String, uri: URL?) -> String? {
     if uri != nil {
-      let assetUrl = uri!.absoluteString.replacingOccurrences(of: "file://", with: "\(CAPBridge.CAP_FILE_SCHEME)://")
-      return assetUrl
+        let uriWithoutFile = uri!.absoluteString.replacingOccurrences(of: "file://", with: "")
+        return host + CAPBridge.CAP_FILE_START + uriWithoutFile
     }
     return nil
   }

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -223,7 +223,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
       ])
     } else if settings.resultType == "uri" {
       let path = try! saveTemporaryImage(jpeg)
-      guard let webPath = CAPFileManager.getPortablePath(uri: URL(string: path)) else {
+      guard let webPath = CAPFileManager.getPortablePath(host: bridge.getLocalUrl(), uri: URL(string: path)) else {
         call?.reject("Unable to get portable path to file")
         return
       }


### PR DESCRIPTION
Use a single scheme for iOS and Android

On Android it also
- Removes duplicated injection of Capacitor js files
- Improves injection of Capacitor for live reload and allowNavigation urls (injecting the script in `onPageFinished` was making Capacitor use the web implementation instead of the native one)
- Fix crash when navigating to another page when allowNavigation is not configured