### PR TITLE
[Docs] "Getting Started" and "With Ionic" updates

### DIFF
--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -5,9 +5,7 @@ There are two ways to start using Capacitor: adding Capacitor to an existing fro
 Capacitor provides a native mobile runtime and API layer for web apps. It does _not_ come with any specific
 set of UI controls which you will most likely need unless you're building a game or something similar.
 
-We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as [Ionic](https://ionicframework.com)),
-though we also provide a blank starter for apps that aren't using a frontend UI framework, and a starter that uses Ionic and
-is ready for building a production-ready native app and Progressive Web App.
+We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as [Ionic](https://ionicframework.com)).
 
 ## Before you start
 
@@ -47,15 +45,7 @@ npx cap add ios
 npx cap add electron
 ```
 
-Capacitor is now installed in your project 🎉
-
-## Using Capacitor Starter with Ionic Framework
-
-Integration into the Ionic CLI is coming soon.
-
-For now, create a new ionic app using `ionic start`, then follow the steps above to add
-Capacitor to an existing web app (in this case, your new Ionic app).
-
+🎉 Capacitor is now installed in your project. 🎉
 
 ## Optional: Starting a fresh project
 
@@ -69,8 +59,7 @@ npx @capacitor/cli create
 
 This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.
 
-This will create a very simple starting app with no UI library that you should nuke before
-starting your own app.
+This will create a very simple starting app with no UI library.
 
 ## Where to go next
 

--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -27,15 +27,15 @@ cd my-app
 npm install --save @capacitor/core @capacitor/cli
 ```
 
-Then, initialize Capacitor with your app information:
+Then, initialize Capacitor with your app information.
+
+*Note: `npx` is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.*
 
 ```
 npx cap init
 ```
 
-*Note: `npx` is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.*
-
-This command will prompt you to enter the name of your app and the app id (used primarily as the package name for Android).
+This command will prompt you to enter the name of your app, the app id (the package name for Android), and the bundle identifier (for iOS).
 
 Next, install any of the desired native platforms:
 

--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -18,7 +18,7 @@ make sure you update CocoaPods using `pod repo update` before starting a new pro
 
 ## Adding Capacitor to an existing web app
 
-Capacitor was designed to drop-in to any existing modern JS web app. Only a valid `package.json` file is required to get started.
+Capacitor was designed to drop-in to any existing modern JS web app. A valid `package.json` file and a folder containing all web assets are required to get started.
 
 To add Capacitor to your web app, run the following commands:
 
@@ -35,7 +35,7 @@ Then, initialize Capacitor with your app information.
 npx cap init
 ```
 
-This command will prompt you to enter the name of your app, the app id (the package name for Android), and the bundle identifier (for iOS).
+This command will prompt you to enter the name of your app and the app id (the package name for Android and the bundle identifier for iOS). Use the `--web-dir` flag to set the web assets folder (the default is `www`).
 
 Next, install any of the desired native platforms:
 
@@ -57,7 +57,7 @@ To create it, run:
 npx @capacitor/cli create
 ```
 
-This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.
+This command will prompt you to enter the name of your app and the app id (the package name for Android and the bundle identifier for iOS).
 
 This will create a very simple starting app with no UI library.
 

--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -5,7 +5,7 @@ There are two ways to start using Capacitor: adding Capacitor to an existing fro
 Capacitor provides a native mobile runtime and API layer for web apps. It does _not_ come with any specific
 set of UI controls which you will most likely need unless you're building a game or something similar.
 
-We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as Ionic),
+We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as [Ionic](https://ionicframework.com)),
 though we also provide a blank starter for apps that aren't using a frontend UI framework, and a starter that uses Ionic and
 is ready for building a production-ready native app and Progressive Web App.
 
@@ -14,10 +14,13 @@ is ready for building a production-ready native app and Progressive Web App.
 Make sure you have all the required [Dependencies](./dependencies) installed for the platforms you will be building for. Most importantly,
 make sure you update CocoaPods using `pod repo update` before starting a new project, if you plan on building for iOS using a Mac.
 
+## Adding Capacitor to an existing Ionic App
+
+[See here.](/docs/getting-started/with-ionic)
 
 ## Adding Capacitor to an existing web app
 
-Capacitor was designed to drop-in to any existing modern JS web app.
+Capacitor was designed to drop-in to any existing modern JS web app. Only a valid `package.json` file is required to get started.
 
 To add Capacitor to your web app, run the following commands:
 
@@ -26,18 +29,25 @@ cd my-app
 npm install --save @capacitor/core @capacitor/cli
 ```
 
-Then, init Capacitor with your app information. This will also install the default
-native platforms.
+Then, initialize Capacitor with your app information:
 
 ```
 npx cap init
 ```
 
-This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.
+*Note: `npx` is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.*
+
+This command will prompt you to enter the name of your app and the app id (used primarily as the package name for Android).
+
+Next, install any of the desired native platforms:
+
+```
+npx cap add android
+npx cap add ios
+npx cap add electron
+```
 
 Capacitor is now installed in your project 🎉
-
-*Note: `npx` is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.*
 
 ## Using Capacitor Starter with Ionic Framework
 

--- a/site/docs-md/getting-started/with-ionic.md
+++ b/site/docs-md/getting-started/with-ionic.md
@@ -19,6 +19,8 @@ ionic integrations enable capacitor
 
 ### Initialize Capacitor with your app information
 
+*Note: `npx` is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.*
+
 ```
 npx cap init [appName] [appId]
 ```

--- a/site/docs-md/getting-started/with-ionic.md
+++ b/site/docs-md/getting-started/with-ionic.md
@@ -27,7 +27,7 @@ npx cap init [appName] [appId]
 
 where `appName` is the name of your app, and `appId` is the domain identifier of your app (ex: `com.example.app`).
 
-*Note: This can be ran any time you would like to update the app information.*
+*Note: Use the native IDEs to change these properties after initial configuration.*
 
 ### Build your Ionic App
 
@@ -55,7 +55,7 @@ npx cap open ios
 npx cap open android
 ```
 
-The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively).
+The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively). Use the IDEs to run and deploy your app.
 
 ## Syncing your app with Capacitor
 

--- a/site/docs-md/getting-started/with-ionic.md
+++ b/site/docs-md/getting-started/with-ionic.md
@@ -1,41 +1,41 @@
 # Using Capacitor with Ionic
 
 ## Install Capacitor into an Ionic project
+Capacitor is easily installed directly into any Ionic project (1.0-4.x+).
 
-Capacitor installs directly into any Ionic project (1.0-4.x+) with a simple `npm install`:
-
-### Start Ionic Project
+### New Ionic Project
 
 ```bash
-ionic start myApp tabs
+ionic start myApp tabs --capacitor
 cd myApp
 ```
 
-Select "N" when asked to add Cordova.
-
-### Build your Ionic App
-
-You must run `npm run build` at least once to create the `www` folder:
+### Existing Ionic Project
 
 ```bash
-npm run build
+cd myApp
+ionic integrations enable capacitor
 ```
 
-### Install Capacitor
-
-Next, install capacitor into your project:
-
-```bash
-npm install --save @capacitor/cli @capacitor/core
-```
-
-### Init Capacitor with your app information
+### Initialize Capacitor with your app information
 
 ```
 npx cap init [appName] [appId]
 ```
 
 where `appName` is the name of your app, and `appId` is the domain identifier of your app (ex: `com.example.app`).
+
+*Note: This can be ran any time you would like to update the app information.*
+
+### Build your Ionic App
+
+You must build your Ionic project at least once before adding any native platforms.
+
+```bash
+ionic build
+```
+
+This creates the `www` folder that Capacitor has been [automatically configured](/docs/basics/configuring-your-app) to use as the `webDir` in `capacitor.config.json`.
 
 ### Add Platforms
 
@@ -44,16 +44,20 @@ npx cap add ios
 npx cap add android
 ```
 
-### Open IDE to build
+Both `android` and `ios` folders at the root of the project are created. These are entirely separate native project artifacts that should be considered part of your Ionic app (i.e., check them into source control, edit them in their own IDEs, etc.).
+
+### Open IDE to build, run, and deploy
 
 ```bash
 npx cap open ios
 npx cap open android
 ```
 
+The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively).
+
 ## Syncing your app with Capacitor
 
-Every time you perform a build (e.g. `npm run build`) that changes your web directory (default: `www`), you'll need to copy those changes down to your native projects:
+Every time you perform a build (e.g. `ionic build`) that changes your web directory (default: `www`), you'll need to copy those changes down to your native projects:
 
 ```bash
 npx cap copy

--- a/site/src/assets/docs-content/getting-started/index.html
+++ b/site/src/assets/docs-content/getting-started/index.html
@@ -9,14 +9,14 @@ make sure you update CocoaPods using <code>pod repo update</code> before startin
 <h2 id="adding-capacitor-to-an-existing-ionic-app">Adding Capacitor to an existing Ionic App</h2>
 <p><a href="/docs/getting-started/with-ionic">See here.</a></p>
 <h2 id="adding-capacitor-to-an-existing-web-app">Adding Capacitor to an existing web app</h2>
-<p>Capacitor was designed to drop-in to any existing modern JS web app. Only a valid <code>package.json</code> file is required to get started.</p>
+<p>Capacitor was designed to drop-in to any existing modern JS web app. A valid <code>package.json</code> file and a folder containing all web assets are required to get started.</p>
 <p>To add Capacitor to your web app, run the following commands:</p>
 <pre><code>cd my-app
 npm install --save @capacitor/core @capacitor/cli
 </code></pre><p>Then, initialize Capacitor with your app information.</p>
 <p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
 <pre><code>npx cap init
-</code></pre><p>This command will prompt you to enter the name of your app, the app id (the package name for Android), and the bundle identifier (for iOS).</p>
+</code></pre><p>This command will prompt you to enter the name of your app and the app id (the package name for Android and the bundle identifier for iOS). Use the <code>--web-dir</code> flag to set the web assets folder (the default is <code>www</code>).</p>
 <p>Next, install any of the desired native platforms:</p>
 <pre><code>npx cap add android
 npx cap add ios
@@ -26,7 +26,7 @@ npx cap add electron
 <p>Capacitor comes with a stock project structure if you&#39;d rather start fresh and plan to add a UI/frontend framework separately.</p>
 <p>To create it, run:</p>
 <pre><code>npx @capacitor/cli create
-</code></pre><p>This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.</p>
+</code></pre><p>This command will prompt you to enter the name of your app and the app id (the package name for Android and the bundle identifier for iOS).</p>
 <p>This will create a very simple starting app with no UI library.</p>
 <h2 id="where-to-go-next">Where to go next</h2>
 <p>Make sure you have the <a href="/docs/getting-started/dependencies">Required Dependencies</a> installed, including <a href="/docs/getting-started/pwa-elements">PWA Elements</a>, then proceed to the

--- a/site/src/assets/docs-content/getting-started/index.html
+++ b/site/src/assets/docs-content/getting-started/index.html
@@ -2,9 +2,7 @@
 <p>There are two ways to start using Capacitor: adding Capacitor to an existing frontend project (recommended), or starting a fresh project. Capacitor was designed primarily to drop-in to existing frontend projects, but comes with a simple starting project structure if you&#39;d like to start fresh.</p>
 <p>Capacitor provides a native mobile runtime and API layer for web apps. It does <em>not</em> come with any specific
 set of UI controls which you will most likely need unless you&#39;re building a game or something similar.</p>
-<p>We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as <a href="https://ionicframework.com">Ionic</a>),
-though we also provide a blank starter for apps that aren&#39;t using a frontend UI framework, and a starter that uses Ionic and
-is ready for building a production-ready native app and Progressive Web App.</p>
+<p>We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as <a href="https://ionicframework.com">Ionic</a>).</p>
 <h2 id="before-you-start">Before you start</h2>
 <p>Make sure you have all the required <a href="./dependencies">Dependencies</a> installed for the platforms you will be building for. Most importantly,
 make sure you update CocoaPods using <code>pod repo update</code> before starting a new project, if you plan on building for iOS using a Mac.</p>
@@ -23,18 +21,13 @@ npm install --save @capacitor/core @capacitor/cli
 <pre><code>npx cap add android
 npx cap add ios
 npx cap add electron
-</code></pre><p>Capacitor is now installed in your project 🎉</p>
-<h2 id="using-capacitor-starter-with-ionic-framework">Using Capacitor Starter with Ionic Framework</h2>
-<p>Integration into the Ionic CLI is coming soon.</p>
-<p>For now, create a new ionic app using <code>ionic start</code>, then follow the steps above to add
-Capacitor to an existing web app (in this case, your new Ionic app).</p>
+</code></pre><p>🎉 Capacitor is now installed in your project. 🎉</p>
 <h2 id="optional-starting-a-fresh-project">Optional: Starting a fresh project</h2>
 <p>Capacitor comes with a stock project structure if you&#39;d rather start fresh and plan to add a UI/frontend framework separately.</p>
 <p>To create it, run:</p>
 <pre><code>npx @capacitor/cli create
 </code></pre><p>This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.</p>
-<p>This will create a very simple starting app with no UI library that you should nuke before
-starting your own app.</p>
+<p>This will create a very simple starting app with no UI library.</p>
 <h2 id="where-to-go-next">Where to go next</h2>
 <p>Make sure you have the <a href="/docs/getting-started/dependencies">Required Dependencies</a> installed, including <a href="/docs/getting-started/pwa-elements">PWA Elements</a>, then proceed to the
 <a href="/docs/basics/workflow">Developer Workflow Guide</a> to learn how Capacitor apps are built.</p>

--- a/site/src/assets/docs-content/getting-started/index.html
+++ b/site/src/assets/docs-content/getting-started/index.html
@@ -2,23 +2,28 @@
 <p>There are two ways to start using Capacitor: adding Capacitor to an existing frontend project (recommended), or starting a fresh project. Capacitor was designed primarily to drop-in to existing frontend projects, but comes with a simple starting project structure if you&#39;d like to start fresh.</p>
 <p>Capacitor provides a native mobile runtime and API layer for web apps. It does <em>not</em> come with any specific
 set of UI controls which you will most likely need unless you&#39;re building a game or something similar.</p>
-<p>We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as Ionic),
+<p>We strongly recommend starting a Capacitor project with your mobile frontend framework of choice (such as <a href="https://ionicframework.com">Ionic</a>),
 though we also provide a blank starter for apps that aren&#39;t using a frontend UI framework, and a starter that uses Ionic and
 is ready for building a production-ready native app and Progressive Web App.</p>
 <h2 id="before-you-start">Before you start</h2>
 <p>Make sure you have all the required <a href="./dependencies">Dependencies</a> installed for the platforms you will be building for. Most importantly,
 make sure you update CocoaPods using <code>pod repo update</code> before starting a new project, if you plan on building for iOS using a Mac.</p>
+<h2 id="adding-capacitor-to-an-existing-ionic-app">Adding Capacitor to an existing Ionic App</h2>
+<p><a href="/docs/getting-started/with-ionic">See here.</a></p>
 <h2 id="adding-capacitor-to-an-existing-web-app">Adding Capacitor to an existing web app</h2>
-<p>Capacitor was designed to drop-in to any existing modern JS web app.</p>
+<p>Capacitor was designed to drop-in to any existing modern JS web app. Only a valid <code>package.json</code> file is required to get started.</p>
 <p>To add Capacitor to your web app, run the following commands:</p>
 <pre><code>cd my-app
 npm install --save @capacitor/core @capacitor/cli
-</code></pre><p>Then, init Capacitor with your app information. This will also install the default
-native platforms.</p>
+</code></pre><p>Then, initialize Capacitor with your app information:</p>
 <pre><code>npx cap init
-</code></pre><p>This command will prompt you to enter the name of your app, the app id (used primarily as the package for android), and the directory of your app.</p>
-<p>Capacitor is now installed in your project 🎉</p>
-<p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
+</code></pre><p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
+<p>This command will prompt you to enter the name of your app and the app id (used primarily as the package name for Android).</p>
+<p>Next, install any of the desired native platforms:</p>
+<pre><code>npx cap add android
+npx cap add ios
+npx cap add electron
+</code></pre><p>Capacitor is now installed in your project 🎉</p>
 <h2 id="using-capacitor-starter-with-ionic-framework">Using Capacitor Starter with Ionic Framework</h2>
 <p>Integration into the Ionic CLI is coming soon.</p>
 <p>For now, create a new ionic app using <code>ionic start</code>, then follow the steps above to add

--- a/site/src/assets/docs-content/getting-started/index.html
+++ b/site/src/assets/docs-content/getting-started/index.html
@@ -13,10 +13,10 @@ make sure you update CocoaPods using <code>pod repo update</code> before startin
 <p>To add Capacitor to your web app, run the following commands:</p>
 <pre><code>cd my-app
 npm install --save @capacitor/core @capacitor/cli
-</code></pre><p>Then, initialize Capacitor with your app information:</p>
+</code></pre><p>Then, initialize Capacitor with your app information.</p>
+<p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
 <pre><code>npx cap init
-</code></pre><p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
-<p>This command will prompt you to enter the name of your app and the app id (used primarily as the package name for Android).</p>
+</code></pre><p>This command will prompt you to enter the name of your app, the app id (the package name for Android), and the bundle identifier (for iOS).</p>
 <p>Next, install any of the desired native platforms:</p>
 <pre><code>npx cap add android
 npx cap add ios

--- a/site/src/assets/docs-content/getting-started/with-ionic.html
+++ b/site/src/assets/docs-content/getting-started/with-ionic.html
@@ -13,7 +13,7 @@ ionic integrations <span class="hljs-built_in">enable</span> capacitor
 <p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
 <pre><code>npx cap init [appName] [appId]
 </code></pre><p>where <code>appName</code> is the name of your app, and <code>appId</code> is the domain identifier of your app (ex: <code>com.example.app</code>).</p>
-<p><em>Note: This can be ran any time you would like to update the app information.</em></p>
+<p><em>Note: Use the native IDEs to change these properties after initial configuration.</em></p>
 <h3 id="build-your-ionic-app">Build your Ionic App</h3>
 <p>You must build your Ionic project at least once before adding any native platforms.</p>
 <pre><code class="lang-bash">ionic build
@@ -28,7 +28,7 @@ npx <span class="hljs-built_in">cap</span> add android
 <pre><code class="lang-bash">npx <span class="hljs-built_in">cap</span> open ios
 npx <span class="hljs-built_in">cap</span> open android
 </code></pre>
-<p>The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively).</p>
+<p>The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively). Use the IDEs to run and deploy your app.</p>
 <h2 id="syncing-your-app-with-capacitor">Syncing your app with Capacitor</h2>
 <p>Every time you perform a build (e.g. <code>ionic build</code>) that changes your web directory (default: <code>www</code>), you&#39;ll need to copy those changes down to your native projects:</p>
 <pre><code class="lang-bash">npx <span class="hljs-built_in">cap</span> copy

--- a/site/src/assets/docs-content/getting-started/with-ionic.html
+++ b/site/src/assets/docs-content/getting-started/with-ionic.html
@@ -10,6 +10,7 @@
 ionic integrations <span class="hljs-built_in">enable</span> capacitor
 </code></pre>
 <h3 id="initialize-capacitor-with-your-app-information">Initialize Capacitor with your app information</h3>
+<p><em>Note: <code>npx</code> is a new utility available in npm 5 or above that executes local binaries/scripts to avoid global installs.</em></p>
 <pre><code>npx cap init [appName] [appId]
 </code></pre><p>where <code>appName</code> is the name of your app, and <code>appId</code> is the domain identifier of your app (ex: <code>com.example.app</code>).</p>
 <p><em>Note: This can be ran any time you would like to update the app information.</em></p>

--- a/site/src/assets/docs-content/getting-started/with-ionic.html
+++ b/site/src/assets/docs-content/getting-started/with-ionic.html
@@ -1,32 +1,35 @@
 <h1 id="using-capacitor-with-ionic">Using Capacitor with Ionic</h1>
 <h2 id="install-capacitor-into-an-ionic-project">Install Capacitor into an Ionic project</h2>
-<p>Capacitor installs directly into any Ionic project (1.0-4.x+) with a simple <code>npm install</code>:</p>
-<h3 id="start-ionic-project">Start Ionic Project</h3>
-<pre><code class="lang-bash">ionic start myApp tabs
+<p>Capacitor is easily installed directly into any Ionic project (1.0-4.x+).</p>
+<h3 id="new-ionic-project">New Ionic Project</h3>
+<pre><code class="lang-bash">ionic start myApp tabs --capacitor
 <span class="hljs-built_in">cd</span> myApp
 </code></pre>
-<p>Select &quot;N&quot; when asked to add Cordova.</p>
-<h3 id="build-your-ionic-app">Build your Ionic App</h3>
-<p>You must run <code>npm run build</code> at least once to create the <code>www</code> folder:</p>
-<pre><code class="lang-bash">npm run build
+<h3 id="existing-ionic-project">Existing Ionic Project</h3>
+<pre><code class="lang-bash"><span class="hljs-built_in">cd</span> myApp
+ionic integrations <span class="hljs-built_in">enable</span> capacitor
 </code></pre>
-<h3 id="install-capacitor">Install Capacitor</h3>
-<p>Next, install capacitor into your project:</p>
-<pre><code class="lang-bash">npm install --save @capacitor/cli @capacitor/core
-</code></pre>
-<h3 id="init-capacitor-with-your-app-information">Init Capacitor with your app information</h3>
+<h3 id="initialize-capacitor-with-your-app-information">Initialize Capacitor with your app information</h3>
 <pre><code>npx cap init [appName] [appId]
 </code></pre><p>where <code>appName</code> is the name of your app, and <code>appId</code> is the domain identifier of your app (ex: <code>com.example.app</code>).</p>
+<p><em>Note: This can be ran any time you would like to update the app information.</em></p>
+<h3 id="build-your-ionic-app">Build your Ionic App</h3>
+<p>You must build your Ionic project at least once before adding any native platforms.</p>
+<pre><code class="lang-bash">ionic build
+</code></pre>
+<p>This creates the <code>www</code> folder that Capacitor has been <a href="/docs/basics/configuring-your-app">automatically configured</a> to use as the <code>webDir</code> in <code>capacitor.config.json</code>.</p>
 <h3 id="add-platforms">Add Platforms</h3>
 <pre><code class="lang-bash">npx <span class="hljs-built_in">cap</span> add ios
 npx <span class="hljs-built_in">cap</span> add android
 </code></pre>
-<h3 id="open-ide-to-build">Open IDE to build</h3>
+<p>Both <code>android</code> and <code>ios</code> folders at the root of the project are created. These are entirely separate native project artifacts that should be considered part of your Ionic app (i.e., check them into source control, edit them in their own IDEs, etc.).</p>
+<h3 id="open-ide-to-build-run-and-deploy">Open IDE to build, run, and deploy</h3>
 <pre><code class="lang-bash">npx <span class="hljs-built_in">cap</span> open ios
 npx <span class="hljs-built_in">cap</span> open android
 </code></pre>
+<p>The native iOS and Android projects are opened in their standard IDEs (Xcode and Android Studio, respectively).</p>
 <h2 id="syncing-your-app-with-capacitor">Syncing your app with Capacitor</h2>
-<p>Every time you perform a build (e.g. <code>npm run build</code>) that changes your web directory (default: <code>www</code>), you&#39;ll need to copy those changes down to your native projects:</p>
+<p>Every time you perform a build (e.g. <code>ionic build</code>) that changes your web directory (default: <code>www</code>), you&#39;ll need to copy those changes down to your native projects:</p>
 <pre><code class="lang-bash">npx <span class="hljs-built_in">cap</span> copy
 </code></pre>
 <h2 id="using-ionic-native">Using Ionic Native</h2>

--- a/site/src/components/site-menu/site-menu.tsx
+++ b/site/src/components/site-menu/site-menu.tsx
@@ -28,12 +28,12 @@ export class SiteMenu {
           url: '/docs/getting-started/'
         },
         {
-          title: 'PWA Elements',
-          url: '/docs/getting-started/pwa-elements/'
-        },
-        {
           title: 'Using with Ionic',
           url: '/docs/getting-started/with-ionic'
+        },
+        {
+          title: 'PWA Elements',
+          url: '/docs/getting-started/pwa-elements/'
         }
         /*
         ,


### PR DESCRIPTION
Revamp of the Getting Started and With Ionic pages:
- Moving "PWA Elements" link down below With Ionic (makes more sense in terms of reading and flowing through docs)
- Changed out of date Capacitor install instructions to match current CLI features
- Added more details as to what happens when commands are run