### PR TITLE
Remove Camera permission from Camera docs

### DIFF
--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -21,7 +21,6 @@ Read about [Setting iOS Permissions](../../ios/configuration/) in the [iOS Guide
 This API requires the following permissions be added to your `AndroidManifest.xml`:
 
 ```xml
-<uses-permission android:name="android.permission.CAMERA" />
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```

--- a/site/src/assets/docs-content/apis/camera/index.html
+++ b/site/src/assets/docs-content/apis/camera/index.html
@@ -10,8 +10,7 @@ Key:     <code>NSCameraUsageDescription</code></p>
 <p>Read about <a href="../../ios/configuration/">Setting iOS Permissions</a> in the <a href="../../ios/">iOS Guide</a> for more information on setting iOS permissions in Xcode</p>
 <h2 id="android-notes">Android Notes</h2>
 <p>This API requires the following permissions be added to your <code>AndroidManifest.xml</code>:</p>
-<pre><code class="lang-xml"><span class="hljs-tag">&lt;<span class="hljs-name">uses-permission</span> <span class="hljs-attr">android:name</span>=<span class="hljs-string">"android.permission.CAMERA"</span> /&gt;</span>
-<span class="hljs-tag">&lt;<span class="hljs-name">uses-permission</span> <span class="hljs-attr">android:name</span>=<span class="hljs-string">"android.permission.READ_EXTERNAL_STORAGE"</span>/&gt;</span>
+<pre><code class="lang-xml"><span class="hljs-tag">&lt;<span class="hljs-name">uses-permission</span> <span class="hljs-attr">android:name</span>=<span class="hljs-string">"android.permission.READ_EXTERNAL_STORAGE"</span>/&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">uses-permission</span> <span class="hljs-attr">android:name</span>=<span class="hljs-string">"android.permission.WRITE_EXTERNAL_STORAGE"</span> /&gt;</span>
 </code></pre>
 <p>The first permission is for Camera access, and the storage permissions are for reading/saving photo files.</p>


### PR DESCRIPTION
Camera permission is not needed for using Camera plugin, so removing it from the docs.