### PR TITLE
Fix(docs): Remove note about pwa-elements import not working

### DIFF
--- a/site/docs-md/guides/ionic-framework-app.md
+++ b/site/docs-md/guides/ionic-framework-app.md
@@ -171,18 +171,7 @@ Some Capacitor plugins, including the Camera, provide the web-based functionalit
 npm install @ionic/pwa-elements
 ```
 
-Include this script tags in `src/index.html`:
-
-```html
-<head>
-  <!-- Other tags -->
-
-  <script type="module" src="https://unpkg.com/@ionic/pwa-elements@latest/dist/ionicpwaelements/ionicpwaelements.esm.js"></script>
-  <script nomodule src="https://unpkg.com/@ionic/pwa-elements@latest/dist/ionicpwaelements/ionicpwaelements.js"></script>
-</head>
-```
-
-Or import `@ionic/pwa-elements` by editing `src/main.ts`:
+Import `@ionic/pwa-elements` by editing `src/main.ts`:
 
 ```typescript
 import { defineCustomElements } from '@ionic/pwa-elements/loader';

--- a/site/docs-md/guides/ionic-framework-app.md
+++ b/site/docs-md/guides/ionic-framework-app.md
@@ -171,7 +171,7 @@ Some Capacitor plugins, including the Camera, provide the web-based functionalit
 npm install @ionic/pwa-elements
 ```
 
-**Note:** There's currently an issue with importing the Ionic PWA elements library in an Ionic Angular app. In the meantime, include this script tag in `src/index.html`: 
+Include this script tags in `src/index.html`:
 
 ```html
 <head>
@@ -180,6 +180,15 @@ npm install @ionic/pwa-elements
   <script type="module" src="https://unpkg.com/@ionic/pwa-elements@latest/dist/ionicpwaelements/ionicpwaelements.esm.js"></script>
   <script nomodule src="https://unpkg.com/@ionic/pwa-elements@latest/dist/ionicpwaelements/ionicpwaelements.js"></script>
 </head>
+```
+
+Or import `@ionic/pwa-elements` by editing `src/main.ts`:
+
+```typescript
+import { defineCustomElements } from '@ionic/pwa-elements/loader';
+
+// Call the element loader after the platform has been bootstrapped
+defineCustomElements(window);
 ```
 
 With that appropriately configured now, re-run `ionic serve` and click the Camera fab button. If your computer has a webcam of any sort, a modal window displays and you can take a photo!


### PR DESCRIPTION
The import is working fine now, so removed the note and added the usage instructions.