### PR TITLE
fix(web): support for App 'appStateChange' event

### DIFF
--- a/core/src/web/app.ts
+++ b/core/src/web/app.ts
@@ -8,10 +8,12 @@ export class AppPluginWeb extends WebPlugin implements AppPlugin {
       name: 'App',
       platforms: ['web']
     });
+
+    document.addEventListener('visibilitychange', this.handleVisibilityChange.bind(this), false);
   }
 
   exitApp(): never {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 
   canOpenUrl(_options: { url: string; }): Promise<{ value: boolean; }> {
@@ -24,6 +26,14 @@ export class AppPluginWeb extends WebPlugin implements AppPlugin {
 
   getLaunchUrl(): Promise<AppLaunchUrl> {
     return Promise.resolve({ url: '' });
+  }
+
+  handleVisibilityChange():void {
+    const data = {
+      isActive: document.hidden !== true
+    };
+
+    this.notifyListeners('appStateChange', data);
   }
 }
 


### PR DESCRIPTION
Today I've started to use Capacitor and I like the fact that I can use the web plug-ins to simplify our codebase. The 'appStateChange' event was not working in the web environment, so I've added it by listening to 'visibilitychange' on the document. 

Since it's my first hours with the project, I don't know if I put it in the right spot... 