### PR TITLE
chore(cli): Autodetect Android Studio path on Windows

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,7 +1,8 @@
-import { accessSync, readFileSync } from 'fs';
+import { accessSync, existsSync, readFileSync } from 'fs';
 import { basename, join, resolve } from 'path';
 import { logFatal, readJSON } from './common';
 import { CliConfig, ExternalConfig, OS, PackageJson } from './definitions';
+import { execSync } from 'child_process';
 
 let Package: PackageJson;
 let ExtConfig: ExternalConfig;
@@ -193,7 +194,17 @@ export class Config implements CliConfig {
   }
 
   private initWindowsConfig() {
-    this.windows.androidStudioPath = this.app.windowsAndroidStudioPath && this.app.windowsAndroidStudioPath;
+    if (this.app.windowsAndroidStudioPath) {
+      if (!existsSync(this.app.windowsAndroidStudioPath) && this.cli.os === OS.Windows) {
+        const buffer = execSync('REG QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio" /v Path');
+        const bufferString = buffer.toString('utf-8').replace(/(\r\n|\n|\r)/gm, '');
+        const ix = bufferString.indexOf('REG_SZ');
+        if (ix > 0) {
+          this.app.windowsAndroidStudioPath = bufferString.substring(ix + 6).trim() + '\\bin\\studio64.exe';
+        }
+      }
+      this.windows.androidStudioPath = this.app.windowsAndroidStudioPath;
+    }
   }
 
   private initLinuxConfig() {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -194,16 +194,23 @@ export class Config implements CliConfig {
   }
 
   private initWindowsConfig() {
+    if (this.cli.os !== OS.Windows) {
+        return;
+    }
     if (this.app.windowsAndroidStudioPath) {
-      if (!existsSync(this.app.windowsAndroidStudioPath) && this.cli.os === OS.Windows) {
-        const buffer = execSync('REG QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio" /v Path');
-        const bufferString = buffer.toString('utf-8').replace(/(\r\n|\n|\r)/gm, '');
-        const ix = bufferString.indexOf('REG_SZ');
-        if (ix > 0) {
-          this.app.windowsAndroidStudioPath = bufferString.substring(ix + 6).trim() + '\\bin\\studio64.exe';
+      try {
+        if (!existsSync(this.app.windowsAndroidStudioPath)) {
+          const buffer = execSync('REG QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio" /v Path');
+          const bufferString = buffer.toString('utf-8').replace(/(\r\n|\n|\r)/gm, '');
+          const ix = bufferString.indexOf('REG_SZ');
+          if (ix > 0) {
+            this.app.windowsAndroidStudioPath = bufferString.substring(ix + 6).trim() + '\\bin\\studio64.exe';
+          }
         }
+        this.windows.androidStudioPath = this.app.windowsAndroidStudioPath;
+      } catch (e) {
+         this.windows.androidStudioPath = '';
       }
-      this.windows.androidStudioPath = this.app.windowsAndroidStudioPath;
     }
   }
 


### PR DESCRIPTION
Auto Detect Android Studio path on Windows by reading a Windows registry entry.

First checks if path in `windowsAndroidStudioPath` exist. 
If not it tries to read the Windows registry entry `HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio`

Issues #560 and #230

Based on getASPath.bat 
https://github.com/apache/cordova-android/blob/master/bin/templates/cordova/lib/getASPath.bat