### PR TITLE
Allow weak linking iOS frameworks

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -164,7 +164,7 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
             if (!weakFrameworks.includes(name)) {
               weakFrameworks.push(name);
             }
-          } if (framework.$.custom && framework.$.custom === 'true') {
+          } else if (framework.$.custom && framework.$.custom === 'true') {
             const frameworktPath = join(sourcesFolderName, plugin.name, name);
             if (!customFrameworks.includes(frameworktPath)) {
               customFrameworks.push(frameworktPath);


### PR DESCRIPTION
I suppose the `else` was missing due to a typo.

Without it all the weakly linked libraries were also added to either the `vendored_frameworks` or the `frameworks` array. If they ended up in the `frameworks` they were no longer **weakly** linked (e.g. they ended up marked as `Required` in the `Link Binaries With Libraries` list in Xcode).