### PR TITLE
Fixed getLanguageCode()

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Device.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Device.swift
@@ -37,7 +37,7 @@ public class CAPDevicePlugin: CAPPlugin {
   }
   
   @objc func getLanguageCode(_ call: CAPPluginCall) {
-    let code = Locale.current.languageCode ?? ""
+    let code = Locale.preferredLanguages[0]
     call.success([
       "value": code
     ])

--- a/ios/Capacitor/Capacitor/Plugins/Device.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Device.swift
@@ -37,7 +37,7 @@ public class CAPDevicePlugin: CAPPlugin {
   }
   
   @objc func getLanguageCode(_ call: CAPPluginCall) {
-    let code = Locale.preferredLanguages[0]
+    let code = String(Locale.preferredLanguages[0].prefix(2))
     call.success([
       "value": code
     ])


### PR DESCRIPTION
Fixed https://github.com/ionic-team/capacitor/issues/1233

Locale.current.languageCode **doesn't return the correct language** used by device, **becouse Capacitor didn't implement localization to project.**
After changing to Locale.preferredLanguages[0] it returns phone lang properly.