### PR TITLE
docs(electron): add updating markdown file

### DIFF
--- a/site/docs-md/electron/updating.md
+++ b/site/docs-md/electron/updating.md
@@ -1,0 +1,15 @@
+---
+title: Updating Your Capacitor Electron Project
+description: Updating Your Capacitor Electron Project
+url: /docs/electron/updating
+contributors:
+  - devinshoemaker
+---
+
+# Updating Your Capacitor Electron Project
+
+<p class="intro">Occasionally, you'll need to make Capacitor updates to your Electron app, including new ways of interfacing with Capacitor inside of your Electron codebase.</a>
+
+## Updating Electron Project
+
+To update the base structure of your Electron project, view the [electron-template](https://github.com/ionic-team/capacitor/tree/master/electron-template) project in the Capacitor repo, under the tag corresponding to the latest stable release of Capacitor. The core project is kept simple on purpose: it shouldn't take much time to see what is different from the core project and your project.


### PR DESCRIPTION
As a developer using Capacitor, I would like to have a guide to updating my Electron application, similar to what is available for iOS and Android, so that I can have a reference to keeping my application up-to-date.