### PR TITLE
Improve pushNotificationActionPerformed

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -60,15 +60,21 @@ public class PushNotifications extends Plugin {
     Bundle bundle = data.getExtras();
     if(bundle != null && bundle.containsKey("google.message_id")) {
       JSObject notificationJson = new JSObject();
+      JSObject dataObject = new JSObject();
       for (String key : bundle.keySet()) {
-        Object value = bundle.get(key);
-        String valueStr = (value != null) ? value.toString() : null;
-        notificationJson.put(key, valueStr);
+        if (key.equals("google.message_id")) {
+          notificationJson.put("id", bundle.get(key));
+        } else {
+          Object value = bundle.get(key);
+          String valueStr = (value != null) ? value.toString() : null;
+          dataObject.put(key, valueStr);
+        }
       }
-      JSObject dataJson = new JSObject();
-      dataJson.put("actionId", "tap");
-      dataJson.put("notificationRequest", notificationJson);
-      notifyListeners("pushNotificationActionPerformed", dataJson, true);
+      notificationJson.put("data", dataObject);
+      JSObject actionJson = new JSObject();
+      actionJson.put("actionId", "tap");
+      actionJson.put("notification", notificationJson);
+      notifyListeners("pushNotificationActionPerformed", actionJson, true);
     }
   }
 
@@ -186,6 +192,7 @@ public class PushNotifications extends Plugin {
     JSObject remoteMessageData = new JSObject();
 
     JSObject data = new JSObject();
+    remoteMessageData.put("id", remoteMessage.getMessageId());
     for (String key : remoteMessage.getData().keySet()) {
       Object value = remoteMessage.getData().get(key);
       data.put(key, value);

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1261,10 +1261,10 @@ export interface PushNotification {
   title?: string;
   subtitle?: string;
   body?: string;
-  id?: string;
+  id: string;
   badge?: number;
   notification?: any;
-  data?: any;
+  data: any;
   click_action?: string;
   link?: string;
 }
@@ -1272,7 +1272,7 @@ export interface PushNotification {
 export interface PushNotificationActionPerformed {
   actionId: string;
   inputValue?: string;
-  notificationRequest: any;
+  notification: PushNotification;
 }
 
 export interface PushNotificationToken {

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -110,7 +110,7 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
 
     if (originalNotificationRequest.trigger?.isKind(of: UNPushNotificationTrigger.self))! {
       plugin = (self.bridge?.getOrLoadPlugin(pluginName: "PushNotifications"))!
-      data["notificationRequest"] = makePushNotificationRequestJSObject(originalNotificationRequest)
+      data["notification"] = makePushNotificationRequestJSObject(originalNotificationRequest)
       action = "pushNotificationActionPerformed"
     } else {
       data["notificationRequest"] = makeNotificationRequestJSObject(originalNotificationRequest)


### PR DESCRIPTION
Changed on `PushNotificationActionPerformed` from `notificationRequest` of type `any` to `notification` of type `PushNotification`.
Made id and data not optional and made sure they are always there on iOS and Android.

Closes #1181