### PR TITLE
Fix prerelease script to proper local verification of podspecs

### DIFF
--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -8,8 +8,8 @@ if [ -z $BINTRAY_USER ]; then
 fi
 
 # Verify pods are good
-pod spec lint --allow-warnings Capacitor.podspec
-pod spec lint --allow-warnings CapacitorCordova.podspec
+pod lib lint --allow-warnings Capacitor.podspec
+pod lib lint --allow-warnings CapacitorCordova.podspec
 
 # Do the gradle
 cd android


### PR DESCRIPTION
For local verification we should use `pod lib lint` instead of `pod spec lint`