### PR TITLE
feat(local-notifications): use app icon for default

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -179,7 +179,13 @@ public class LocalNotification {
 
   public int getSmallIcon(Context context) {
     // TODO support custom icons
-    int resId = android.R.drawable.ic_dialog_info;
+
+    int resId = context.getApplicationInfo().icon;
+
+    if (resId == 0) {
+      resId = android.R.drawable.ic_dialog_info;
+    }
+
     return resId;
   }
 


### PR DESCRIPTION
waiting for custom icons we suggest to use at least default application icon before using ic_dialog_info