### PR TITLE
Add <access origin="*" /> to generated config.xml

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -151,6 +151,7 @@ export async function autoGenerateConfig(config: Config, cordovaPlugins: Plugin[
   }));
   const content = `<?xml version='1.0' encoding='utf-8'?>
   <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+  <access origin="*" />
   ${pluginEntriesString.join('\n')}
   </widget>`;
   await writeFileAsync(cordovaConfigXMLFile, content);


### PR DESCRIPTION
So cordova-plugin-file-transfer and other plugins checking the whitelist can connect. 

Closes #1199
