### PR TITLE
chore(electron): improve template and dependency installation

### DIFF
--- a/cli/src/electron/add.ts
+++ b/cli/src/electron/add.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { Config } from '../config';
-import { copyTemplate, hasYarn, runTask } from '../common';
+import { copyTemplate, installDeps, hasYarn, runTask } from '../common';
 
 export async function addElectron(config: Config) {
 
@@ -16,14 +16,11 @@ export async function addElectron(config: Config) {
 function installNpmDeps(config: Config) {
   const pathToElectronPackageJson = config.electron.platformDir;
   return new Promise(async (resolve, reject) => {
-    console.log('Installing NPM Dependencies...');
-    exec(`${await hasYarn(config) ? 'yarn' : 'npm'} install`, {cwd: pathToElectronPackageJson}, (error, stdout, stderr) => {
+    exec(`${await hasYarn(config) ? 'yarn' : 'npm'} install`, {cwd: pathToElectronPackageJson}, async (error, stdout, stderr) => {
       if (error) {
         reject(error);
       }
-      console.log(`${stdout}`);
-      console.log(`${stderr}`);
-      console.log(`NPM Dependencies installed!`);
+      await installDeps(pathToElectronPackageJson, ['@capacitor/electron'], config);
       resolve();
     });
   });

--- a/cli/src/electron/copy.ts
+++ b/cli/src/electron/copy.ts
@@ -8,13 +8,8 @@ export async function copyElectron(config: Config) {
   const webAbsDir = config.app.webDirAbs;
   const webRelDir = basename(webAbsDir);
   const nativeRelDir = relative(config.app.rootDir, config.electron.webDirAbs);
-  // const runtimePath = resolveNode(config, '@capacitor/core', 'dist', 'capacitor.js');
   return await runTask(`Copying web assets from ${chalk.bold(webRelDir)} to ${chalk.bold(nativeRelDir)}`, async () => {
-    console.log(`Cleaning ${config.electron.webDirAbs}...`);
     await removeAsync(config.electron.webDirAbs);
-    console.log(`Copying web assets...`);
     return copyTemplate(webAbsDir, config.electron.webDirAbs);
-    // console.log(`Copying runtime...`);
-    // return copy(runtimePath, join(config.electron.webDirAbs, 'capacitor.js'));
   });
 }

--- a/electron-template/package.json
+++ b/electron-template/package.json
@@ -7,8 +7,7 @@
     "electron:start": "electron ./"
   },
   "dependencies": {
-    "@capacitor/electron": "^1.0.0",
-    "electron-is-dev": "^0.3.0"
+    "electron-is-dev": "^1.1.0"
   },
   "devDependencies": {
     "electron": "^4.0.0"


### PR DESCRIPTION
More clean install/add logs
Removed comments
Install @capacitor/electron on add instead of as dependency of package.json so the template doesn't need to be updated.
Updated dependency
