### PR TITLE
Use correct install command for @capacitor/cli in "Installing Capacitor"

### DIFF
--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -33,7 +33,8 @@ To add Capacitor to your web app, run the following commands:
 
 ```bash
 cd my-app
-npm install --save @capacitor/core @capacitor/cli
+npm install --save-dev @capacitor/cli
+npm install --save @capacitor/core
 ```
 
 Then, initialize Capacitor with your app information.


### PR DESCRIPTION
The `@capacitor/cli` package should be installed as a devDependency. Updated the "Installing Capacitor" page to use the correct commands for this.