### PR TITLE
Open links with any scheme outside the app

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -171,13 +171,11 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
         }
       }
     }
-    if let scheme = navUrl.scheme {
-      let validSchemes = ["tel", "mailto", "facetime", "sms", "maps", "itms-services", "http", "https"]
-      if validSchemes.contains(scheme) && navUrl.absoluteString.range(of: hostname!) == nil && (navigationAction.targetFrame == nil || (navigationAction.targetFrame?.isMainFrame)!) {
-        UIApplication.shared.open(navUrl, options: [:], completionHandler: nil)
-        decisionHandler(.cancel)
-        return
-      }
+
+    if navUrl.absoluteString.range(of: hostname!) == nil && (navigationAction.targetFrame == nil || (navigationAction.targetFrame?.isMainFrame)!) {
+      UIApplication.shared.open(navUrl, options: [:], completionHandler: nil)
+      decisionHandler(.cancel)
+      return
     }
 
     // TODO: Allow plugins to handle this. See


### PR DESCRIPTION
At the moment, only links with `target="_blank"` are opening outside the app or if it's one of the allowed schemes.
Let any link with any scheme to open outside even if target is not _blank

Closes #839
