### PR TITLE
Allow to configure Cordova linker flags

### DIFF
--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -19,6 +19,7 @@ export interface ExternalConfig {
   ios?: {
     cordovaSwiftVersion?: string;
     minVersion?: string;
+    cordovaLinkerFlags?: string[];
   };
 }
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -235,11 +235,18 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
     s.source = { :git => 'https://github.com/ionic-team/does-not-exist.git', :tag => '${config.cli.package.version}' }
     s.source_files = '${sourcesFolderName}/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '${config.ios.minVersion}'
-    s.dependency 'CapacitorCordova'
+    s.dependency 'CapacitorCordova'${getLinkerFlags(config)}
     s.swift_version  = '${config.ios.cordovaSwiftVersion}'
     ${frameworksString}
   end`;
   await writeFileAsync(join(pluginsPath, `${name}.podspec`), content);
+}
+
+function getLinkerFlags(config: Config) {
+  if (config.app.extConfig.ios && config.app.extConfig.ios.cordovaLinkerFlags) {
+    return `\n    s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '${config.app.extConfig.ios.cordovaLinkerFlags.join(' ')}' }`;
+  }
+  return '';
 }
 
 function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -72,7 +72,9 @@ The current ones you might configure are:
     "cordovaSwiftVersion": "3.0",
     // Minimum iOS version supported by the project.
     // Default is 11.0
-    "minVersion": "11.3"
+    "minVersion": "11.3",
+    // Some Cordova plugins require to configure the linker flags
+    "cordovaLinkerFlags": ["-ObjC"]
   }
 }
 ```


### PR DESCRIPTION
So far I've only needed `-ObjC` linker flag, but adding it as default could increase the app size, so I made it configurable to add it only when needed and add some other linker flag we didn't think about.

Closes #1133