### PR TITLE
Move @types/lodash to devDependencies

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -26,6 +26,7 @@
     "@ionic/core": "0.0.2-59",
     "@ionic/pwa-elements": "1.0.1",
     "@types/jest": "^21.1.8",
+    "@types/lodash": "^4.14.120",
     "jest": "^22.0.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.52.0",
@@ -61,7 +62,6 @@
     ]
   },
   "dependencies": {
-    "@types/lodash": "^4.14.120",
     "tslib": "^1.9.0"
   }
 }


### PR DESCRIPTION
@types package is not needed during runtime.
Fixed https://github.com/ionic-team/capacitor/issues/1195