### PR TITLE
Make Keyboard plugin methods return proper promises

### DIFF
--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -3,7 +3,7 @@ public typealias PluginResultData = [String:Any]
 public typealias PluginEventListener = CAPPluginCall
 
 /**
- * Swift niceities for CAPPluginCall
+ * Swift niceties for CAPPluginCall
  */
 @objc public extension CAPPluginCall {
 

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -5,31 +5,31 @@ public typealias PluginEventListener = CAPPluginCall
 /**
  * Swift niceities for CAPPluginCall
  */
-public extension CAPPluginCall {
+@objc public extension CAPPluginCall {
 
   private static var UNIMPLEMENTED = "not implemented"
 
-  public func get<T>(_ key: String, _ ofType: T.Type, _ defaultValue: T? = nil) -> T? {
+  @nonobjc public func get<T>(_ key: String, _ ofType: T.Type, _ defaultValue: T? = nil) -> T? {
     return self.options[key] as? T ?? defaultValue
   }
   
-  public func getArray<T>(_ key: String, _ ofType: T.Type, _ defaultValue: [T]? = nil) -> [T]? {
+  @nonobjc public func getArray<T>(_ key: String, _ ofType: T.Type, _ defaultValue: [T]? = nil) -> [T]? {
     return self.options[key] as? [T] ?? defaultValue
   }
   
-  public func getBool(_ key: String, _ defaultValue: Bool? = nil) -> Bool? {
+  @nonobjc public func getBool(_ key: String, _ defaultValue: Bool? = nil) -> Bool? {
     return self.options[key] as? Bool ?? defaultValue
   }
   
-  public func getInt(_ key: String, _ defaultValue: Int? = nil) -> Int? {
+  @nonobjc public func getInt(_ key: String, _ defaultValue: Int? = nil) -> Int? {
     return self.options[key] as? Int ?? defaultValue
   }
   
-  public func getFloat(_ key: String, _ defaultValue: Float? = nil) -> Float? {
+  @nonobjc public func getFloat(_ key: String, _ defaultValue: Float? = nil) -> Float? {
     return self.options[key] as? Float ?? defaultValue
   }
   
-  public func getDouble(_ key: String, _ defaultValue: Double? = nil) -> Double? {
+  @nonobjc public func getDouble(_ key: String, _ defaultValue: Double? = nil) -> Double? {
     return self.options[key] as? Double ?? defaultValue
   }
   

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -245,7 +245,7 @@ static IMP WKOriginalImp;
 
   NSLog(@"Accessory bar visible change %d", value);
   self.hideFormAccessoryBar = !value;
-  [call successHandler];
+  [call success];
 }
 
 - (void)hide:(CAPPluginCall *)call
@@ -253,11 +253,12 @@ static IMP WKOriginalImp;
   dispatch_async(dispatch_get_main_queue(), ^{
     [self.webView endEditing:YES];
   });
+  [call success];
 }
 
 - (void)show:(CAPPluginCall *)call
 {
-  [call successHandler];
+  [call unimplemented];
 }
 
 - (void)setKeyboardAppearanceDark


### PR DESCRIPTION
Make the Swift CAPPluginCall Extension to be accessible from Objective-C, so Objective-C plugins can use it's niceties.

Also make show return success, hide return unimplemented and setAccessoryBarVisible a regular success call