### PR TITLE
Use custom config for Android and Electron platforms like iOS does

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -125,13 +125,13 @@ export class Config implements CliConfig {
   setCurrentWorkingDir(currentWorkingDir: string) {
     try {
       this.initAppConfig(resolve(currentWorkingDir));
-      this.initAndroidConfig();
-      this.initElectronConfig();
       this.initPluginsConfig();
       this.loadExternalConfig();
       this.mergeConfigData();
 
       // Post-merge
+      this.initAndroidConfig();
+      this.initElectronConfig();
       this.initIosConfig();
       this.initWindowsConfig();
       this.initLinuxConfig();


### PR DESCRIPTION
I was attempting to use capacitor in a monorepo setup with the native project in a subdirectory and capacitor config at root. I want to have the platform directories in the project directory instead of at root so I set the `rootDir` in the config to my project's directory. This worked great for iOS, but Android did not work because it put some files in my project directory and some at root. To me it seems like if iOS uses the custom config, then Android and Electron should as well. This seemed like the only way to resolve this issue, but I may be wrong about that.