### PR TITLE
Remove header form data

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -247,6 +247,10 @@ public class Filesystem extends Plugin {
       call.error("Unsupported encoding provided: " + encoding);
       return;
     }
+    //remove header from dataURL
+    if(data.indexOf(",") != -1) {
+      data = data.split(",")[1]; 
+    }    
 
     // if charset is not null assume its a plain text file the user wants to save
     boolean success = false;


### PR DESCRIPTION
Occasionally you can send a dataURL with header. To prevent an error while creating the file on Android and save developer time by discovering this.

Issue #1130