### PR TITLE
Fix(camera web): Reject promise if pwa-elements return error

### DIFF
--- a/core/src/web/camera.ts
+++ b/core/src/web/camera.ts
@@ -29,6 +29,8 @@ export class CameraPluginWeb extends WebPlugin implements CameraPlugin {
 
         if (photo === null) {
           reject('User cancelled photos app');
+        } else if (photo instanceof Error) {
+          reject(photo.message);
         } else {
           resolve(await this._getCameraPhoto(photo, options));
         }


### PR DESCRIPTION
If using pwa-elements 1.3.0 or newer, it will return an error.
Capacitor Camera will detect the error and reject the camera promise with the error message.

Closes #1577 