### PR TITLE
1381 - PR1128 broke my use case AKA star mask in `server.allowNavigation` 

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/UriMatcher.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/UriMatcher.java
@@ -18,6 +18,8 @@ package com.getcapacitor;
 
 import android.net.Uri;
 
+import com.getcapacitor.util.HostMask;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -96,7 +98,9 @@ public class UriMatcher {
       if (j == numChildren) {
         // Child not found, create it
         child = new UriMatcher();
-        if (token.equals("**")) {
+        if(i == -1 && token.contains("*")) {
+          child.mWhich = MASK;
+        } else if (token.equals("**")) {
           child.mWhich = REST;
         } else if (token.equals("*")) {
           child.mWhich = TEXT;
@@ -148,6 +152,11 @@ public class UriMatcher {
         UriMatcher n = list.get(j);
         which_switch:
         switch (n.mWhich) {
+          case MASK:
+            if(HostMask.Parser.parse(n.mText).matches(u)) {
+              node = n;
+            }
+          break;
           case EXACT:
             if (n.mText.equals(u)) {
               node = n;
@@ -174,6 +183,7 @@ public class UriMatcher {
   private static final int EXACT = 0;
   private static final int TEXT = 1;
   private static final int REST = 2;
+  private static final int MASK = 3;
 
   private Object mCode;
   private int mWhich;

--- a/android/capacitor/src/main/java/com/getcapacitor/util/HostMask.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/HostMask.java
@@ -1,0 +1,125 @@
+package com.getcapacitor.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public interface HostMask {
+    
+    boolean matches(String host);
+
+    class Parser {
+        private static HostMask NOTHING = new Nothing();
+
+        public static HostMask parse(String[] masks) {
+            return masks == null
+                    ? NOTHING
+                    : HostMask.Any.parse(masks);
+        }
+        public static HostMask parse(String mask) {
+            return mask == null
+                    ? NOTHING
+                    : HostMask.Simple.parse(mask);
+        }
+    }
+
+    class Simple implements HostMask {
+        private final List<String> maskParts;
+
+        private Simple(List<String> maskParts) {
+            if(maskParts == null) {
+                throw new IllegalArgumentException("Mask parts can not be null");
+            }
+            this.maskParts = maskParts;
+        }
+
+        static Simple parse(String mask) {
+            List<String> parts = Util.splitAndReverse(mask);
+            return new Simple(parts);
+        }
+
+
+        @Override
+        public boolean matches(String host) {
+            if(host == null) {
+                return false;
+            }
+            List<String> hostParts = Util.splitAndReverse(host);
+            int hostSize = hostParts.size();
+            int maskSize = maskParts.size();
+            if(hostSize != maskSize) {
+                return false;
+            }
+
+            int minSize = Math.min(hostSize, maskSize);
+
+            for(int i=0; i < minSize; i++) {
+                String maskPart = maskParts.get(i);
+                String hostPart = hostParts.get(i);
+                if(!Util.matches(maskPart, hostPart)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+    }
+
+    class Any implements HostMask {
+        private final List<? extends HostMask> masks;
+
+        Any(List<? extends HostMask> masks) {
+            this.masks = masks;
+        }
+
+        @Override
+        public boolean matches(String host) {
+            for(HostMask mask: masks) {
+                if(mask.matches(host)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static Any parse(String... rawMasks) {
+            List<HostMask.Simple> masks = new ArrayList<>();
+            for(String raw: rawMasks) {
+                masks.add(HostMask.Simple.parse(raw));
+            }
+            return new Any(masks);
+        }
+    }
+
+    class Nothing implements HostMask{
+
+        @Override
+        public boolean matches(String host) {
+            return false;
+        }
+    }
+
+    class Util {
+        static boolean matches(String mask, String string) {
+            if(mask == null) {
+                return false;
+            } else if("*".equals(mask)) {
+                return true;
+            } else if(string == null) {
+                return false;
+            } else {
+                return mask.toUpperCase().equals(string.toUpperCase());
+            }
+        }
+        static List<String> splitAndReverse(String string) {
+            if(string == null) {
+                throw new IllegalArgumentException("Can not split null argument");
+            }
+            List<String> parts = Arrays.asList(string.split("\\."));
+            Collections.reverse(parts);
+            return parts;
+        }
+    }
+}
+

--- a/android/capacitor/src/test/java/com/getcapacitor/util/HostMaskTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/util/HostMaskTest.java
@@ -1,0 +1,70 @@
+package com.getcapacitor.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.getcapacitor.util.HostMask.Util;
+
+public class HostMaskTest {
+
+    @Test
+    public void testParser() {
+        assertEquals(HostMask.Any.class, HostMask.Parser.parse("*,example.org,*.example.org".split(",")).getClass());
+        assertEquals(HostMask.Simple.class, HostMask.Parser.parse("*").getClass());
+        assertEquals(HostMask.Nothing.class, HostMask.Parser.parse((String) null).getClass());
+    }
+
+    @Test
+    public void testAny() {
+        HostMask mask = HostMask.Any.parse("*", "*.example.org", "example.org");
+        assertTrue(mask.matches("org"));
+        assertTrue(mask.matches("example.org"));
+        assertTrue(mask.matches("www.example.org"));
+        assertFalse(mask.matches("imap.mail.example.org"));
+        assertFalse(mask.matches("another.org"));
+        assertFalse(mask.matches("www.another.org"));
+        assertFalse(mask.matches(null));
+    }
+
+
+    @Test
+    public void testSimple() {
+        HostMask mask = HostMask.Simple.parse("*.org");
+        assertTrue(mask.matches("example.org"));
+        assertFalse(mask.matches("org"));
+        assertFalse(mask.matches("www.example.org"));
+        assertFalse("Null host never matches", mask.matches(null));
+    }
+
+    @Test
+    public void testSimpleExample1() {
+        HostMask mask = HostMask.Simple.parse("*.example.org");
+        assertFalse("Null host never matches", mask.matches("example.org"));
+    }
+
+    @Test
+    public void testSimpleExample2() {
+        HostMask mask = HostMask.Simple.parse("*");
+        assertFalse("Single star does not match with 2nd level domain", mask.matches("example.org"));
+    }
+
+    @Test
+    public void test192168ForLocalTestingSakes() {
+        HostMask mask = HostMask.Simple.parse("192.168.*.*");
+        assertTrue("Matches 192.168.*.*", mask.matches("192.168.2.5"));
+        assertFalse("Matches NOT 192.168.*.*", mask.matches("192.66.2.5"));
+    }
+
+    @Test
+    public void testUtil() {
+        assertTrue("Everything matches *", Util.matches("*", "*"));
+        assertTrue("Everything matches *", Util.matches("*", "org"));
+        assertTrue(Util.matches("org", "org"));
+        assertTrue("Match is case insensitive", Util.matches("ORG", "org"));
+        assertFalse("Nothing matches null mask", Util.matches(null, "org"));
+        assertFalse("Nothing matches null mask", Util.matches(null, null));
+    }
+
+
+}


### PR DESCRIPTION
Makes it possible use star masks in `server.allowNavigation` option of `capacitor.config.json`.
Examples:
- `*.example.com` would match `app.example.com`, `www.example.com` but not `example.com`
- `192.168.*.*` is valid

What the changes are:
- `HostMask` is a matcher, it parses text into masks and check strings against it `boolean matches(String host)`, i.e. `HostMask.Parser.parse("192.168.*.*).matches("192.168.1.1")` would return `true`
- `HostMaskTest` is a test suite for the above, more mask examples are inside
- `UriMatcher` was tought to use `HostMask` for the host part
- `Bridge` contained some matching of its own, that was replaced with use of `HostMask`

Closes #1381 
Closes #1389