### PR TITLE
Fix writing files with , on the content

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -257,10 +257,6 @@ public class Filesystem extends Plugin {
       call.error("Unsupported encoding provided: " + encoding);
       return;
     }
-    //remove header from dataURL
-    if(data.indexOf(",") != -1) {
-      data = data.split(",")[1];
-    }
 
     // if charset is not null assume its a plain text file the user wants to save
     boolean success = false;
@@ -273,6 +269,10 @@ public class Filesystem extends Plugin {
         Log.e(getLogTag(), "Creating text file '" + file.getPath() + "' with charset '" + charset + "' failed. Error: " + e.getMessage(), e);
       }
     } else {
+      //remove header from dataURL
+      if(data.indexOf(",") != -1) {
+        data = data.split(",")[1];
+      }
       try (FileOutputStream fos = new FileOutputStream(file, append)) {
         fos.write(Base64.decode(data, Base64.NO_WRAP));
         success = true;


### PR DESCRIPTION
If trying to write to a file and the content contains `,`, everything before it is being stripped.
This fix only strips it when the file doesn't have encoding.