### PR TITLE
feat(init): add an option for setting the webdir of a project.

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,7 +34,7 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
   program
     .command('init [appName] [appId]')
     .description('Initializes a new Capacitor project in the current directory')
-    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets')
+    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets', 'www')
     .action((appName, appId, cmd) => {
       return initCommand(config, appName, appId, cmd.webDir);
     });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,8 +34,9 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
   program
     .command('init [appName] [appId]')
     .description('Initializes a new Capacitor project in the current directory')
-    .action((appName, appId) => {
-      return initCommand(config, appName, appId);
+    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets')
+    .action((appName, appId, cmd) => {
+      return initCommand(config, appName, appId, cmd.webDir);
     });
 
   program

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -1,6 +1,4 @@
 import { Config } from '../config';
-import { OS } from '../definitions';
-import { addCommand } from '../tasks/add';
 import {
   check,
   checkAppId,
@@ -12,13 +10,16 @@ import {
   logFatal,
   mergeConfig,
   printNextSteps,
-  runTask
+  runTask,
 } from '../common';
 import { emoji as _e } from '../util/emoji';
 
 const chalk = require('chalk');
 
-export async function initCommand(config: Config, name: string, id: string) {
+export async function initCommand(config: Config, name: string, id: string, webDir = 'www') {
+  if (webDir === '') {
+    webDir = 'www';
+  }
   try {
     // Get app name
     const appName = await getName(config, name);
@@ -36,12 +37,14 @@ export async function initCommand(config: Config, name: string, id: string) {
     await runTask(`Initializing Capacitor project in ${chalk.blue(config.app.rootDir)}`, async () => {
       config.app.appId = appId;
       config.app.appName = appName;
+      config.app.webDir = webDir;
 
       // Get or create our config
       await getOrCreateConfig(config);
       await mergeConfig(config, {
         appId,
-        appName
+        appName,
+        webDir
       });
     });
 

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -16,7 +16,7 @@ import { emoji as _e } from '../util/emoji';
 
 const chalk = require('chalk');
 
-export async function initCommand(config: Config, name: string, id: string, webDir = 'www') {
+export async function initCommand(config: Config, name: string, id: string, webDir: string) {
   if (webDir === '') {
     webDir = 'www';
   }

--- a/cli/test/init.spec.ts
+++ b/cli/test/init.spec.ts
@@ -59,4 +59,16 @@ describe('Init', () => {
     expect(jsonContents.bundledWebRuntime).toEqual(false);
     expect(jsonContents.webDir).toEqual('www');
   });
+
+  it('Should init a project with webDir passed without a value', async () => {
+    await run(appDir, `init "${APP_NAME}" "${APP_ID}" --web-dir`);
+    expect(await FS.exists('capacitor.config.json')).toBe(true);
+
+    const fileContents = await FS.read('capacitor.config.json');
+    const jsonContents = JSON.parse(fileContents);
+    expect(jsonContents.appId).toEqual(APP_ID);
+    expect(jsonContents.appName).toEqual(APP_NAME);
+    expect(jsonContents.bundledWebRuntime).toEqual(false);
+    expect(jsonContents.webDir).toEqual('www');
+  });
 });

--- a/cli/test/init.spec.ts
+++ b/cli/test/init.spec.ts
@@ -27,5 +27,36 @@ describe('Init', () => {
   it('Should init a project', async () => {
     await run(appDir, `init "${APP_NAME}" "${APP_ID}"`);
     expect(await FS.exists('capacitor.config.json')).toBe(true);
+
+    const fileContents = await FS.read('capacitor.config.json');
+    const jsonContents = JSON.parse(fileContents);
+    expect(jsonContents.appId).toEqual(APP_ID);
+    expect(jsonContents.appName).toEqual(APP_NAME);
+    expect(jsonContents.bundledWebRuntime).toEqual(false);
+    expect(jsonContents.webDir).toEqual('www');
+  });
+
+  it('Should init a project with webDir set', async () => {
+    await run(appDir, `init "${APP_NAME}" "${APP_ID}" --web-dir="build"`);
+    expect(await FS.exists('capacitor.config.json')).toBe(true);
+
+    const fileContents = await FS.read('capacitor.config.json');
+    const jsonContents = JSON.parse(fileContents);
+    expect(jsonContents.appId).toEqual(APP_ID);
+    expect(jsonContents.appName).toEqual(APP_NAME);
+    expect(jsonContents.bundledWebRuntime).toEqual(false);
+    expect(jsonContents.webDir).toEqual('build');
+  });
+
+  it('Should init a project with webDir set', async () => {
+    await run(appDir, `init "${APP_NAME}" "${APP_ID}" --web-dir=""`);
+    expect(await FS.exists('capacitor.config.json')).toBe(true);
+
+    const fileContents = await FS.read('capacitor.config.json');
+    const jsonContents = JSON.parse(fileContents);
+    expect(jsonContents.appId).toEqual(APP_ID);
+    expect(jsonContents.appName).toEqual(APP_NAME);
+    expect(jsonContents.bundledWebRuntime).toEqual(false);
+    expect(jsonContents.webDir).toEqual('www');
   });
 });


### PR DESCRIPTION
This pull request is to add an option to the init command of Capacitor. This option will make it possible to set the `webDir` setting in the capacitor config.  By default it is set to 'www'.

The default works for Angular projects but for React and Vue will require a different directory. By opening up this option it is now possible for the Ionic CLI to set this in the creation of the project.