### PR TITLE
Make iOS correctOrientation default match docs

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -22,7 +22,7 @@ struct CameraSettings {
   var direction: CameraDirection = CameraDirection.rear
   var allowEditing = false
   var shouldResize = false
-  var shouldCorrectOrientation = false
+  var shouldCorrectOrientation = true
   var quality: Float = 1.0
   var width: Float = 0
   var height: Float = 0
@@ -74,7 +74,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
       settings.shouldResize = true
     }
     
-    settings.shouldCorrectOrientation = call.get("correctOrientation", Bool.self, false)!
+    settings.shouldCorrectOrientation = call.get("correctOrientation", Bool.self, true)!
 
     return settings
   }


### PR DESCRIPTION
Docs say correctOrientation is true, but on iOS it was set to false

Closes #1269