### PR TITLE
feat(): labels for actionsheet options on camera plugin

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -26,6 +26,10 @@ import com.getcapacitor.plugin.camera.CameraSource;
 import com.getcapacitor.plugin.camera.CameraUtils;
 import com.getcapacitor.plugin.camera.ExifWrapper;
 import com.getcapacitor.plugin.camera.ImageUtils;
+import com.getcapacitor.plugin.camera.PromptSettings;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -84,7 +88,7 @@ public class Camera extends Plugin {
   private void doShow(PluginCall call) {
     switch (settings.getSource()) {
       case PROMPT:
-        showPrompt(call);
+        showPrompt(call, settings.getPromptSettings());
         break;
       case CAMERA:
         showCamera(call);
@@ -93,17 +97,17 @@ public class Camera extends Plugin {
         showPhotos(call);
         break;
       default:
-        showPrompt(call);
+        showPrompt(call, settings.getPromptSettings());
         break;
     }
   }
 
-  private void showPrompt(final PluginCall call) {
+  private void showPrompt(final PluginCall call, PromptSettings settings) {
     // We have all necessary permissions, open the camera
     JSObject fromPhotos = new JSObject();
-    fromPhotos.put("title", "From Photos");
+    fromPhotos.put("title", settings.getFromPhotos());
     JSObject takePicture = new JSObject();
-    takePicture.put("title", "Take Picture");
+    takePicture.put("title", settings.getTakePicture());
     Object[] options = new Object[] {
       fromPhotos,
       takePicture
@@ -173,6 +177,25 @@ public class Camera extends Plugin {
       settings.setSource(CameraSource.valueOf(call.getString("source", CameraSource.PROMPT.getSource())));
     } catch (IllegalArgumentException ex) {
       settings.setSource(CameraSource.PROMPT);
+    }
+    settings.setPromptSettings(getPromptSettings(call));
+
+    return settings;
+  }
+
+  private PromptSettings getPromptSettings(PluginCall call) {
+    PromptSettings settings = new  PromptSettings();
+    JSONObject labels = call.getObject("labels");
+    if (labels != null) {
+      try {
+        String fromPhotos = labels.getString("fromPhotos");
+        settings.setFromPhotos(fromPhotos);
+      } catch (JSONException e) {}
+
+      try {
+        String takePicture = labels.getString("takePicture");
+        settings.setTakePicture(takePicture);
+      } catch (JSONException e) {}
     }
     return settings;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraSettings.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraSettings.java
@@ -7,6 +7,8 @@ public class CameraSettings {
     public static final boolean DEFAULT_CORRECT_ORIENTATION = true;
 
     private CameraResultType resultType = CameraResultType.BASE64;
+    private PromptSettings promptSettings = new PromptSettings();
+
     private int quality = DEFAULT_QUALITY;
     private boolean shouldResize = false;
     private boolean shouldCorrectOrientation = DEFAULT_CORRECT_ORIENTATION;
@@ -23,6 +25,10 @@ public class CameraSettings {
     public void setResultType(CameraResultType resultType) {
         this.resultType = resultType;
     }
+
+    public PromptSettings getPromptSettings() { return promptSettings; }
+
+    public void setPromptSettings(PromptSettings promptSettings) { this.promptSettings = promptSettings; }
 
     public int getQuality() {
         return quality;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/PromptSettings.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/PromptSettings.java
@@ -1,0 +1,22 @@
+package com.getcapacitor.plugin.camera;
+
+public class PromptSettings {
+    public String fromPhotos = "Photo";
+    public String takePicture = "Take Picture";
+
+    public String getFromPhotos() {
+        return fromPhotos;
+    }
+
+    public void setFromPhotos(String fromPhotos) {
+        this.fromPhotos = fromPhotos;
+    }
+
+    public String getTakePicture() {
+        return takePicture;
+    }
+
+    public void setTakePicture(String takePicture) {
+        this.takePicture = takePicture;
+    }
+}

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -309,6 +309,16 @@ export interface CameraOptions {
    * iOS only: The presentation style of the Camera. Defaults to fullscreen.
    */
   presentationStyle?: 'fullscreen' | 'popover';
+
+  /**
+   * UI labels available thought the plugin
+   */
+  labels?: {
+    photo: string;
+    fromPhotos: string;
+    takePicture: string;
+    cancel: string;
+  };
 }
 
 export enum CameraSource {

--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -52,7 +52,13 @@ async takePicture() {
   const image = await Camera.getPhoto({
     quality: 90,
     allowEditing: true,
-    resultType: CameraResultType.Uri
+    resultType: CameraResultType.Uri,
+    labels: { // not required, but available
+      photo: 'Photo', // Only iOS (action-sheet title)
+      fromPhotos: 'From my photo gallery',
+      takePicture: 'Take a Picture',
+      cancel: 'Cancel' // Only iOS (action-sheet cancel label)
+    }
   });
   // image.webPath will contain a path that can be set as an image src. 
   // You can access the original file using image.path, which can be 


### PR DESCRIPTION
We have found the need to translate the camera plugin action-sheet labels and we think you might find it usefull.

We came up with the following interface, but we are of course open to any suggestion or correction:
```ts

async takePicture() {
  const image = await Camera.getPhoto({
    quality: 90,
    allowEditing: true,
    resultType: CameraResultType.Uri,
    labels: {
      photo: 'Photo', // Only iOS (action-sheet title)
      fromPhotos: 'From my photo gallery',
      takePicture: 'Take a Picture',
      cancel: 'Cancel' // Only iOS (action-sheet cancel label)
    }
});
```

thanks for the great work ;) 
(we will be in production pretty soon)