### PR TITLE
Add more non-interactive checks for when using as subprocess

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join, parse, resolve } from 'path';
 import { copyAsync, existsAsync, readFileAsync, renameAsync, writeFileAsync } from './util/fs';
 import { existsSync, readFile } from 'fs';
 import { emoji as _e } from './util/emoji';
+import { isInteractive } from './util/term';
 import * as semver from 'semver';
 
 import * as inquirer from 'inquirer';
@@ -327,7 +328,7 @@ export function getNpmClient(config: Config, npmClient: string): Promise<string>
       // const isYarnInstalled
       exec('yarn --version', async (err, stdout) => {
         // Don't show prompt if yarn is not installed
-        if (err) {
+        if (err || !isInteractive()) {
           resolve('npm');
         } else {
           const answers = await inquirer.prompt([{

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -15,6 +15,7 @@ import {
   runTask,
 } from '../common';
 import { emoji as _e } from '../util/emoji';
+import { checkInteractive } from '../util/term';
 
 const chalk = require('chalk');
 
@@ -23,6 +24,9 @@ export async function initCommand(config: Config, name: string, id: string, webD
     webDir = 'www';
   }
   try {
+    if (!checkInteractive(name, id)) {
+      return;
+    }
     // Get app name
     const appName = await getName(config, name);
     // Get app identifier


### PR DESCRIPTION
Add checkInteractive for init command and set npm as default package installer in non interactive cases if no option is selected