### PR TITLE
Add workaround for Xcode 10 CocoaPods caching

### DIFF
--- a/ios-template/App/Podfile
+++ b/ios-template/App/Podfile
@@ -1,6 +1,11 @@
 platform :ios, '11.0'
 use_frameworks!
 
+# workaround to avoid Xcode 10 caching of Pods that requires
+# Product -> Clean Build Folder after new Cordova plugins installed
+# Requires CocoaPods 1.6 or newer
+install! 'cocoapods', :disable_input_output_paths => true
+
 def capacitor_pods
   # Automatic Capacitor Pod dependencies, do not delete
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'


### PR DESCRIPTION
Xcode 10 caches or don't rebuild existing Pods, so when adding new Cordova plugins users need to do a `Product -> Clean Build Folder` before running or plugins won't be detected.
Also if developing a Capacitor plugin or editing Capacitor source code, same thing happens.
This workaround prevents the caching but requires CocoaPods 1.6. 