### PR TITLE
Set open wait to false to not block the terminal

### DIFF
--- a/cli/src/android/open.ts
+++ b/cli/src/android/open.ts
@@ -21,7 +21,7 @@ export async function openAndroid(config: Config) {
       break;
     case OS.Windows:
       try {
-        await opn(dir, { app: config.windows.androidStudioPath, wait: true });
+        await opn(dir, { app: config.windows.androidStudioPath, wait: false });
       } catch (e) {
         logError('Unable to launch Android Studio. Make sure the latest version of Android Studio is installed, or,' +
                  'if you\'ve installed Android Studio in a custom location, configure "windowsAndroidStudioPath" ' +
@@ -45,7 +45,7 @@ export async function openAndroid(config: Config) {
       };
 
       try {
-        await opn(dir, { app: config.linux.androidStudioPath, wait: true });
+        await opn(dir, { app: config.linux.androidStudioPath, wait: false });
       } catch (e) {
         linuxError();
       }


### PR DESCRIPTION
wait true blocks the terminal until Android Studio is closed, setting it to false to just launch without blocking. 