### PR TITLE
Inject Capacitor into https urls too

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -441,7 +441,6 @@ public class WebViewLocalServer {
             if (!path.startsWith(capacitorFileStart)) {
               path = basePath + url.getPath();
             }
-            System.out.println("path "+path);
             stream = protocolHandler.openFile(path);
           } else {
             stream = protocolHandler.openAsset(assetPath + path);
@@ -457,6 +456,7 @@ public class WebViewLocalServer {
 
     for (String authority: authorities) {
       registerUriForScheme(capacitorScheme, handler, authority);
+      registerUriForScheme("https", handler, authority);
     }
 
   }


### PR DESCRIPTION
We are only injecting Capacitor when the url scheme matches the Capacitor one (http), make it work for https too

Closes #1381