### PR TITLE
Add timestamp and altitudeAccuracy to native geolocation plugins

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
@@ -7,6 +7,7 @@ import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
+import android.os.Build;
 import android.os.Bundle;
 
 import com.getcapacitor.JSObject;
@@ -216,10 +217,14 @@ public class Geolocation extends Plugin {
     JSObject ret = new JSObject();
     JSObject coords = new JSObject();
     ret.put("coords", coords);
+    ret.put("timestamp", location.getTime());
     coords.put("latitude", location.getLatitude());
     coords.put("longitude", location.getLongitude());
     coords.put("accuracy", location.getAccuracy());
     coords.put("altitude", location.getAltitude());
+    if (Build.VERSION.SDK_INT >= 26) {
+      coords.put("altitudeAccuracy", location.getVerticalAccuracyMeters());
+    }
     coords.put("speed", location.getSpeed());
     coords.put("heading", location.getBearing());
     return ret;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -721,12 +721,29 @@ export interface GeolocationPlugin extends Plugin {
 
 export interface GeolocationPosition {
   /**
+   * Creation timestamp for coords
+   */
+  timestamp: number;
+  /**
    * The GPS coordinates along with the accuracy of the data
    */
   coords: {
+    /**
+     * Latitude in decimal degrees
+     */
     latitude: number;
+    /**
+     * longitude in decimal degrees
+     */
     longitude: number;
+    /**
+     * Accuracy level of the latitude and longitude coordinates in meters
+     */
     accuracy: number;
+    /**
+     * Accuracy level of the altitude coordinate in meters (if available)
+     */
+    altitudeAccuracy?: number;
     /**
      * The altitude the user is at (if available)
      */

--- a/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
@@ -63,7 +63,7 @@ class GetLocationHandler: NSObject, CLLocationManagerDelegate {
     coords["altitudeAccuracy"] = location.verticalAccuracy
     coords["speed"] = location.speed
     coords["heading"] = location.course
-    ret["timestamp"] = NSNumber(value: Double((location.timestamp.timeIntervalSince1970 * 1000)))
+    ret["timestamp"] = NSNumber(value: Int((location.timestamp.timeIntervalSince1970 * 1000)))
     ret["coords"] = coords
     return ret
   }

--- a/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
@@ -60,8 +60,10 @@ class GetLocationHandler: NSObject, CLLocationManagerDelegate {
     coords["longitude"] = location.coordinate.longitude
     coords["accuracy"] = location.horizontalAccuracy
     coords["altitude"] = location.altitude
+    coords["altitudeAccuracy"] = location.verticalAccuracy
     coords["speed"] = location.speed
     coords["heading"] = location.course
+    ret["timestamp"] = NSNumber(value: Double((location.timestamp.timeIntervalSince1970 * 1000)))
     ret["coords"] = coords
     return ret
   }


### PR DESCRIPTION
This adds the `timestamp` and `altitudeAccuracy` properties to the built in Geolocation plugin to match the [current web API for geolocation](https://developer.mozilla.org/en-US/docs/Web/API/Position), as well as the equivalent [Cordova plugin](https://github.com/apache/cordova-plugin-geolocation).