### PR TITLE
Implement convertFileSrc for getting compatible urls

### DIFF
--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -135,6 +135,22 @@
     return this.Plugins.hasOwnProperty(name);
   }
 
+  capacitor.convertFileSrc = function convertFileSrc(url) {
+    if (!url) {
+      return url;
+    }
+    if (url.startsWith('/')) {
+      return window.WEBVIEW_SERVER_URL + '/_capacitor_file_' + url;
+    }
+    if (url.startsWith('file://')) {
+      return window.WEBVIEW_SERVER_URL + url.replace('file://', '/_capacitor_file_');
+    }
+    if (url.startsWith('content://')) {
+      return window.WEBVIEW_SERVER_URL + url.replace('content:/', '/_capacitor_content_');
+    }
+    return url;
+  }
+
   /**
    * Send a plugin method call to the native layer
    */
@@ -504,19 +520,7 @@
   }
 
   win.Ionic.WebView.convertFileSrc = function(url) {
-    if (!url) {
-      return url;
-    }
-    if (url.startsWith('/')) {
-      return window.WEBVIEW_SERVER_URL + '/_capacitor_file_' + url;
-    }
-    if (url.startsWith('file://')) {
-      return window.WEBVIEW_SERVER_URL + url.replace('file://', '/_capacitor_file_');
-    }
-    if (url.startsWith('content://')) {
-      return window.WEBVIEW_SERVER_URL + url.replace('content:/', '/_capacitor_content_');
-    }
-    return url;
+    return Capacitor.convertFileSrc(url);
   }
 
 })(window);

--- a/core/src/definitions.ts
+++ b/core/src/definitions.ts
@@ -73,6 +73,7 @@ export interface Capacitor {
   isNative?: boolean;
   platform?: string;
   isPluginAvailable: (name: string) => boolean;
+  convertFileSrc:(filePath: string) => string;
   toNative?: (pluginId: string, methodName: string, options: any, storedCallback?: StoredCallback) => void;
   fromNative?: (result: PluginResult) => void;
   withPlugin?: (pluginId: string, fn: Function) => void;

--- a/core/src/web-runtime.ts
+++ b/core/src/web-runtime.ts
@@ -38,6 +38,10 @@ export class CapacitorWeb {
     return this.Plugins.hasOwnProperty(name);
   }
 
+  convertFileSrc(filePath: string) {
+    return filePath;
+  }
+
   handleError(e: Error) {
     console.error(e);
   }

--- a/electron/src/runtime.ts
+++ b/electron/src/runtime.ts
@@ -38,6 +38,10 @@ export class CapacitorElectron {
     return this.Plugins.hasOwnProperty(name);
   }
 
+  convertFileSrc(filePath: string) {
+    return filePath;
+  }
+
   handleError(e: Error) {
     console.error(e);
   }


### PR DESCRIPTION
`Ionic.WebView.convertFileSrc` was implemented for the same purpose, but that feels weird for non Ionic developers, so added `convertFileSrc` to Capacitor object.