### PR TITLE
docs: Fix install link on web section

### DIFF
--- a/site/docs-md/web/index.md
+++ b/site/docs-md/web/index.md
@@ -14,7 +14,7 @@ contributors:
 
 Chances are, you already have Capacitor installed in your app if you're using Capacitor to build an iOS, Android, or Electron app. In capacitor, the `web` platform is just the web project that powers your app!
 
-If you don't have Capacitor installed yet, consult the [Installation](../getting-started) guide before continuing.
+If you don't have Capacitor installed yet, consult the [Installation](./getting-started) guide before continuing.
 
 #### Using Capacitor as a Module
 


### PR DESCRIPTION
It current brings to https://capacitor.ionicframework.com/getting-started/