### PR TITLE
Give access to the local server.

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -801,4 +801,8 @@ public class Bridge {
   public String getLocalUrl() {
     return localUrl;
   }
+
+  public WebViewLocalServer getLocalServer() {
+    return localServer;
+  }
 }


### PR DESCRIPTION
Sometimes it would be helpful if plugins had access to the local server. A possible use case can be seen in https://stackoverflow.com/a/55916297/1004651, where a plugin uses `ServiceWorkerController` to intercept the requests that a service worker makes and treats them the same way as "normal" requests.