### PR TITLE
Restore camera settings after app was killed (#1238)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -444,6 +444,8 @@ public class Camera extends Plugin {
       return;
     }
 
+    settings = getSettings(savedCall);
+
     if (requestCode == REQUEST_IMAGE_CAPTURE) {
       processCameraImage(savedCall, data);
     } else if (requestCode == REQUEST_IMAGE_PICK) {


### PR DESCRIPTION
As described in #1238, the camera settings were not restored when the app was killed in the background. This caused the settings to fallback to their default values.