### PR TITLE
fix(ios): ignore Podfile.lock

### DIFF
--- a/ios-template/gitignore
+++ b/ios-template/gitignore
@@ -5,6 +5,7 @@
 App/build
 App/Pods
 App/public
+App/Podfile.lock
 xcuserdata
 
 # Cordova plugins for Capacitor


### PR DESCRIPTION
It seems appropriate to ignore `ios/App/Podfile.lock`. Podfile.lock is generated when `npx cap update ios` is executed, and the file is updated based on the host system (cocoapods version).