### PR TITLE
fix(types): return value of `StoragePlugin.get`

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1453,7 +1453,7 @@ export interface StoragePlugin extends Plugin {
   /**
    * Get the value with the given key.
    */
-  get(options: { key: string }): Promise<{ value: string }>;
+  get(options: { key: string }): Promise<{ value: string | null }>;
   /**
    * Set the value for the given key
    */


### PR DESCRIPTION
If no value for a key has been set yet, the returned value is `null`, not a string:

![image](https://user-images.githubusercontent.com/3410759/57778283-0355e680-7724-11e9-8223-cc33100b600f.png)
