### PR TITLE
Add cordova-plugin-braintree to incompatible plugins

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -298,5 +298,5 @@ export function getIncompatibleCordovaPlugins(){
   return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
   "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console",
   "cordova-plugin-compat", "cordova-plugin-music-controls", "cordova-plugin-add-swift-support",
-  "cordova-plugin-ionic-keyboard"];
+  "cordova-plugin-ionic-keyboard", "cordova-plugin-braintree"];
 }


### PR DESCRIPTION
Doesn't build on iOS because of problems with its .framework files. 