### PR TITLE
Android javascript injection improvements

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -57,7 +57,13 @@ class JSInjector {
   public InputStream getInjectedStream(InputStream responseStream) {
     String js = "<script type=\"text/javascript\">" + getScriptString() + "</script>";
     String html = this.readAssetStream(responseStream);
-    html = html.replace("<head>", "<head>\n" + js + "\n");
+    if (html.contains("<head>")) {
+      html = html.replace("<head>", "<head>\n" + js + "\n");
+    } else if (html.contains("</head>")) {
+      html = html.replace("</head>", js + "\n" + "</head>");
+    } else {
+      Log.e(LogUtils.getCoreTag(), "Unable to inject Capacitor, Plugins won't work");
+    }
     return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
   }
 


### PR DESCRIPTION
Some frameworks like nuxt put things in the `<head>` tag (i.e. `<head data-n-head="">`, so injector wasn't working as we were relying on that tag to inject the javascript. 

This fix will check if the html has a regular head tag, if not it will put the javascript before the closing `</head>` tag if present, and if not it will log an error. 

Closes #1550