### PR TITLE
Add ls command for listing iOS and Android plugins

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { createCommand } from './tasks/create';
 import { initCommand } from './tasks/init';
 import { copyCommand } from './tasks/copy';
+import { listCommand } from './tasks/list';
 import { updateCommand } from './tasks/update';
 import { openCommand } from './tasks/open';
 import { serveCommand } from './tasks/serve';
@@ -82,6 +83,13 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
     .description('add a native platform project')
     .action((platform) => {
       return addCommand(config, platform);
+    });
+
+  program
+    .command('ls [platform]')
+    .description('list installed Cordova and Capacitor plugins')
+    .action(platform => {
+      return listCommand(config, platform);
     });
 
   program

--- a/cli/src/tasks/list.ts
+++ b/cli/src/tasks/list.ts
@@ -1,0 +1,42 @@
+import { Config } from '../config';
+import { logError, logInfo } from '../common';
+import { allSerial } from '../util/promise';
+import { getPlugins, getPluginType, printPlugins, Plugin, PluginType } from '../plugin';
+import { getAndroidPlugins } from '../android/common';
+import { getIOSPlugins } from '../ios/common';
+
+export async function listCommand(config: Config, selectedPlatformName: string) {
+  const platforms = config.selectPlatforms(selectedPlatformName);
+  if (platforms.length === 0) {
+    logInfo(`There are no platforms to list yet. Create one with \`capacitor create\`.`);
+    return;
+  }
+  try {
+    await allSerial(platforms.map(platformName => () => list(config, platformName)));
+  } catch (e) {
+    logError(e);
+  }
+}
+
+export async function list(config: Config, platform: string) {
+   
+  const allPlugins = await getPlugins(config);
+  let plugins: Plugin[] = [];
+  if (platform === config.ios.name) {
+    plugins = getIOSPlugins(allPlugins);
+  } else if (platform === config.android.name) { 
+    plugins = getAndroidPlugins(allPlugins);
+  } else if (platform === config.web.name || platform === config.electron.name) {
+    logInfo(`Listing plugins for ${platform} is not possible`);
+    return;
+  } else {
+    throw `Platform ${platform} is not valid.`;
+  }
+  
+  const capacitorPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Core);
+  printPlugins(capacitorPlugins, platform);
+  const cordovaPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Cordova);
+  printPlugins(cordovaPlugins, platform, 'cordova');
+  const incompatibleCordovaPlugins = plugins.filter(p => getPluginType(p, platform) === PluginType.Incompatible);
+  printPlugins(incompatibleCordovaPlugins, platform, 'incompatible');
+}


### PR DESCRIPTION
Added a ls command that list plugins of the available (installed) platforms, or per platform if the command contains the platform name.

Closes #1522 