### PR TITLE
fix(electron): incorrect path being used for Filesystem.stat

### DIFF
--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -157,7 +157,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.stat(options.path, (err:any, stats:any) => {
+      this.NodeFS.stat(lookupPath, (err:any, stats:any) => {
         if(err) {
           reject(err);
           return;

--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -106,7 +106,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
-| DatePicker | `capacitor-datepicker | <https://github.com/triniwiz/capacitor-datepicker> | |
+| DatePicker | `capacitor-datepicker` | <https://github.com/triniwiz/capacitor-datepicker> | |
 
 ## Images
 


### PR DESCRIPTION
This fixes an issue where Filesystem.stat used the passed in path, instead of the directory + path combination