### PR TITLE
Fix Universal Links not passing data to app

### DIFF
--- a/example/ios/IonicRunner/IonicRunner/AppDelegate.swift
+++ b/example/ios/IonicRunner/IonicRunner/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return CAPAppDelegate.shared.application(application, open: url, options: options)
   }
   
-  func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+  func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     return CAPAppDelegate.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
   }
 

--- a/ios-template/App/App/AppDelegate.swift
+++ b/ios-template/App/App/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return CAPBridge.handleOpenUrl(url, options)
   }
   
-  func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+  func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     // Called when the app was launched with an activity, including Universal Links.
     // Feel free to add additional processing here, but if you want the App API to support
     // tracking app url opens, make sure to keep this call

--- a/ios/Capacitor/Capacitor/CAPAppDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPAppDelegate.swift
@@ -5,7 +5,7 @@ public final class CAPAppDelegate {
     return CAPBridge.handleOpenUrl(url, options)
   }
   
-  public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+  public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     return CAPBridge.handleContinueActivity(userActivity, restorationHandler)
   }
   

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -98,7 +98,7 @@ enum BridgeError: Error {
   /**
    * Handle continueUserActivity, for now this just provides universal link responding support.
    */
-  public static func handleContinueActivity(_ userActivity: NSUserActivity, _ restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+  public static func handleContinueActivity(_ userActivity: NSUserActivity, _ restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
     // TODO: Support other types, emit to rest of plugins
     if userActivity.activityType != NSUserActivityTypeBrowsingWeb || userActivity.webpageURL == nil {
       return false


### PR DESCRIPTION
Not sure if related to the Swift 4.2 conversion, but looks like when it has `Any` it doesn't work and the `application continue` method is not called. Changing it to `UIUserActivityRestoring` makes it work again.