### PR TITLE
feat(Filesystem): Add move implementation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -20,5 +20,5 @@ public class PluginRequestCodes {
   public static final int FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS = 9017;
   public static final int FILESYSTEM_REQUEST_URI_PERMISSIONS = 9018;
   public static final int FILESYSTEM_REQUEST_STAT_PERMISSIONS = 9019;
-  public static final int FILESYSTEM_REQUEST_MOVE_PERMISSIONS = 9020;
+  public static final int FILESYSTEM_REQUEST_RENAME_PERMISSIONS = 9020;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -20,4 +20,5 @@ public class PluginRequestCodes {
   public static final int FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS = 9017;
   public static final int FILESYSTEM_REQUEST_URI_PERMISSIONS = 9018;
   public static final int FILESYSTEM_REQUEST_STAT_PERMISSIONS = 9019;
+  public static final int FILESYSTEM_REQUEST_MOVE_PERMISSIONS = 9020;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -40,7 +40,7 @@ import java.nio.charset.StandardCharsets;
   PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS,
-  PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS,
+  PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS,
 })
 public class Filesystem extends Plugin {
 
@@ -446,7 +446,7 @@ public class Filesystem extends Plugin {
   }
 
   @PluginMethod()
-  public void move(PluginCall call) {
+  public void rename(PluginCall call) {
     saveCall(call);
     String from = call.getString("from");
     String to = call.getString("to");
@@ -466,7 +466,7 @@ public class Filesystem extends Plugin {
     File toObject = getFileObject(to, directory);
 
     if (!isPublicDirectory(directory)
-            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
 
       assert toObject != null;
       if (toObject.isDirectory()) {
@@ -476,10 +476,10 @@ public class Filesystem extends Plugin {
       toObject.delete();
 
       assert fromObject != null;
-      boolean moved = fromObject.renameTo(toObject);
+      boolean renamed = fromObject.renameTo(toObject);
 
-      if (!moved) {
-        call.error("Unable to move, unknown reason");
+      if (!renamed) {
+        call.error("Unable to rename, unknown reason");
         return;
       }
 
@@ -560,8 +560,8 @@ public class Filesystem extends Plugin {
       this.getUri(savedCall);
     } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS) {
       this.stat(savedCall);
-    } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS) {
-      this.move(savedCall);
+    } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS) {
+      this.rename(savedCall);
     }
     this.freeSavedCall();
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -39,7 +39,8 @@ import java.nio.charset.StandardCharsets;
   PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FILE_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS,
-  PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS
+  PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS,
+  PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS,
 })
 public class Filesystem extends Plugin {
 
@@ -444,6 +445,48 @@ public class Filesystem extends Plugin {
     }
   }
 
+  @PluginMethod()
+  public void move(PluginCall call) {
+    saveCall(call);
+    String from = call.getString("from");
+    String to = call.getString("to");
+    String directory = getDirectoryParameter(call);
+
+    if (from == null || from.isEmpty() || to == null || to.isEmpty()) {
+      call.error("Both to and from must be provided");
+      return;
+    }
+
+    if (to.equals(from)) {
+      call.success();
+      return;
+    }
+
+    File fromObject = getFileObject(from, directory);
+    File toObject = getFileObject(to, directory);
+
+    if (!isPublicDirectory(directory)
+            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+
+      assert toObject != null;
+      if (toObject.isDirectory()) {
+        call.error("Cannot overwrite a directory");
+        return;
+      }
+      toObject.delete();
+
+      assert fromObject != null;
+      boolean moved = fromObject.renameTo(toObject);
+
+      if (!moved) {
+        call.error("Unable to move, unknown reason");
+        return;
+      }
+
+      call.success();
+    }
+  }
+
   /**
    * Checks the the given permission and requests them if they are not already granted.
    * @param permissionRequestCode the request code see {@link PluginRequestCodes}
@@ -517,6 +560,8 @@ public class Filesystem extends Plugin {
       this.getUri(savedCall);
     } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS) {
       this.stat(savedCall);
+    } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_MOVE_PERMISSIONS) {
+      this.move(savedCall);
     }
     this.freeSavedCall();
   }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -519,6 +519,13 @@ export interface FilesystemPlugin extends Plugin {
    * @return a promise that resolves with the file stat result
    */
   stat(options: StatOptions): Promise<StatResult>;
+
+  /**
+   * Move a file or directory
+   * @param options the options for the move operation
+   * @return a promise that resolves with the move result
+   */
+  move(options: MoveOptions): Promise<MoveResult>;
 }
 
 export enum FilesystemDirectory {
@@ -680,6 +687,21 @@ export interface StatOptions {
   directory?: FilesystemDirectory;
 }
 
+export interface MoveOptions {
+  /**
+   * The existing file or directory to move
+   */
+  from: string;
+  /**
+   * The destination to move the file or directory to
+   */
+  to: string;
+  /**
+   * The FilesystemDirectory to move the file or directory within
+   */
+  directory?: FilesystemDirectory;
+}
+
 export interface FileReadResult {
   data: string;
 }
@@ -692,6 +714,8 @@ export interface FileAppendResult {
 export interface MkdirResult {
 }
 export interface RmdirResult {
+}
+export interface MoveResult {
 }
 export interface ReaddirResult {
   files: string[];

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -521,11 +521,11 @@ export interface FilesystemPlugin extends Plugin {
   stat(options: StatOptions): Promise<StatResult>;
 
   /**
-   * Move a file or directory
-   * @param options the options for the move operation
-   * @return a promise that resolves with the move result
+   * Rename a file or directory
+   * @param options the options for the rename operation
+   * @return a promise that resolves with the rename result
    */
-  move(options: MoveOptions): Promise<MoveResult>;
+  rename(options: RenameOptions): Promise<RenameResult>;
 }
 
 export enum FilesystemDirectory {
@@ -687,17 +687,17 @@ export interface StatOptions {
   directory?: FilesystemDirectory;
 }
 
-export interface MoveOptions {
+export interface RenameOptions {
   /**
-   * The existing file or directory to move
+   * The existing file or directory to rename
    */
   from: string;
   /**
-   * The destination to move the file or directory to
+   * The destination to rename the file or directory to
    */
   to: string;
   /**
-   * The FilesystemDirectory to move the file or directory within
+   * The FilesystemDirectory containing the file or directory to rename
    */
   directory?: FilesystemDirectory;
 }
@@ -715,7 +715,7 @@ export interface MkdirResult {
 }
 export interface RmdirResult {
 }
-export interface MoveResult {
+export interface RenameResult {
 }
 export interface ReaddirResult {
   files: string[];

--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -15,8 +15,8 @@ import {
   GetUriResult,
   MkdirOptions,
   MkdirResult,
-  MoveOptions,
-  MoveResult,
+  RenameOptions,
+  RenameResult,
   ReaddirOptions,
   ReaddirResult,
   RmdirOptions,
@@ -340,11 +340,11 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
   }
 
   /**
-   * Move a file or directory
-   * @param options the options for the move operation
-   * @return a promise that resolves with the move result
+   * Rename a file or directory
+   * @param options the options for the rename operation
+   * @return a promise that resolves with the rename result
    */
-  async move(options: MoveOptions): Promise<MoveResult> {
+  async rename(options: RenameOptions): Promise<RenameResult> {
     let {to, from, directory} = options;
 
     if (!to || !from) {
@@ -460,7 +460,7 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
 
         for (let filename of contents) {
           // Move item from the from directory to the to directory
-          await this.move({
+          await this.rename({
             from: `${from}/${filename}`,
             to: `${to}/${filename}`,
             directory,

--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -15,6 +15,8 @@ import {
   GetUriResult,
   MkdirOptions,
   MkdirResult,
+  MoveOptions,
+  MoveResult,
   ReaddirOptions,
   ReaddirResult,
   RmdirOptions,
@@ -335,6 +337,144 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
       mtime: entry.mtime,
       uri: entry.path
     };
+  }
+
+  /**
+   * Move a file or directory
+   * @param options the options for the move operation
+   * @return a promise that resolves with the move result
+   */
+  async move(options: MoveOptions): Promise<MoveResult> {
+    let {to, from, directory} = options;
+
+    if (!to || !from) {
+      throw Error('Both to and from must be provided');
+    }
+
+    // Test that the "to" and "from" locations are different
+    if (from === to) {
+      return {};
+    }
+
+    if (to.startsWith(from)) {
+      throw Error('To path cannot contain the from path');
+    }
+
+    // Check the state of the "to" location
+    let toObj;
+    try {
+      toObj = await this.stat({
+        path: to,
+        directory
+      });
+    } catch (e) {
+      // To location does not exist, ensure the directory containing "to" location exists and is a directory
+      let toPathComponents = to.split('/');
+      toPathComponents.pop();
+      let toPath = toPathComponents.join('/');
+
+      // Check the containing directory of the "to" location exists
+      if (toPathComponents.length > 0) {
+        let toParentDirectory = await this.stat({
+          path: toPath,
+          directory,
+        });
+
+        if (toParentDirectory.type !== 'directory') {
+          throw new Error('Parent directory of the to path is a file');
+        }
+      }
+    }
+
+    // Cannot overwrite a directory
+    if (toObj && toObj.type === 'directory') {
+      throw new Error('Cannot overwrite a directory with a file');
+    }
+
+    // Ensure the "from" object exists
+    let fromObj = await this.stat({
+      path: from,
+      directory: directory
+    });
+
+    // Set the mtime/ctime of the supplied path
+    let updateTime = async (path: string, ctime: number, mtime: number) => {
+      let fullPath: string = this.getPath(directory, path);
+      let entry = await this.dbRequest('get', [fullPath]) as EntryObj;
+      entry.ctime = ctime;
+      entry.mtime = mtime;
+      await this.dbRequest('put', [entry]);
+    };
+
+    switch (fromObj.type) {
+      // The "from" object is a file
+      case 'file':
+        // Read the file
+        let file = await this.readFile({
+          path: from,
+          directory
+        });
+
+        // Remove the file
+        await this.deleteFile({
+          path: from,
+          directory
+        });
+
+        // Write the file to the new location
+        await this.writeFile({
+          path: to,
+          directory,
+          data: file.data
+        });
+
+        // Copy the mtime/ctime of the original file
+        await updateTime(to, fromObj.ctime, fromObj.mtime);
+
+        // Resolve promise
+        return {};
+
+      case 'directory':
+        if (toObj) {
+          throw Error('Cannot move a directory over an existing object');
+        }
+
+        try {
+          // Create the to directory
+          await this.mkdir({
+            path: to,
+            directory,
+            createIntermediateDirectories: false,
+          });
+
+          // Copy the mtime/ctime of the original directory
+          await updateTime(to, fromObj.ctime, fromObj.mtime);
+        } catch (e) {
+        }
+
+        // Iterate over the contents of the from location
+        let contents = (await this.readdir({
+          path: from,
+          directory
+        })).files;
+
+        for (let filename of contents) {
+          // Move item from the from directory to the to directory
+          await this.move({
+            from: `${from}/${filename}`,
+            to: `${to}/${filename}`,
+            directory,
+          });
+        }
+
+        // Remove the original from directory
+        await this.rmdir({
+          path: from,
+          directory
+        });
+    }
+
+    return {};
   }
 }
 

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -6,7 +6,7 @@ import {
   FileAppendOptions, FileAppendResult,
   FilesystemDirectory,
   ReaddirOptions, ReaddirResult,
-  MoveOptions, MoveResult,
+  RenameOptions, RenameResult,
   MkdirOptions, MkdirResult, GetUriOptions,
   RmdirOptions, RmdirResult, GetUriResult,
   StatOptions, StatResult,FileDeleteOptions,
@@ -169,7 +169,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     });
   }
 
-  move(options: MoveOptions): Promise<MoveResult> {
+  rename(options: RenameOptions): Promise<RenameResult> {
     return new Promise((resolve, reject) => {
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -6,6 +6,7 @@ import {
   FileAppendOptions, FileAppendResult,
   FilesystemDirectory,
   ReaddirOptions, ReaddirResult,
+  MoveOptions, MoveResult,
   MkdirOptions, MkdirResult, GetUriOptions,
   RmdirOptions, RmdirResult, GetUriResult,
   StatOptions, StatResult,FileDeleteOptions,
@@ -164,6 +165,24 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
         }
 
         resolve({type: 'Not Available', size: stats.size, ctime: stats.ctimeMs, mtime: stats.mtimeMs, uri: lookupPath});
+      });
+    });
+  }
+
+  move(options: MoveOptions): Promise<MoveResult> {
+    return new Promise((resolve, reject) => {
+      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
+        reject(`${options.directory} is currently not supported in the Electron implementation.`);
+      let fromPath = this.fileLocations[options.directory] + options.from;
+      let toPath = this.fileLocations[options.directory] + options.to;
+
+      this.NodeFS.rename(fromPath, toPath, (err: any) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve();
       });
     });
   }

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -53,7 +53,7 @@ CAP_PLUGIN(CAPFilesystemPlugin, "Filesystem",
   CAP_PLUGIN_METHOD(readdir, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getUri, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(stat, CAPPluginReturnPromise);
-  CAP_PLUGIN_METHOD(move, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(rename, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPGeolocationPlugin, "Geolocation",

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -53,6 +53,7 @@ CAP_PLUGIN(CAPFilesystemPlugin, "Filesystem",
   CAP_PLUGIN_METHOD(readdir, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getUri, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(stat, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(move, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPGeolocationPlugin, "Geolocation",

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -338,9 +338,9 @@ public class CAPFilesystemPlugin : CAPPlugin {
   }
 
   /**
-   * Move a file or directory.
+   * Rename a file or directory.
    */
-  @objc func move(_ call: CAPPluginCall) {
+  @objc func rename(_ call: CAPPluginCall) {
     guard let from = call.get("from", String.self) else {
       handleError(call, "from must be provided and must be a string.")
       return

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -337,5 +337,50 @@ public class CAPFilesystemPlugin : CAPPlugin {
     
   }
 
+  /**
+   * Move a file or directory.
+   */
+  @objc func move(_ call: CAPPluginCall) {
+    guard let from = call.get("from", String.self) else {
+      handleError(call, "from must be provided and must be a string.")
+      return
+    }
+    
+    guard let to = call.get("to", String.self) else {
+      handleError(call, "to must be provided and must be a string.")
+      return
+    }
+    
+    let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
+    
+    guard let fromUrl = getFileUrl(from, directoryOption) else {
+      handleError(call, "Invalid from path")
+      return
+    }
+    
+    guard let toUrl = getFileUrl(to, directoryOption) else {
+      handleError(call, "Invalid to path")
+      return
+    }
+    
+    if (fromUrl == toUrl) {
+      call.success()
+      return
+    }
+    
+    do {
+      var isDir : ObjCBool = false
+      if FileManager.default.fileExists(atPath: toUrl.path, isDirectory: &isDir) {
+        if (!isDir.boolValue) {
+          try? FileManager.default.removeItem(at: toUrl)
+        }
+      }
+      
+      try FileManager.default.moveItem(at: fromUrl, to: toUrl)
+      call.success()
+    } catch let error as NSError {
+      handleError(call, error.localizedDescription, error)
+    }
+  }
 }
 

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -123,15 +123,15 @@ async readFilePath() {
   }
 }
 
-async move() {
+async rename() {
   try {
-    let ret = await Filesystem.move({
+    let ret = await Filesystem.rename({
       from: 'text.txt',
       to: 'text2.txt',
       directory: FilesystemDirectory.Documents
     });
   } catch(e) {
-    console.error('Unable to move file', e);
+    console.error('Unable to rename file', e);
   }
 }
 ```

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -122,6 +122,18 @@ async readFilePath() {
     })
   }
 }
+
+async move() {
+  try {
+    let ret = await Filesystem.move({
+      from: 'text.txt',
+      to: 'text2.txt',
+      directory: FilesystemDirectory.Documents
+    });
+  } catch(e) {
+    console.error('Unable to move file', e);
+  }
+}
 ```
 
 ## API

--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -106,7 +106,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
-| DatePicker | `capacitor-datepicker | <https://github.com/triniwiz/capacitor-datepicker> | |
+| DatePicker | `capacitor-datepicker` | <https://github.com/triniwiz/capacitor-datepicker> | |
 
 ## Images
 


### PR DESCRIPTION
Implementation for all platforms, and uses the same move semantics across all.
It also preserves mtime across all platforms for both files and directories, (ctime is not available in some platforms, or is inconsistently handled by the underlying filesystem).
Moving a file to a directory does not imply moving it into that directory (ie "mv <file> <directory>" does not imply "mv <file> <directory>/<file>" and will fail

```
Missing arguments -> fails
Move into a subdirectory of itself -> fails
Move a file to an nonexistent location -> fails
Move a file to "overwrite" a directory -> fails
Move a file into a nonexistent directory -> fails
Move a nonexistent file -> fails
Move a file into a subdirectory that is a file -> fails

Move a file onto itself -> succeeds (with no on-disk change)
Move a file into a directory -> succeeds
Move an empty directory into a directory -> succeeds
Move a file to overwrite an existing file -> succeeds (same as writeFile)
Move a directory tree into a directory -> succeeds
Move a directory tree out of a directory -> succeeds
```