### PR TITLE
Limit the Device platform return to 4 values

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -402,9 +402,9 @@ export interface DeviceInfo {
    */
   model: string;
   /**
-   * The device platform (lowercase). For example, "ios", "android", or "web"
+   * The device platform (lowercase).
    */
-  platform: string;
+  platform: 'ios' | 'android' | 'electron' | 'web';
   /**
    * The UUID of the device as available to the app. This identifier may change
    * on modern mobile platforms that only allow per-app install UUIDs.

--- a/core/src/web/device.ts
+++ b/core/src/web/device.ts
@@ -31,7 +31,7 @@ export class DevicePluginWeb extends WebPlugin implements DevicePlugin {
 
     return Promise.resolve({
       model: uaFields.model,
-      platform: "web",
+      platform: <'web'> 'web',
       appVersion: '',
       osVersion: uaFields.osVersion,
       manufacturer: navigator.vendor,


### PR DESCRIPTION
Platform can only be 'ios', 'android', 'electron' or 'web', so make Device.getInfo platform to only allow one of those values.

Closes #1177