### PR TITLE
Remove extra/options from LocalNotificationRequest

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -825,7 +825,6 @@ export interface KeyboardPlugin extends Plugin {
 
 export interface LocalNotificationRequest {
   id: string;
-  options: any;
 }
 
 export interface LocalNotificationPendingList {

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -118,11 +118,8 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
    * Turn a UNNotificationRequest into a JSObject to return back to the client.
    */
   func makeNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
-    let notificationRequest = notificationRequestLookup[request.identifier] ?? [:]
-
     return [
-      "id": request.identifier,
-      "extra": notificationRequest["extra"] ?? [:]
+      "id": request.identifier
     ]
   }
 


### PR DESCRIPTION
I think we should use just `LocalNotification` instead of `LocalNotificationRequest` and return all the fields the `LocalNotification` has on both iOS and Android, but for now I'm removing `options` as it's not returned by Android, and returned as `extras` on iOS. 

Closes #947