### PR TITLE
Notifications crash fix and handled extra argument value

### DIFF
--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -45,7 +45,7 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
     var presentationOptions: UNNotificationPresentationOptions = [];
 
     var notificationData = makeNotificationRequestJSObject(request)
-    if (request.trigger?.isKind(of: UNPushNotificationTrigger.self))! {
+    if (request.trigger?.isKind(of: UNPushNotificationTrigger.self) ?? false) {
       plugin = (self.bridge?.getOrLoadPlugin(pluginName: "PushNotifications"))!
       let options = plugin.getConfigValue("presentationOptions") as? [String] ?? ["badge"]
 
@@ -116,7 +116,7 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
     var plugin: CAPPlugin
     var action = "localNotificationActionPerformed"
 
-    if (originalNotificationRequest.trigger?.isKind(of: UNPushNotificationTrigger.self))! {
+    if (originalNotificationRequest.trigger?.isKind(of: UNPushNotificationTrigger.self) ?? false) {
       plugin = (self.bridge?.getOrLoadPlugin(pluginName: "PushNotifications"))!
       data["notification"] = makePushNotificationRequestJSObject(originalNotificationRequest)
       action = "pushNotificationActionPerformed"
@@ -133,7 +133,8 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
    */
   func makeNotificationRequestJSObject(_ request: UNNotificationRequest) -> JSObject {
     return [
-      "id": request.identifier
+      "id": request.identifier,
+      "extra": request.content.userInfo
     ]
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -164,12 +164,14 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     let actionTypeId = notification["actionTypeId"] as? String
     let sound = notification["sound"] as? String
     let attachments = notification["attachments"] as? JSArray
+    let extra = notification["extra"] as? JSObject ?? [:]
     
     let content = UNMutableNotificationContent()
     content.title = NSString.localizedUserNotificationString(forKey: title, arguments: nil)
     content.body = NSString.localizedUserNotificationString(forKey: body,
                                                             arguments: nil)
     
+    content.userInfo = extra
     if actionTypeId != nil {
       content.categoryIdentifier = actionTypeId!
     }


### PR DESCRIPTION
Issue: 

1. After receiving Push/Local Notifications app crashing immediately.
2. In iOS also handled the extra parameter which is not receiving back when notification fired.
