### PR TITLE
Docs: Add more community guides to APIs and comm guides pages

### DIFF
--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -64,9 +64,9 @@ async takePicture() {
 }
 ```
 
-## Angular example
+## Example Guides
 
-[Follow this guide](../../guides/ionic-framework-app) to implement the Camera API in an Ionic Angular app.
+[Building an Ionic Framework Camera App](/docs/guides/ionic-framework-app)
 
 ## API
 

--- a/site/docs-md/apis/network/index.md
+++ b/site/docs-md/apis/network/index.md
@@ -48,6 +48,10 @@ The Network API requires the following permission be added to your `AndroidManif
 
 This permission allows the app to access information about the current network, such as whether it is connected to wifi or cellular.
 
+## Example Guides
+
+[Network: Ionic 4 and Network Detection with Capacitor &#8250;](https://developer.school/posts/ionic-4-network-detection-with-capacitor/)
+
 ## API
 
 <plugin-api name="network"></plugin-api>

--- a/site/docs-md/apis/push-notifications/index.md
+++ b/site/docs-md/apis/push-notifications/index.md
@@ -67,7 +67,9 @@ An empty Array can be provided if none of the previous options are desired. `pus
 <plugin-api index="true" name="push-notifications"></plugin-api>
 
 
-## Example
+## Example Guides
+
+[Using Push Notifications with Firebase in an Ionic Angular App](/docs/guides/push-notifications-firebase)
 
 ## API
 

--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -71,7 +71,7 @@ Then run `npx cap copy` to apply these changes.
 
 ## Configuration
 
-These config parameters are availiable in `capacitor.config.json`:
+These config parameters are available in `capacitor.config.json`:
 
 ```json
 {
@@ -85,10 +85,6 @@ These config parameters are availiable in `capacitor.config.json`:
   }
 }
 ```
-
-## Add your own splash screen images
-
-See [Josh Morony's blog post](https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/) on how to change it. 
 
 ### Android
 
@@ -125,6 +121,12 @@ with
         <item name="android:background">@drawable/screen</item>
     </style>
 ```
+
+## Example Guides
+
+[Adding Your Own Icons and Splash Screen Images &#8250;](https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/)
+
+[Creating a Dynamic/Adaptable Splash Screen for Capacitor (Android) &#8250;](https://www.joshmorony.com/creating-a-dynamic-universal-splash-screen-for-capacitor-android/)
 
 ## API
 

--- a/site/docs-md/guides/community.md
+++ b/site/docs-md/guides/community.md
@@ -10,8 +10,6 @@ contributors:
 
 ## General
 
-General Capacitor guides and tutorials from the community.
-
 [How to Build an Ionic Chat App with React and Stream &#8250;](https://levelup.gitconnected.com/how-to-build-an-ionic-chat-app-with-react-and-stream-739b67611280)
 
 [Capacitor: Five Apps in Five Minutes &#8250;](https://angularfirebase.com/lessons/capacitor-five-apps-in-five-minutes/)
@@ -19,6 +17,16 @@ General Capacitor guides and tutorials from the community.
 [Create an Ionic 4 PWA with Capacitor &#8250;](https://blog.jscrambler.com/create-an-ionic-4-pwa-with-capacitor/)
 
 [Capacitor Workflow for iOS and Android Apps &#8250;](https://www.youtube.com/watch?v=oXbRcpsytGQ)
+
+## APIs
+
+[Camera: Building an Ionic Framework Camera App](/docs/guides/ionic-framework-app)
+
+[Network: Ionic 4 and Network Detection with Capacitor &#8250;](https://developer.school/posts/ionic-4-network-detection-with-capacitor/)
+
+[Push Notifications: Using Push Notifications with Firebase in an Ionic Angular App](/docs/guides/push-notifications-firebase)
+
+[Splash Screen: Creating a Dynamic/Adaptable Splash Screen for Capacitor (Android) &#8250;](https://www.joshmorony.com/creating-a-dynamic-universal-splash-screen-for-capacitor-android/)
 
 ## Integrations
 


### PR DESCRIPTION
- Community Guides page: adding *APIs* as a new subsection and link Paul’s Network post. Others in the future.

- Individual API pages: If content is explicitly about an API (like Paul’s on Network - https://developer.school/posts/ionic-4-network-detection-with-capacitor/), then link to it here too. Add header *Example Guides* to existing ones that could use it.

We get the best of both worlds and account for multiple ways that devs could be viewing the docs, for the lowest effort.