### PR TITLE
fix(cordova): forward requestCode 0 to Cordova plugins

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -663,8 +663,8 @@ public class Bridge {
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
-    if (plugin == null || requestCode == 0) {
-      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle requestCode, try with Cordova plugins " + requestCode);
+    if (plugin == null) {
+      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle permission requestCode, trying Cordova plugins " + requestCode);
       try {
         cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);
       } catch (JSONException e) {

--- a/android/capacitor/src/main/java/com/getcapacitor/NativePlugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/NativePlugin.java
@@ -23,7 +23,7 @@ public @interface NativePlugin {
   /**
    * The request code to use when automatically requesting permissions
    */
-  int permissionRequestCode() default 0;
+  int permissionRequestCode() default PluginRequestCodes.DEFAULT_CAPACITOR_REQUEST_PERMISSIONS;
 
   /**
    * A custom name for the plugin, otherwise uses the

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -1,6 +1,7 @@
 package com.getcapacitor;
 
 public class PluginRequestCodes {
+  public static final int DEFAULT_CAPACITOR_REQUEST_PERMISSIONS = 9000;
   public static final int BROWSER_OPEN_CHROME_TAB = 9001;
   public static final int CAMERA_IMAGE_CAPTURE = 9002;
   public static final int CAMERA_IMAGE_PICK = 9003;


### PR DESCRIPTION
Change default permissionRequestCode from 0 to 9000, so Cordova plugins that use incremental codes starting from 0 work.

Closes #1617