### PR TITLE
fix(electron): add .gitignore

### DIFF
--- a/electron-template/gitignore
+++ b/electron-template/gitignore
@@ -1,0 +1,6 @@
+# NPM renames .gitignore to .npmignore
+# In order to prevent that, we remove the initial "."
+# And the CLI then renames it
+
+app/
+node_modules/


### PR DESCRIPTION
The `app/` directory is generated with `npx cap copy electron` and consequently can be ignored. Also, `node_modules/` can be ignored for obvious reasons.

This also resolves #1560.