### PR TITLE
Removes npm-scope from package name.

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -90,6 +90,7 @@ export function getDependencies(config: Config): string[] {
 
 export function fixName(name: string): string {
   name = name
+    .replace(/^@[^/]*\//g, '')
     .replace(/\//g, '_')
     .replace(/-/g, '_')
     .replace(/@/g, '')


### PR DESCRIPTION
`npx cap update` generates wrong pod name when the package is using npm-scope, causing a mismatch and failing `npx cap update` as generated plugin **podspec** filename does not include the scope name.

A plugin package named `@codetrixstudio/capacitor-google-auth`, generates pod named `CodetrixstudioCapacitorGoogleAuth` instead of `CapacitorGoogleAuth`

This fixes the issue by removing npm-scope from the package name.