### PR TITLE
fix(cli): Allow to filter incompatible plugins per platform

### DIFF
--- a/cli/src/android/common.ts
+++ b/cli/src/android/common.ts
@@ -16,12 +16,13 @@ export function getAndroidPlugins(allPlugins: Plugin[]): Plugin[] {
 }
 
 export function resolvePlugin(plugin: Plugin): Plugin | null {
+  const platform = 'android';
   if (plugin.manifest && plugin.manifest.android) {
-    let pluginFilesPath = plugin.manifest.android.src ? plugin.manifest.android.src : 'android';
+    let pluginFilesPath = plugin.manifest.android.src ? plugin.manifest.android.src : platform;
     const absolutePath = join(plugin.rootPath, pluginFilesPath, plugin.id);
     // Android folder shouldn't have subfolders, but they used to, so search for them for compatibility reasons
     if (existsSync(absolutePath)) {
-      pluginFilesPath = join('android', plugin.id);
+      pluginFilesPath = join(platform, plugin.id);
     }
     plugin.android = {
       type: PluginType.Core,
@@ -30,9 +31,9 @@ export function resolvePlugin(plugin: Plugin): Plugin | null {
   } else if (plugin.xml) {
     plugin.android = {
       type: PluginType.Cordova,
-      path: 'src/android'
+      path: 'src/' + platform
     };
-    if(getIncompatibleCordovaPlugins().includes(plugin.id) || !getPluginPlatform(plugin, 'android')) {
+    if(getIncompatibleCordovaPlugins(platform).includes(plugin.id) || !getPluginPlatform(plugin, platform)) {
       plugin.android.type = PluginType.Incompatible;
     }
   } else {

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -318,7 +318,7 @@ export function getIncompatibleCordovaPlugins(platform: string){
   let pluginList = ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
   "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console",
   "cordova-plugin-compat", "cordova-plugin-music-controls", "cordova-plugin-add-swift-support",
-  "cordova-plugin-ionic-keyboard", "cordova-plugin-braintree"]
+  "cordova-plugin-ionic-keyboard", "cordova-plugin-braintree"];
   if (platform === "ios") {
     pluginList.push("cordova-plugin-googlemaps");
   }

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -290,7 +290,7 @@ export async function checkAndInstallDependencies(config: Config, plugins: Plugi
     if (p.xml['dependency']) {
       allDependencies = allDependencies.concat(p.xml['dependency']);
     }
-    allDependencies = allDependencies.filter((dep: any) => !getIncompatibleCordovaPlugins().includes(dep.$.id) && incompatible.filter(p => p.id === dep.$.id || p.xml.$.id === dep.$.id).length === 0);
+    allDependencies = allDependencies.filter((dep: any) => !getIncompatibleCordovaPlugins(platform).includes(dep.$.id) && incompatible.filter(p => p.id === dep.$.id || p.xml.$.id === dep.$.id).length === 0);
     if (allDependencies) {
       await Promise.all(allDependencies.map(async (dep: any) => {
         if (cordovaPlugins.filter(p => p.id === dep.$.id || p.xml.$.id === dep.$.id).length === 0) {
@@ -314,9 +314,13 @@ export async function checkAndInstallDependencies(config: Config, plugins: Plugi
   return needsUpdate;
 }
 
-export function getIncompatibleCordovaPlugins(){
-  return ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
+export function getIncompatibleCordovaPlugins(platform: string){
+  let pluginList = ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
   "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console",
   "cordova-plugin-compat", "cordova-plugin-music-controls", "cordova-plugin-add-swift-support",
-  "cordova-plugin-ionic-keyboard", "cordova-plugin-braintree"];
+  "cordova-plugin-ionic-keyboard", "cordova-plugin-braintree"]
+  if (platform === "ios") {
+    pluginList.push("cordova-plugin-googlemaps");
+  }
+  return pluginList;
 }

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -42,19 +42,20 @@ export function getIOSPlugins(allPlugins: Plugin[]): Plugin[] {
 }
 
 export function resolvePlugin(plugin: Plugin): Plugin | null {
+  const platform = 'ios';
   if (plugin.manifest && plugin.manifest.ios) {
     plugin.ios = {
       name: plugin.name,
       type: PluginType.Core,
-      path: plugin.manifest.ios.src ? plugin.manifest.ios.src : 'ios'
+      path: plugin.manifest.ios.src ? plugin.manifest.ios.src : platform
     };
   } else if (plugin.xml) {
     plugin.ios = {
       name: plugin.name,
       type: PluginType.Cordova,
-      path: 'src/ios'
+      path: 'src/' + platform
     };
-    if(getIncompatibleCordovaPlugins().includes(plugin.id) || !getPluginPlatform(plugin, 'ios')) {
+    if(getIncompatibleCordovaPlugins(platform).includes(plugin.id) || !getPluginPlatform(plugin, platform)) {
       plugin.ios.type = PluginType.Incompatible;
     }
   } else {


### PR DESCRIPTION
and add `cordova-plugin-googlemaps` as iOS incompatible only.