### PR TITLE
[core][filesystem plugin] fixing writeFile when no subdir is used

### DIFF
--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -147,8 +147,11 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
 
     let parentEntry = await this.dbRequest('get', [parentPath]) as EntryObj;
     if (parentEntry === undefined) {
-      const parentArgPath = parentPath.substr(parentPath.indexOf('/', 1));
-      await this.mkdir({path: parentArgPath, directory: options.directory, createIntermediateDirectories: true})
+      const subDirIndex = parentPath.indexOf('/', 1);
+      if (subDirIndex !== -1) {
+        const parentArgPath = parentPath.substr(subDirIndex);
+        await this.mkdir({path: parentArgPath, directory: options.directory, createIntermediateDirectories: true})
+      }
     }
     const now = Date.now();
     const pathObj: EntryObj = {


### PR DESCRIPTION
I have found an issue writting a file using filesystem core plugin (on the web platform); The plugin tries to create the "A" directory, when trying to save the following structure:

```ts
const savingFile = <FileWriteOptions>{
  directory: FilesystemDirectory.Data,
  data,
  path: '/' + identifier
};
```

Since  FilesystemDirectory.Data turns into "DATA", I have noticed a substr was being used with an "-1" incorrectly handled from an indexOf; so "A" folder was incorrectly being created.

