### PR TITLE
Remove scope on plugin creation

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -98,6 +98,13 @@ export function fixName(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
+export function removeScope(name: string): string {
+  var parts = name.split("/");
+  if (parts.length > 1) {
+    name = parts[parts.length-1];
+  }
+  return name;
+}
 
 export function printPlugins(plugins: Plugin[], platform: string, type: string = 'capacitor') {
   const plural = plugins.length === 1 ? '' : 's';

--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -2,7 +2,7 @@ import { Config } from '../config';
 import { log, logFatal, logInfo, runCommand, runTask, writePrettyJSON, logWarn } from '../common';
 import { emoji } from '../util/emoji';
 import { existsAsync, mkdirAsync, writeFileAsync, readFileAsync } from '../util/fs';
-import { fixName } from '../plugin'
+import { fixName, removeScope } from '../plugin'
 
 import { copy, move, mkdirs, unlink } from 'fs-extra';
 import { dirname, join } from 'path';
@@ -103,7 +103,7 @@ export async function newPlugin(config: Config) {
   console.log('\n');
 
   if (answers.confirm) {
-    const pluginPath = answers.name;
+    const pluginPath = removeScope(answers.name);
     const domain = answers.domain;
     const className = answers.className;
 


### PR DESCRIPTION
If the user provides a scope on the plugin name it was failing to create the plugin, now it removes the scope from the folder name