### PR TITLE
feat(webview): Add backgroundColor configuration option

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -320,6 +321,20 @@ public class Bridge {
     if (Config.getBoolean("android.allowMixedContent", false)) {
       settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
     }
+    String backgroundColor = Config.getString("android.backgroundColor" , Config.getString("backgroundColor", null));
+    try {
+      if (backgroundColor != null) {
+        webView.setBackgroundColor(Color.parseColor(backgroundColor));
+      }
+    } catch (IllegalArgumentException ex) {
+      Log.d(LogUtils.getCoreTag(), "WebView background color not applied");
+    }
+    boolean defaultDebuggable = false;
+    if (isDevMode()) {
+      defaultDebuggable = true;
+    }
+
+    WebView.setWebContentsDebuggingEnabled(Config.getBoolean("android.webContentsDebuggingEnabled", defaultDebuggable));
   }
 
   /**

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -3,7 +3,6 @@ package com.getcapacitor;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -14,7 +13,6 @@ import com.getcapacitor.cordova.MockCordovaWebViewImpl;
 import com.getcapacitor.plugin.App;
 
 import org.apache.cordova.ConfigXmlParser;
-import org.apache.cordova.CordovaInterfaceImpl;
 import org.apache.cordova.CordovaPreferences;
 import org.apache.cordova.PluginEntry;
 import org.apache.cordova.PluginManager;
@@ -52,12 +50,6 @@ public class BridgeActivity extends AppCompatActivity {
     setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
     setTheme(R.style.AppTheme_NoActionBar);
 
-    boolean defaultDebuggable = false;
-    if (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
-      defaultDebuggable = true;
-    }
-
-    WebView.setWebContentsDebuggingEnabled(Config.getBoolean("android.webContentsDebuggingEnabled", defaultDebuggable));
 
     setContentView(R.layout.bridge_layout_main);
 
@@ -71,6 +63,7 @@ public class BridgeActivity extends AppCompatActivity {
     Log.d(LogUtils.getCoreTag(), "Starting BridgeActivity");
 
     webView = findViewById(R.id.webview);
+
     cordovaInterface = new MockCordovaInterfaceImpl(this);
     if (savedInstanceState != null) {
       cordovaInterface.restoreInstanceState(savedInstanceState);

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -70,6 +70,11 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     if let scrollEnabled = bridge!.config.getValue("ios.scrollEnabled") as? Bool {
         webView?.scrollView.isScrollEnabled = scrollEnabled
     }
+
+    if let backgroundColor = (bridge!.config.getValue("ios.backgroundColor") as? String) ?? (bridge!.config.getValue("backgroundColor") as? String) {
+        webView?.backgroundColor = UIColor(fromHex: backgroundColor)
+        webView?.scrollView.backgroundColor = UIColor(fromHex: backgroundColor)
+    }
   }
   
   private func getStartPath() -> String? {

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -71,7 +71,11 @@ The current ones you might configure are:
       "192.0.2.1"
     ]
   },
+  // Background color of Capacitor WebView for both iOS and Android unless also declared inside ios or android objects
+  "backgroundColor": "#ffffffff",
   "android": {
+    // Background color of Capacitor WebView for Android only
+    "backgroundColor": "#ffffffff",
     // On Android, if you are loading the app from a remote/testing server from https
     // protocol, you need to enable mixed content mode to allow the WebView to load
     // files from different schemes such as capacitor-content:// or capacitor-file://
@@ -87,6 +91,8 @@ The current ones you might configure are:
     "webContentsDebuggingEnabled": true
   },
   "ios": {
+    // Background color of Capacitor WebView for iOS only
+    "backgroundColor": "#ffffffff",
     // Configure the Swift version to be used for Cordova plugins.
     // Default is 4.0
     "cordovaSwiftVersion": "3.0",


### PR DESCRIPTION
Adds backgroundColor configuration option for the webview for both Android and iOS. It can use the same value for both platforms if on the root, or per platform if inside the platform object.

Also fixes a problem with `android.webContentsDebuggingEnabled` configuration option not working. 

Closes #1003