### PR TITLE
Fixed broken documentation link

### DIFF
--- a/site/docs-md/plugins/web.md
+++ b/site/docs-md/plugins/web.md
@@ -14,7 +14,7 @@ The basic structure of a Web plugin looks like this, follow the comments inline 
 more explanation:
 
 ```typescript
-import { WebPlugin } from '@capacitor/core'
+import { WebPlugin } from '@capacitor/core';
 
 export class MyPluginWeb extends WebPlugin {
   constructor() {
@@ -28,13 +28,13 @@ export class MyPluginWeb extends WebPlugin {
   }
 
   async echo(options: { value: string }) {
-    console.log('ECHO', options)
-    return options
+    console.log('ECHO', options);
+    return options;
   }
 }
 
 // Instantiate the plugin
-const MyPlugin = new MyPluginWeb()
+const MyPlugin = new MyPluginWeb();
 
 // Export the plugin
 export { MyPlugin }
@@ -43,5 +43,5 @@ export { MyPlugin }
 Finally, make sure your `src/index.ts` has this line:
 
 ```typescript
-export * from './web'
+export * from './web';
 ```

--- a/site/docs-md/plugins/web.md
+++ b/site/docs-md/plugins/web.md
@@ -4,7 +4,7 @@ Capacitor utilizes a web/native compatibility layer, making it easy to build plu
 
 ## Getting Started
 
-To get started, first generate a plugin as shown in the [Getting Started]('./#getting-started) section of the Plugin guide.
+To get started, first generate a plugin as shown in the [Getting Started](./#getting-started) section of the Plugin guide.
 
 Next, open `your-plugin/src/web.ts` in your editor of choice.
 
@@ -14,7 +14,7 @@ The basic structure of a Web plugin looks like this, follow the comments inline 
 more explanation:
 
 ```typescript
-import { WebPlugin } from '@capacitor/core';
+import { WebPlugin } from '@capacitor/core'
 
 export class MyPluginWeb extends WebPlugin {
   constructor() {
@@ -24,24 +24,24 @@ export class MyPluginWeb extends WebPlugin {
     super({
       name: 'MyPlugin',
       platforms: ['web']
-    });
+    })
   }
 
   async echo(options: { value: string }) {
-    console.log('ECHO', options);
-    return options;
+    console.log('ECHO', options)
+    return options
   }
 }
 
 // Instantiate the plugin
-const MyPlugin = new MyPluginWeb();
+const MyPlugin = new MyPluginWeb()
 
 // Export the plugin
-export { MyPlugin };
+export { MyPlugin }
 ```
 
 Finally, make sure your `src/index.ts` has this line:
 
 ```typescript
-export * from './web';
+export * from './web'
 ```

--- a/site/docs-md/plugins/web.md
+++ b/site/docs-md/plugins/web.md
@@ -24,7 +24,7 @@ export class MyPluginWeb extends WebPlugin {
     super({
       name: 'MyPlugin',
       platforms: ['web']
-    })
+    });
   }
 
   async echo(options: { value: string }) {
@@ -37,7 +37,7 @@ export class MyPluginWeb extends WebPlugin {
 const MyPlugin = new MyPluginWeb();
 
 // Export the plugin
-export { MyPlugin }
+export { MyPlugin };
 ```
 
 Finally, make sure your `src/index.ts` has this line:


### PR DESCRIPTION
Clicking on the 'Getting Started' link in the web plugin documentation took you to https://capacitor.ionicframework.com/docs/plugins/'./#getting-started

Clicking that link causes some oddities where it'll continue to reload and really isn't the right place anyway.

Probably one of the smallest PRs ever :)