### PR TITLE
Return error message on Camera web plugin

### DIFF
--- a/core/src/web/camera.ts
+++ b/core/src/web/camera.ts
@@ -28,7 +28,7 @@ export class CameraPluginWeb extends WebPlugin implements CameraPlugin {
         const photo = e.detail;
 
         if (photo === null) {
-          reject();
+          reject('User cancelled photos app');
         } else {
           resolve(await this._getCameraPhoto(photo, options));
         }


### PR DESCRIPTION
Add error message when user clicks the close button instead of taking a picture