### PR TITLE
Prevent splash blink

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -94,6 +94,7 @@ public class CAPSplashScreenPlugin : CAPPlugin {
   }
   
   func showOnLaunch() {
+    self.bridge.viewController.view.addSubview(self.imageView)
     let launchShowDurationConfig = getConfigValue("launchShowDuration") as? Int ?? launchShowDuration
     let launchAutoHideConfig = getConfigValue("launchAutoHide") as? Bool ?? launchAutoHide
     showSplash(showDuration: launchShowDurationConfig, fadeInDuration: 0, fadeOutDuration: defaultFadeOutDuration, autoHide: launchAutoHideConfig, completion: {
@@ -104,7 +105,9 @@ public class CAPSplashScreenPlugin : CAPPlugin {
     
     DispatchQueue.main.async {
       
-      self.bridge.viewController.view.addSubview(self.imageView)
+      if !isLaunchSplash {
+        self.bridge.viewController.view.addSubview(self.imageView)
+      }
 
       self.bridge.viewController.view.isUserInteractionEnabled = false
 


### PR DESCRIPTION
Found a simpler fix for the splash screen blink than #1120 

@stewwan @corysmc, can you give it a try?

Looks like the problem was using the `addSubview` in the `DispatchQueue.main.async`

Closes #620 
Closes #1120