### PR TITLE
Make generated plugin use npm version of @capacitor/android

### DIFF
--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -238,7 +238,8 @@ function generatePackageJSON(answers: any) {
     },
     devDependencies: {
       'typescript': '^3.2.4',
-      '@capacitor/ios': 'latest'
+      '@capacitor/ios': 'latest',
+      '@capacitor/android': 'latest'
     },
     files: [
       'dist/',

--- a/plugin-template/android/plugin/build.gradle
+++ b/plugin-template/android/plugin/build.gradle
@@ -34,15 +34,12 @@ repositories {
     google()
     jcenter()
     mavenCentral()
-    maven {
-        url  "https://dl.bintray.com/ionic-team/capacitor"
-    }
 }
 
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'ionic-team:capacitor-android:1+'
+    implementation project(':capacitor-android')
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/plugin-template/android/settings.gradle
+++ b/plugin-template/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':capacitor-android'
+project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')


### PR DESCRIPTION
Use a local @capacitor/android from npm instead of `implementation 'ionic-team:capacitor-android:1+'`, which was causing problems because of fetching an old version and causes version conflicts when imported.

Closes #978
