### PR TITLE
[splash/android] Configuration for scaleType

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -52,7 +52,15 @@ public class Splash {
     // https://stackoverflow.com/a/21847579/32140
     splashImage.setDrawingCacheEnabled(true);
 
-    splashImage.setScaleType(ImageView.ScaleType.FIT_XY);
+    String scaleTypeName = Config.getString(CONFIG_KEY_PREFIX + "scaleType", "FIT_XY");
+    ImageView.ScaleType scaleType = null;
+    try {
+        scaleType = ImageView.ScaleType.valueOf(scaleTypeName);
+    } catch (IllegalArgumentException ex) {
+        scaleType = ImageView.ScaleType.FIT_XY;
+    }
+
+    splashImage.setScaleType(scaleType);
     splashImage.setImageDrawable(splash);
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -52,12 +52,12 @@ public class Splash {
     // https://stackoverflow.com/a/21847579/32140
     splashImage.setDrawingCacheEnabled(true);
 
-    String scaleTypeName = Config.getString(CONFIG_KEY_PREFIX + "scaleType", "FIT_XY");
+    String scaleTypeName = Config.getString(CONFIG_KEY_PREFIX + "androidScaleType", "FIT_XY");
     ImageView.ScaleType scaleType = null;
     try {
-        scaleType = ImageView.ScaleType.valueOf(scaleTypeName);
+      scaleType = ImageView.ScaleType.valueOf(scaleTypeName);
     } catch (IllegalArgumentException ex) {
-        scaleType = ImageView.ScaleType.FIT_XY;
+      scaleType = ImageView.ScaleType.FIT_XY;
     }
 
     splashImage.setScaleType(scaleType);

--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -69,7 +69,7 @@ These config parameters are availiable in `capacitor.config.json`:
       "launchShowDuration": 3000,
       "launchAutoHide": true,
       "androidSplashResourceName": "splash",
-      "scaleType": "FIT_XY"
+      "androidScaleType": "CENTER_CROP"
     }
   }
 }

--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -68,7 +68,8 @@ These config parameters are availiable in `capacitor.config.json`:
     "SplashScreen": {
       "launchShowDuration": 3000,
       "launchAutoHide": true,
-      "androidSplashResourceName": "splash"
+      "androidSplashResourceName": "splash",
+      "scaleType": "FIT_XY"
     }
   }
 }

--- a/site/src/assets/docs-content/apis/splash-screen/index.html
+++ b/site/src/assets/docs-content/apis/splash-screen/index.html
@@ -50,6 +50,7 @@ app should boot much faster than this!</p>
       <span class="hljs-attr">"launchShowDuration"</span>: <span class="hljs-number">3000</span>,
       <span class="hljs-attr">"launchAutoHide"</span>: <span class="hljs-literal">true</span>,
       <span class="hljs-attr">"androidSplashResourceName"</span>: <span class="hljs-string">"splash"</span>
+      <span class="hljs-attr">"scaleType"</span>: <span class="hljs-string">"FIT_XY"</span>
     }
   }
 }

--- a/site/src/assets/docs-content/apis/splash-screen/index.html
+++ b/site/src/assets/docs-content/apis/splash-screen/index.html
@@ -50,7 +50,6 @@ app should boot much faster than this!</p>
       <span class="hljs-attr">"launchShowDuration"</span>: <span class="hljs-number">3000</span>,
       <span class="hljs-attr">"launchAutoHide"</span>: <span class="hljs-literal">true</span>,
       <span class="hljs-attr">"androidSplashResourceName"</span>: <span class="hljs-string">"splash"</span>
-      <span class="hljs-attr">"scaleType"</span>: <span class="hljs-string">"FIT_XY"</span>
     }
   }
 }


### PR DESCRIPTION
Since https://github.com/ionic-team/capacitor/commit/d68af92b8fba3aa8735bc812e91a3aa25b9a5541, the splash screen is not `CENTER_CROP`ed anymore which makes difficult to have (animated) vector drawables as splash screen.

As a middle ground, this PR allows to configure the `scaleType` in splashScreen plugin configuration.

The default is set to the new value since https://github.com/ionic-team/capacitor/commit/d68af92b8fba3aa8735bc812e91a3aa25b9a5541, i.e. `FIT_XY`.