### PR TITLE
Make generated plugin use npm version of @capacitor/ios

### DIFF
--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -237,7 +237,8 @@ function generatePackageJSON(answers: any) {
       '@capacitor/core': 'latest'
     },
     devDependencies: {
-      'typescript': '^3.2.4'
+      'typescript': '^3.2.4',
+      '@capacitor/ios': 'latest'
     },
     files: [
       'dist/',

--- a/plugin-template/ios/Podfile
+++ b/plugin-template/ios/Podfile
@@ -1,16 +1,13 @@
-# Uncomment the next line to define a global platform for your project
 platform :ios, '11.0'
 
 target 'Plugin' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-
-  # Pods for IonicRunner
-  pod 'Capacitor'
+  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
 end
 
 target 'PluginTests' do
   use_frameworks!
 
-  pod 'Capacitor'
+  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
 end


### PR DESCRIPTION
Add @capacitor/ios as devDependency and make the Podfile point to it to use latest version instead of the old one that CocoaPods return

Closes #1237