### PR TITLE
fix(cli/init): check if project already uses yarn before prompting

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -325,7 +325,7 @@ export async function getAppId(config: Config, id: string) {
 export function getNpmClient(config: Config, npmClient: string): Promise<string> {
   return new Promise(async (resolve) => {
     if (!npmClient) {
-      // const isYarnInstalled
+      if (await hasYarn(config)) return resolve('yarn')
       exec('yarn --version', async (err, stdout) => {
         // Don't show prompt if yarn is not installed
         if (err || !isInteractive()) {


### PR DESCRIPTION
If you init capacitor in a project, it would prompt for an npm client, even if the project already has a `yarn.lock`. If a project has a `yarn.lock`, capacitor should automatically use yarn as the npm client, instead of prompting. This PR fixes that.