### PR TITLE
Android pushNotificationActionPerformed 

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -3,6 +3,8 @@ package com.getcapacitor.plugin;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.net.Uri;
 
@@ -49,6 +51,24 @@ public class PushNotifications extends Plugin {
     if (lastMessage != null) {
       fireNotification(lastMessage);
       lastMessage = null;
+    }
+  }
+
+  @Override
+  protected void handleOnNewIntent(Intent data) {
+    super.handleOnNewIntent(data);
+    Bundle bundle = data.getExtras();
+    if(bundle != null && bundle.containsKey("google.message_id")) {
+      JSObject notificationJson = new JSObject();
+      for (String key : bundle.keySet()) {
+        Object value = bundle.get(key);
+        String valueStr = (value != null) ? value.toString() : null;
+        notificationJson.put(key, valueStr);
+      }
+      JSObject dataJson = new JSObject();
+      dataJson.put("actionId", "tap");
+      dataJson.put("notificationRequest", notificationJson);
+      notifyListeners("pushNotificationActionPerformed", dataJson, true);
     }
   }
 


### PR DESCRIPTION
This PR does not solve all of the issues regarding pushNotificationActionPerformed event as described in #1221  and #1181 but, I believe it is a step closer, and at least gets people a little unblocked.

App launchMode must be set to singleTask or handleOnNewIntent wont be called as described in #971 

The returned data does not contain the original notification (like on iOS), since I'm not sure how to get it on Android. I'm just passing everything I get from extras bundle to notificationRequest property. It seems that extras contain stuff from notification's data property.

Even it this gets merged there is still a problem that pushNotificationActionPerformed event is not fired if the app is closed (not in background) when notification is tapped. I'm not sure how to solve this.

