### PR TITLE
DO NOT MERGE (WIP) - FilesystemWeb inconsistency

### DIFF
--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -26,7 +26,6 @@ import {
 } from '../core-plugin-definitions';
 
 export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
-  DEFAULT_DIRECTORY = FilesystemDirectory.Data;
   DB_VERSION = 1;
   DB_NAME = 'Disc';
 
@@ -108,9 +107,10 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
   }
 
   private getPath(directory: FilesystemDirectory | undefined, uriPath: string | undefined): string {
-    directory = directory || this.DEFAULT_DIRECTORY;
     let cleanedUriPath = uriPath !== undefined ? uriPath.replace(/^[/]+|[/]+$/g, '') : '';
-    return '/' + directory + '/' + cleanedUriPath;
+    return directory
+      ? '/' + directory + '/' + cleanedUriPath
+      : '/' + cleanedUriPath;
   }
 
   async clear(): Promise<{}> {


### PR DESCRIPTION
To stay consestent with iOS and Android do not use DEFAULT_DIRECTORY if it is not provided in readFile options. It was adding '/Data/' event when full there was full URI provided in path option.