### PR TITLE
update(plugins): add @rdlabo/capacitor-admob

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -86,6 +86,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
 | AdMob | `capacitor-admob` | <https://github.com/rahadur/capacitor-admob> | Android only (currently) |
+| AdMob | `@rdlabo/capacitor-admob` | <https://github.com/rdlabo/capacitor-admob> | |
 
 ## Notifications
 


### PR DESCRIPTION
This is forked from `capacitor-admob` , because `capacitor-admob` worked only capacitor/android@beta only.