### PR TITLE
capacitor.config.json with templates

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -140,16 +140,34 @@ public class Plugin {
   }
 
   public Object getConfigValue(String key) {
+    String configKey = "plugins." + getPluginHandle().getId();
+
     try {
-      JSONObject plugins = Config.getObject("plugins");
-      if (plugins == null) {
-        return null;
+      JSONObject JSONObject = Config.getObject(configKey);
+      Object object = JSONObject.get(key);
+
+      if (object != null) {
+        if (object instanceof String) {
+          return Config.substituteTemplateValue((String) object);
+        }
+
+        if (object instanceof String[]) {
+          String[] stringArray = (String[]) object;
+
+          int l = stringArray.length;
+          String[] value = new String[l];
+
+          for(int i=0; i<l; i++) {
+            value[i] = Config.substituteTemplateValue(stringArray[i]);
+          }
+
+          return value;
+        }
+
+        return object;
       }
-      JSONObject pluginConfig = plugins.getJSONObject(getPluginHandle().getId());
-      return pluginConfig.get(key);
-    } catch (JSONException ex) {
-      return null;
-    }
+    } catch (JSONException eq) {}
+    return null;
   }
 
   /**

--- a/ios/Capacitor/Capacitor/CAPConfig.swift
+++ b/ios/Capacitor/Capacitor/CAPConfig.swift
@@ -72,6 +72,14 @@ import Foundation
       return nil
     }
     
+    if let string = pluginOptions[configKey] as? String {
+      return substituteTemplateValue(string: string)
+    }
+    
+    if let stringArray = pluginOptions[configKey] as? [String] {
+      return stringArray.map({ substituteTemplateValue(string: $0) })
+    }
+    
     return pluginOptions[configKey]
   }
   


### PR DESCRIPTION
The basic idea is to allow for pulling in variables from the platforms configuration systems.

Both iOS and Android allow users to have different configurations for dev / release they may choose from when running a build, along with ways of managing that configuration with respect to source control.

This PR allows utilization of those values from the capacitor.config.json through the syntax $(variable_name). 

This could be part of the solution for: https://github.com/ionic-team/capacitor/issues/1478

And provides better configuration as asked for by me here: https://github.com/ionic-team/capacitor/issues/1741

Note that this PR only includes Android / iOS implementations, web / electron is not supported by this PR at this time.

Future improvements may include default values and non string types.