### PR TITLE
Add support for Web Share API Level 2 in Share plugin

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1387,9 +1387,14 @@ export interface ShareOptions {
    */
   url?: string;
   /**
+   * Set files object array to share
+   */
+  files?: [File];
+  /**
    * Set a title for the share modal. Android only
    */
   dialogTitle?: string;
+
 }
 
 //

--- a/core/src/web/share.ts
+++ b/core/src/web/share.ts
@@ -19,12 +19,23 @@ export class SharePluginWeb extends WebPlugin implements SharePlugin {
     if (!navigator.share) {
       return Promise.reject("Web Share API not available");
     }
-
+    if (!options.files) {
+      return navigator.share({
+        title: options.title,
+        text: options.text,
+        url: options.url
+      });
+    }
+    if (!(navigator.canShare && navigator.canShare({files: options.files}))) {
+      return Promise.reject("Web Share API Level 2 not available");
+    }
     return navigator.share({
       title: options.title,
       text: options.text,
-      url: options.url
+      url: options.url,
+      files: options.files
     });
+
   }
 }
 


### PR DESCRIPTION
Add 'files' field to ShareOptions interface. If this new field is not filled, the share plugin behaves as usual, otherwise it checks for availability of file sharing, and requests it from the global navigator.

Closes #1704