### PR TITLE
Remove fireos from getPlatform

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
@@ -73,9 +73,6 @@ public class Device extends Plugin {
   }
 
   private String getPlatform() {
-    if (android.os.Build.MANUFACTURER.equalsIgnoreCase("Amazon")) {
-      return "amazon-fireos";
-    }
     return "android";
   }
 


### PR DESCRIPTION
We don't support fireos and users can guess if it's an amazon device from `manufacturer` property, so removing fireos from the return as it's not a real platform right now. 