### PR TITLE
fix(splash): prevent centerCrop splash from rescaling

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -163,6 +163,9 @@ public class Splash {
         // Required to enable the view to actually fade
         params.format = PixelFormat.TRANSLUCENT;
 
+        if (params.width == -1) params.width = 0;
+        if (params.height == -1) params.height = 0;
+
         wm.addView(splashImage, params);
 
         splashImage.setAlpha(0f);


### PR DESCRIPTION
When the plugin calls `.show()` the splash screen re-scale a little bit from the initial splash screen when using `centerCrop`. Changing width and height from -1 to 0 fixes this. I added the `if`-cases just for extra safety, but in my experience it's always -1.