### PR TITLE
Fix conflict between Capacitor and Cordova document events

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -206,7 +206,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
   }
 
   public void triggerDocumentEvent(final String eventName) {
-    eval("cordova.fireDocumentEvent('"+ eventName + "');", new ValueCallback<String>() {
+    eval("window.Capacitor.triggerEvent('" + eventName + "', 'document');", new ValueCallback<String>() {
       @Override
       public void onReceiveValue(String s) {
       }

--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -309,9 +309,14 @@
   }
 
   capacitor.triggerEvent = function(eventName, target, data) {
-    var event = new CustomEvent(eventName, { detail: data || {} });
+    var eventData = data || {};
+    var event = new CustomEvent(eventName, { detail: eventData });
     if (target === "document") {
-      document.dispatchEvent(event);
+      if (cordova.fireDocumentEvent) {
+        cordova.fireDocumentEvent(eventName, eventData);
+      } else {
+        document.dispatchEvent(event);
+      }
     } else if (target === "window") {
       window.dispatchEvent(event);
     } else {

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegate.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegate.h
@@ -41,6 +41,8 @@ typedef NSURL* (^ UrlTransformerBlock)(NSURL*);
 // without reason. Without the run-loop delay, alerts used in JS callbacks may result
 // in dead-lock. This method must be called from the UI thread.
 - (void)evalJs:(NSString*)js scheduledOnRunLoop:(BOOL)scheduledOnRunLoop;
+// Run the javascript
+- (void)evalJsHelper2:(NSString*)js;
 // Runs the given block on a background thread using a shared thread-pool.
 - (void)runInBackground:(void (^)())block;
 // Returns the User-Agent of the associated UIWebView.

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
@@ -66,12 +66,12 @@
 
 - (void)onAppDidEnterBackground:(NSNotification*)notification
 {
-  [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('pause', null, true);" scheduledOnRunLoop:NO];
+  [self.commandDelegate evalJsHelper2:@"window.Capacitor.triggerEvent('pause', 'document');"];
 }
 
 - (void)onAppWillEnterForeground:(NSNotification*)notification
 {
-  [self.commandDelegate evalJs:@"cordova.fireDocumentEvent('resume');"];
+  [self.commandDelegate evalJsHelper2:@"window.Capacitor.triggerEvent('resume', 'document');"];
 }
 
 @end


### PR DESCRIPTION
When Cordova is present it prevents Capacitor document events from firing, so use `cordova.fireDocumentEvent` when available.
Also makes possible to fire pause and resume events even if no cordova plugins are present.

Closes #1443