### PR TITLE
feat(): Add copy implementation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -22,4 +22,5 @@ public class PluginRequestCodes {
   public static final int FILESYSTEM_REQUEST_URI_PERMISSIONS = 9018;
   public static final int FILESYSTEM_REQUEST_STAT_PERMISSIONS = 9019;
   public static final int FILESYSTEM_REQUEST_RENAME_PERMISSIONS = 9020;
+  public static final int FILESYSTEM_REQUEST_COPY_PERMISSIONS = 9021;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
+import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -39,6 +40,7 @@ import java.nio.charset.StandardCharsets;
   PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS,
   PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS,
+  PluginRequestCodes.FILESYSTEM_REQUEST_COPY_PERMISSIONS,
 })
 public class Filesystem extends Plugin {
 
@@ -49,7 +51,7 @@ public class Filesystem extends Plugin {
       return null;
     }
 
-    switch(encoding) {
+    switch (encoding) {
       case "utf8":
         return StandardCharsets.UTF_8;
       case "utf16":
@@ -62,7 +64,7 @@ public class Filesystem extends Plugin {
 
   private File getDirectory(String directory) {
     Context c = bridge.getContext();
-    switch(directory) {
+    switch (directory) {
       case "APPLICATION":
         return c.getFilesDir();
       case "DOCUMENTS":
@@ -92,7 +94,7 @@ public class Filesystem extends Plugin {
     if (androidDirectory == null) {
       return null;
     } else {
-      if(!androidDirectory.exists()) {
+      if (!androidDirectory.exists()) {
         androidDirectory.mkdir();
       }
     }
@@ -156,32 +158,32 @@ public class Filesystem extends Plugin {
     String encoding = call.getString("encoding");
 
     Charset charset = this.getEncoding(encoding);
-    if(encoding != null && charset == null) {
+    if (encoding != null && charset == null) {
       call.error("Unsupported encoding provided: " + encoding);
       return;
     }
 
     if (!isPublicDirectory(directory)
-        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FILE_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-        try {
-          InputStream is = getInputStream(file, directory);
-          String dataStr;
-          if (charset != null) {
-            dataStr = readFileAsString(is, charset.name());
-          } else {
-            dataStr = readFileAsBase64EncodedData(is);
-          }
-
-          JSObject ret = new JSObject();
-          ret.putOpt("data", dataStr);
-          call.success(ret);
-        } catch (FileNotFoundException ex) {
-          call.error("File does not exist", ex);
-        } catch (IOException ex) {
-          call.error("Unable to read file", ex);
-        } catch(JSONException ex) {
-          call.error("Unable to return value for reading file", ex);
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FILE_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+      try {
+        InputStream is = getInputStream(file, directory);
+        String dataStr;
+        if (charset != null) {
+          dataStr = readFileAsString(is, charset.name());
+        } else {
+          dataStr = readFileAsBase64EncodedData(is);
         }
+
+        JSObject ret = new JSObject();
+        ret.putOpt("data", dataStr);
+        call.success(ret);
+      } catch (FileNotFoundException ex) {
+        call.error("File does not exist", ex);
+      } catch (IOException ex) {
+        call.error("Unable to read file", ex);
+      } catch (JSONException ex) {
+        call.error("Unable to return value for reading file", ex);
+      }
     }
   }
 
@@ -263,7 +265,7 @@ public class Filesystem extends Plugin {
       }
     } else {
       //remove header from dataURL
-      if(data.indexOf(",") != -1) {
+      if (data.indexOf(",") != -1) {
         data = data.split(",")[1];
       }
       try (FileOutputStream fos = new FileOutputStream(file, append)) {
@@ -277,7 +279,7 @@ public class Filesystem extends Plugin {
     if (success) {
       // update mediaStore index only if file was written to external storage
       if (isPublicDirectory(getDirectoryParameter(call))) {
-        MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
+        MediaScannerConnection.scanFile(getContext(), new String[]{file.getAbsolutePath()}, null, null);
       }
       Log.d(getLogTag(), "File '" + file.getAbsolutePath() + "' saved!");
       call.success();
@@ -304,14 +306,14 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(file, directory);
 
     if (!isPublicDirectory(directory)
-        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FILE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FILE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("File does not exist");
         return;
       }
 
       boolean deleted = fileObject.delete();
-      if(deleted == false) {
+      if (deleted == false) {
         call.error("Unable to delete file");
       } else {
         call.success();
@@ -334,14 +336,14 @@ public class Filesystem extends Plugin {
     }
 
     if (!isPublicDirectory(directory)
-            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       boolean created = false;
       if (intermediate) {
         created = fileObject.mkdirs();
       } else {
         created = fileObject.mkdir();
       }
-      if(created == false) {
+      if (created == false) {
         call.error("Unable to create directory, unknown reason");
       } else {
         call.success();
@@ -358,7 +360,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("Directory does not exist");
         return;
@@ -366,7 +368,7 @@ public class Filesystem extends Plugin {
 
       boolean deleted = fileObject.delete();
 
-      if(deleted == false) {
+      if (deleted == false) {
         call.error("Unable to delete directory, unknown reason");
       } else {
         call.success();
@@ -382,8 +384,8 @@ public class Filesystem extends Plugin {
 
     File fileObject = getFileObject(path, directory);
 
-     if (!isPublicDirectory(directory)
-         || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FOLDER_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+    if (!isPublicDirectory(directory)
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FOLDER_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       if (fileObject != null && fileObject.exists()) {
         String[] files = fileObject.list();
 
@@ -391,7 +393,7 @@ public class Filesystem extends Plugin {
         ret.put("files", JSArray.from(files));
         call.success(ret);
       } else {
-      call.error("Directory does not exist");
+        call.error("Directory does not exist");
       }
     }
   }
@@ -405,7 +407,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       JSObject data = new JSObject();
       data.put("uri", Uri.fromFile(fileObject).toString());
       call.success(data);
@@ -421,7 +423,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("File does not exist");
         return;
@@ -437,12 +439,48 @@ public class Filesystem extends Plugin {
     }
   }
 
-  @PluginMethod()
-  public void rename(PluginCall call) {
+  /**
+   * Helper function to recursively copy a directory structure (or just a file)
+   *
+   * @param src The source location
+   * @param dst The destination location
+   * @throws IOException
+   */
+  private static void copyRecursively(File src, File dst) throws IOException {
+    if (src.isDirectory()) {
+      dst.mkdir();
+
+      for (String file : src.list()) {
+        copyRecursively(new File(src, file), new File(dst, file));
+      }
+
+      return;
+    }
+
+    if (!dst.getParentFile().exists()) {
+      dst.getParentFile().mkdirs();
+    }
+
+    if (!dst.exists()) {
+      dst.createNewFile();
+    }
+
+    try (FileChannel source = new FileInputStream(src).getChannel(); FileChannel destination = new FileOutputStream(dst).getChannel()) {
+      destination.transferFrom(source, 0, source.size());
+    }
+  }
+
+  private void _copy(PluginCall call, boolean doRename) {
     saveCall(call);
+
     String from = call.getString("from");
     String to = call.getString("to");
-    String directory = getDirectoryParameter(call);
+    String directory = call.getString("directory");
+    String toDirectory = call.getString("toDirectory");
+
+    if (toDirectory == null) {
+      toDirectory = directory;
+    }
 
     if (from == null || from.isEmpty() || to == null || to.isEmpty()) {
       call.error("Both to and from must be provided");
@@ -455,43 +493,87 @@ public class Filesystem extends Plugin {
     }
 
     File fromObject = getFileObject(from, directory);
-    File toObject = getFileObject(to, directory);
+    File toObject = getFileObject(to, toDirectory);
 
-    if (!isPublicDirectory(directory)
-            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-
-      assert toObject != null;
-      if (toObject.isDirectory()) {
-        call.error("Cannot overwrite a directory");
-        return;
-      }
-      toObject.delete();
-
-      assert fromObject != null;
-      boolean renamed = fromObject.renameTo(toObject);
-
-      if (!renamed) {
-        call.error("Unable to rename, unknown reason");
-        return;
-      }
-
-      call.success();
+    if (!fromObject.exists()) {
+      call.error("The source object does not exist");
+      return;
     }
+
+    if (toObject.getParentFile().isFile()) {
+      call.error("The parent object of the destination is a file");
+      return;
+    }
+
+    if (!toObject.getParentFile().exists()) {
+      call.error("The parent object of the destination does not exist");
+      return;
+    }
+
+    if (isPublicDirectory(directory) || isPublicDirectory(toDirectory)) {
+      if (doRename) {
+        if (!isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          return;
+        }
+      } else {
+        if (!isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_COPY_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          return;
+        }
+      }
+    }
+
+    assert toObject != null;
+    if (toObject.isDirectory()) {
+      call.error("Cannot overwrite a directory");
+      return;
+    }
+
+    toObject.delete();
+
+    assert fromObject != null;
+    boolean modified = false;
+
+    if (doRename) {
+      modified = fromObject.renameTo(toObject);
+    } else {
+      try {
+        copyRecursively(fromObject, toObject);
+        modified = true;
+      } catch (IOException ignored) {
+      }
+    }
+
+    if (!modified) {
+      call.error("Unable to perform action, unknown reason");
+      return;
+    }
+
+    call.success();
+  }
+
+  @PluginMethod()
+  public void rename(PluginCall call) {
+    this._copy(call, true);
+  }
+
+  @PluginMethod()
+  public void copy(PluginCall call) {
+    this._copy(call, false);
   }
 
   /**
    * Checks the the given permission and requests them if they are not already granted.
    * @param permissionRequestCode the request code see {@link PluginRequestCodes}
-   * @param permission the permission string
+   * @param permission            the permission string
    * @return Returns true if the permission is granted and false if it is denied.
    */
   private boolean isStoragePermissionGranted(int permissionRequestCode, String permission) {
     if (hasPermission(permission)) {
-      Log.v(getLogTag(),"Permission '" + permission + "' is granted");
+      Log.v(getLogTag(), "Permission '" + permission + "' is granted");
       return true;
     } else {
-      Log.v(getLogTag(),"Permission '" + permission + "' denied. Asking user for it.");
-      pluginRequestPermissions(new String[] {permission}, permissionRequestCode);
+      Log.v(getLogTag(), "Permission '" + permission + "' denied. Asking user for it.");
+      pluginRequestPermissions(new String[]{permission}, permissionRequestCode);
       return false;
     }
   }
@@ -516,10 +598,10 @@ public class Filesystem extends Plugin {
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
 
-    Log.d(getLogTag(),"handling request perms result");
+    Log.d(getLogTag(), "handling request perms result");
 
     if (getSavedCall() == null) {
-      Log.d(getLogTag(),"No stored plugin call for permissions request result");
+      Log.d(getLogTag(), "No stored plugin call for permissions request result");
       return;
     }
 
@@ -528,7 +610,7 @@ public class Filesystem extends Plugin {
     for (int i = 0; i < grantResults.length; i++) {
       int result = grantResults[i];
       String perm = permissions[i];
-      if(result == PackageManager.PERMISSION_DENIED) {
+      if (result == PackageManager.PERMISSION_DENIED) {
         Log.d(getLogTag(), "User denied storage permission: " + perm);
         savedCall.error(PERMISSION_DENIED_ERROR);
         this.freeSavedCall();
@@ -554,6 +636,8 @@ public class Filesystem extends Plugin {
       this.stat(savedCall);
     } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_RENAME_PERMISSIONS) {
       this.rename(savedCall);
+    } else if (requestCode == PluginRequestCodes.FILESYSTEM_REQUEST_COPY_PERMISSIONS) {
+      this.copy(savedCall);
     }
     this.freeSavedCall();
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -51,7 +51,7 @@ public class Filesystem extends Plugin {
       return null;
     }
 
-    switch (encoding) {
+    switch(encoding) {
       case "utf8":
         return StandardCharsets.UTF_8;
       case "utf16":
@@ -64,7 +64,7 @@ public class Filesystem extends Plugin {
 
   private File getDirectory(String directory) {
     Context c = bridge.getContext();
-    switch (directory) {
+    switch(directory) {
       case "APPLICATION":
         return c.getFilesDir();
       case "DOCUMENTS":
@@ -94,7 +94,7 @@ public class Filesystem extends Plugin {
     if (androidDirectory == null) {
       return null;
     } else {
-      if (!androidDirectory.exists()) {
+      if(!androidDirectory.exists()) {
         androidDirectory.mkdir();
       }
     }
@@ -158,32 +158,32 @@ public class Filesystem extends Plugin {
     String encoding = call.getString("encoding");
 
     Charset charset = this.getEncoding(encoding);
-    if (encoding != null && charset == null) {
+    if(encoding != null && charset == null) {
       call.error("Unsupported encoding provided: " + encoding);
       return;
     }
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FILE_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-      try {
-        InputStream is = getInputStream(file, directory);
-        String dataStr;
-        if (charset != null) {
-          dataStr = readFileAsString(is, charset.name());
-        } else {
-          dataStr = readFileAsBase64EncodedData(is);
-        }
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FILE_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+        try {
+          InputStream is = getInputStream(file, directory);
+          String dataStr;
+          if (charset != null) {
+            dataStr = readFileAsString(is, charset.name());
+          } else {
+            dataStr = readFileAsBase64EncodedData(is);
+          }
 
-        JSObject ret = new JSObject();
-        ret.putOpt("data", dataStr);
-        call.success(ret);
-      } catch (FileNotFoundException ex) {
-        call.error("File does not exist", ex);
-      } catch (IOException ex) {
-        call.error("Unable to read file", ex);
-      } catch (JSONException ex) {
-        call.error("Unable to return value for reading file", ex);
-      }
+          JSObject ret = new JSObject();
+          ret.putOpt("data", dataStr);
+          call.success(ret);
+        } catch (FileNotFoundException ex) {
+          call.error("File does not exist", ex);
+        } catch (IOException ex) {
+          call.error("Unable to read file", ex);
+        } catch(JSONException ex) {
+          call.error("Unable to return value for reading file", ex);
+        }
     }
   }
 
@@ -265,7 +265,7 @@ public class Filesystem extends Plugin {
       }
     } else {
       //remove header from dataURL
-      if (data.indexOf(",") != -1) {
+      if(data.indexOf(",") != -1) {
         data = data.split(",")[1];
       }
       try (FileOutputStream fos = new FileOutputStream(file, append)) {
@@ -279,7 +279,7 @@ public class Filesystem extends Plugin {
     if (success) {
       // update mediaStore index only if file was written to external storage
       if (isPublicDirectory(getDirectoryParameter(call))) {
-        MediaScannerConnection.scanFile(getContext(), new String[]{file.getAbsolutePath()}, null, null);
+        MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
       }
       Log.d(getLogTag(), "File '" + file.getAbsolutePath() + "' saved!");
       call.success();
@@ -306,14 +306,14 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(file, directory);
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FILE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FILE_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("File does not exist");
         return;
       }
 
       boolean deleted = fileObject.delete();
-      if (deleted == false) {
+      if(deleted == false) {
         call.error("Unable to delete file");
       } else {
         call.success();
@@ -336,14 +336,14 @@ public class Filesystem extends Plugin {
     }
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       boolean created = false;
       if (intermediate) {
         created = fileObject.mkdirs();
       } else {
         created = fileObject.mkdir();
       }
-      if (created == false) {
+      if(created == false) {
         call.error("Unable to create directory, unknown reason");
       } else {
         call.success();
@@ -360,7 +360,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_DELETE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("Directory does not exist");
         return;
@@ -368,7 +368,7 @@ public class Filesystem extends Plugin {
 
       boolean deleted = fileObject.delete();
 
-      if (deleted == false) {
+      if(deleted == false) {
         call.error("Unable to delete directory, unknown reason");
       } else {
         call.success();
@@ -384,8 +384,8 @@ public class Filesystem extends Plugin {
 
     File fileObject = getFileObject(path, directory);
 
-    if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FOLDER_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+     if (!isPublicDirectory(directory)
+         || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_READ_FOLDER_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       if (fileObject != null && fileObject.exists()) {
         String[] files = fileObject.list();
 
@@ -393,7 +393,7 @@ public class Filesystem extends Plugin {
         ret.put("files", JSArray.from(files));
         call.success(ret);
       } else {
-        call.error("Directory does not exist");
+      call.error("Directory does not exist");
       }
     }
   }
@@ -407,7 +407,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_URI_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       JSObject data = new JSObject();
       data.put("uri", Uri.fromFile(fileObject).toString());
       call.success(data);
@@ -423,7 +423,7 @@ public class Filesystem extends Plugin {
     File fileObject = getFileObject(path, directory);
 
     if (!isPublicDirectory(directory)
-      || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+        || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_STAT_PERMISSIONS, Manifest.permission.READ_EXTERNAL_STORAGE)) {
       if (!fileObject.exists()) {
         call.error("File does not exist");
         return;
@@ -564,16 +564,16 @@ public class Filesystem extends Plugin {
   /**
    * Checks the the given permission and requests them if they are not already granted.
    * @param permissionRequestCode the request code see {@link PluginRequestCodes}
-   * @param permission            the permission string
+   * @param permission the permission string
    * @return Returns true if the permission is granted and false if it is denied.
    */
   private boolean isStoragePermissionGranted(int permissionRequestCode, String permission) {
     if (hasPermission(permission)) {
-      Log.v(getLogTag(), "Permission '" + permission + "' is granted");
+      Log.v(getLogTag(),"Permission '" + permission + "' is granted");
       return true;
     } else {
-      Log.v(getLogTag(), "Permission '" + permission + "' denied. Asking user for it.");
-      pluginRequestPermissions(new String[]{permission}, permissionRequestCode);
+      Log.v(getLogTag(),"Permission '" + permission + "' denied. Asking user for it.");
+      pluginRequestPermissions(new String[] {permission}, permissionRequestCode);
       return false;
     }
   }
@@ -598,10 +598,10 @@ public class Filesystem extends Plugin {
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
 
-    Log.d(getLogTag(), "handling request perms result");
+    Log.d(getLogTag(),"handling request perms result");
 
     if (getSavedCall() == null) {
-      Log.d(getLogTag(), "No stored plugin call for permissions request result");
+      Log.d(getLogTag(),"No stored plugin call for permissions request result");
       return;
     }
 
@@ -610,7 +610,7 @@ public class Filesystem extends Plugin {
     for (int i = 0; i < grantResults.length; i++) {
       int result = grantResults[i];
       String perm = permissions[i];
-      if (result == PackageManager.PERMISSION_DENIED) {
+      if(result == PackageManager.PERMISSION_DENIED) {
         Log.d(getLogTag(), "User denied storage permission: " + perm);
         savedCall.error(PERMISSION_DENIED_ERROR);
         this.freeSavedCall();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -487,13 +487,16 @@ public class Filesystem extends Plugin {
       return;
     }
 
-    if (to.equals(from)) {
+    File fromObject = getFileObject(from, directory);
+    File toObject = getFileObject(to, toDirectory);
+
+    assert fromObject != null;
+    assert toObject != null;
+
+    if (toObject.equals(fromObject)) {
       call.success();
       return;
     }
-
-    File fromObject = getFileObject(from, directory);
-    File toObject = getFileObject(to, toDirectory);
 
     if (!fromObject.exists()) {
       call.error("The source object does not exist");
@@ -522,7 +525,6 @@ public class Filesystem extends Plugin {
       }
     }
 
-    assert toObject != null;
     if (toObject.isDirectory()) {
       call.error("Cannot overwrite a directory");
       return;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1,4 +1,4 @@
-import {Plugin, PluginListenerHandle} from './definitions';
+import { Plugin, PluginListenerHandle } from './definitions';
 
 export interface PluginRegistry {
   Accessibility: AccessibilityPlugin;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginListenerHandle } from './definitions';
+import {Plugin, PluginListenerHandle} from './definitions';
 
 export interface PluginRegistry {
   Accessibility: AccessibilityPlugin;
@@ -526,6 +526,13 @@ export interface FilesystemPlugin extends Plugin {
    * @return a promise that resolves with the rename result
    */
   rename(options: RenameOptions): Promise<RenameResult>;
+
+  /**
+   * Copy a file or directory
+   * @param options the options for the copy operation
+   * @return a promise that resolves with the copy result
+   */
+  copy(options: CopyOptions): Promise<CopyResult>;
 }
 
 export enum FilesystemDirectory {
@@ -687,20 +694,27 @@ export interface StatOptions {
   directory?: FilesystemDirectory;
 }
 
-export interface RenameOptions {
+export interface CopyOptions {
   /**
-   * The existing file or directory to rename
+   * The existing file or directory
    */
   from: string;
   /**
-   * The destination to rename the file or directory to
+   * The destination file or directory
    */
   to: string;
   /**
-   * The FilesystemDirectory containing the file or directory to rename
+   * The FilesystemDirectory containing the existing file or directory
    */
   directory?: FilesystemDirectory;
+  /**
+   * The FilesystemDirectory containing the destination file or directory. If not supplied will use the 'directory'
+   * parameter as the destination
+   */
+  toDirectory?: FilesystemDirectory;
 }
+
+export interface RenameOptions extends CopyOptions {}
 
 export interface FileReadResult {
   data: string;
@@ -716,6 +730,8 @@ export interface MkdirResult {
 export interface RmdirResult {
 }
 export interface RenameResult {
+}
+export interface CopyResult {
 }
 export interface ReaddirResult {
   files: string[];

--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -1,6 +1,8 @@
 import {WebPlugin} from './index';
 
 import {
+  CopyOptions,
+  CopyResult,
   FileAppendOptions,
   FileAppendResult,
   FileDeleteOptions,
@@ -15,10 +17,10 @@ import {
   GetUriResult,
   MkdirOptions,
   MkdirResult,
-  RenameOptions,
-  RenameResult,
   ReaddirOptions,
   ReaddirResult,
+  RenameOptions,
+  RenameResult,
   RmdirOptions,
   RmdirResult,
   StatOptions,
@@ -345,18 +347,45 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
    * @return a promise that resolves with the rename result
    */
   async rename(options: RenameOptions): Promise<RenameResult> {
-    let {to, from, directory} = options;
+    return this._copy(options, true);
+  }
+
+  /**
+   * Copy a file or directory
+   * @param options the options for the copy operation
+   * @return a promise that resolves with the copy result
+   */
+  async copy(options: CopyOptions): Promise<CopyResult> {
+    return this._copy(options, false);
+  }
+
+  /**
+   * Function that can perform a copy or a rename
+   * @param options the options for the rename operation
+   * @param doRename whether to perform a rename or copy operation
+   * @return a promise that resolves with the result
+   */
+  private async _copy(options: CopyOptions, doRename: boolean = false): Promise<CopyResult> {
+    let {to, from, directory: fromDirectory, toDirectory} = options;
 
     if (!to || !from) {
       throw Error('Both to and from must be provided');
     }
 
+    // If no "to" directory is provided, use the "from" directory
+    if (!toDirectory) {
+      toDirectory = fromDirectory;
+    }
+
+    let fromPath = this.getPath(fromDirectory, from);
+    let toPath = this.getPath(toDirectory, to);
+
     // Test that the "to" and "from" locations are different
-    if (from === to) {
+    if (fromPath === toPath) {
       return {};
     }
 
-    if (to.startsWith(from)) {
+    if (toPath.startsWith(fromPath)) {
       throw Error('To path cannot contain the from path');
     }
 
@@ -365,7 +394,7 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
     try {
       toObj = await this.stat({
         path: to,
-        directory
+        directory: toDirectory
       });
     } catch (e) {
       // To location does not exist, ensure the directory containing "to" location exists and is a directory
@@ -377,7 +406,7 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
       if (toPathComponents.length > 0) {
         let toParentDirectory = await this.stat({
           path: toPath,
-          directory,
+          directory: toDirectory,
         });
 
         if (toParentDirectory.type !== 'directory') {
@@ -394,12 +423,12 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
     // Ensure the "from" object exists
     let fromObj = await this.stat({
       path: from,
-      directory: directory
+      directory: fromDirectory,
     });
 
     // Set the mtime/ctime of the supplied path
     let updateTime = async (path: string, ctime: number, mtime: number) => {
-      let fullPath: string = this.getPath(directory, path);
+      let fullPath: string = this.getPath(toDirectory, path);
       let entry = await this.dbRequest('get', [fullPath]) as EntryObj;
       entry.ctime = ctime;
       entry.mtime = mtime;
@@ -412,24 +441,28 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
         // Read the file
         let file = await this.readFile({
           path: from,
-          directory
+          directory: fromDirectory
         });
 
-        // Remove the file
-        await this.deleteFile({
-          path: from,
-          directory
-        });
+        // Optionally remove the file
+        if (doRename) {
+          await this.deleteFile({
+            path: from,
+            directory: fromDirectory
+          });
+        }
 
         // Write the file to the new location
         await this.writeFile({
           path: to,
-          directory,
+          directory: toDirectory,
           data: file.data
         });
 
-        // Copy the mtime/ctime of the original file
-        await updateTime(to, fromObj.ctime, fromObj.mtime);
+        // Copy the mtime/ctime of a renamed file
+        if (doRename) {
+          await updateTime(to, fromObj.ctime, fromObj.mtime);
+        }
 
         // Resolve promise
         return {};
@@ -443,35 +476,40 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
           // Create the to directory
           await this.mkdir({
             path: to,
-            directory,
+            directory: toDirectory,
             createIntermediateDirectories: false,
           });
 
-          // Copy the mtime/ctime of the original directory
-          await updateTime(to, fromObj.ctime, fromObj.mtime);
+          // Copy the mtime/ctime of a renamed directory
+          if (doRename) {
+            await updateTime(to, fromObj.ctime, fromObj.mtime);
+          }
         } catch (e) {
         }
 
         // Iterate over the contents of the from location
         let contents = (await this.readdir({
           path: from,
-          directory
+          directory: fromDirectory,
         })).files;
 
         for (let filename of contents) {
           // Move item from the from directory to the to directory
-          await this.rename({
+          await this._copy({
             from: `${from}/${filename}`,
             to: `${to}/${filename}`,
-            directory,
-          });
+            directory: fromDirectory,
+            toDirectory,
+          }, doRename);
         }
 
-        // Remove the original from directory
-        await this.rmdir({
-          path: from,
-          directory
-        });
+        // Optionally remove the original from directory
+        if (doRename) {
+          await this.rmdir({
+            path: from,
+            directory: fromDirectory
+          });
+        }
     }
 
     return {};

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -1,5 +1,6 @@
 import {
   WebPlugin,
+  CopyOptions, CopyResult,
   FileReadOptions, FileReadResult,
   FilesystemPlugin, FileWriteOptions,
   FileWriteResult, FileDeleteResult,
@@ -16,6 +17,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
 
   NodeFS:any = null;
   fileLocations:any = null;
+  Path:any = null;
 
   constructor() {
     super({
@@ -34,6 +36,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     this.fileLocations[FilesystemDirectory.Documents] = path.join(os.homedir(), `Documents`) + path.sep;
 
     this.NodeFS = require('fs');
+    this.Path = path;
   }
 
   readFile(options: FileReadOptions): Promise<FileReadResult>{
@@ -173,24 +176,103 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     });
   }
 
-  rename(options: RenameOptions): Promise<RenameResult> {
-    return new Promise((resolve, reject) => {
-      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
-        reject(`${options.directory} is currently not supported in the Electron implementation.`);
-      let fromPath = this.fileLocations[options.directory] + options.from;
-      let toPath = this.fileLocations[options.directory] + options.to;
+  private _copy(options: CopyOptions, doRename: boolean = false): Promise<CopyResult> {
+    const copyRecursively = (src: string, dst: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        this.NodeFS.stat(src, (err: any, stats: any) => {
+          if(err) {
+            reject(err);
+            return;
+          }
 
-      this.NodeFS.rename(fromPath, toPath, (err: any) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+          if(stats.isDirectory()) {
+            this.NodeFS.mkdir(dst, (err: any) => {
+              if(err) {
+                reject(err);
+                return;
+              }
 
-        resolve();
+              const files = this.NodeFS.readdirSync(src);
+              Promise.all(
+                files.map(
+                  (file: string) =>
+                    copyRecursively(src + this.Path.sep + file, dst + this.Path.sep + file)
+                )
+              )
+                .then(() => resolve())
+                .catch(reject);
+              return;
+            });
+
+            return;
+          }
+
+          const dstParent = this.Path.dirname(dst).split(this.Path.sep).pop();
+          this.NodeFS.stat(dstParent, (err: any) => {
+            if(err) {
+              this.NodeFS.mkdirSync(dstParent);
+            }
+
+            this.NodeFS.copyFile(src, dst, (err: any) => {
+              if(err) {
+                reject(err);
+                return;
+              }
+
+              resolve();
+            });
+          });
+        });
       });
+    };
+
+    return new Promise((resolve, reject) => {
+      if(!options.from || !options.to) {
+        reject('Both to and from must be supplied');
+        return;
+      }
+
+      if(!options.toDirectory) {
+        options.toDirectory = options.directory;
+      }
+
+      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1) {
+        reject(`${options.directory} is currently not supported in the Electron implementation.`);
+        return;
+      }
+
+      if(Object.keys(this.fileLocations).indexOf(options.toDirectory) === -1) {
+        reject(`${options.toDirectory} is currently not supported in the Electron implementation.`);
+        return;
+      }
+
+      const fromPath = this.fileLocations[options.directory] + options.from;
+      const toPath = this.fileLocations[options.toDirectory] + options.to;
+
+      if(doRename) {
+        this.NodeFS.rename(fromPath, toPath, (err: any) => {
+          if(err) {
+            reject(err);
+            return;
+          }
+
+          resolve();
+        });
+      } else {
+        copyRecursively(fromPath, toPath)
+          .then(() => resolve())
+          .catch(reject);
+      }
     });
   }
 
+  copy(options: CopyOptions): Promise<CopyResult> {
+    return this._copy(options, true);
+  }
+
+  rename(options: RenameOptions): Promise<RenameResult> {
+    return this._copy(options, false);
+  }
 }
 
 const Filesystem = new FilesystemPluginElectron();

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -267,11 +267,11 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
   }
 
   copy(options: CopyOptions): Promise<CopyResult> {
-    return this._copy(options, true);
+    return this._copy(options, false);
   }
 
   rename(options: RenameOptions): Promise<RenameResult> {
-    return this._copy(options, false);
+    return this._copy(options, true);
   }
 }
 

--- a/example/src/pages/filesystem/filesystem.html
+++ b/example/src/pages/filesystem/filesystem.html
@@ -44,7 +44,16 @@
   <button (click)="directoryTest()" ion-button>
     Directory Test
   </button>
-  <button (click)="moveCopyTest()" ion-button>
-    Move/Copy Test
+  <button (click)="renameFileTest()" ion-button>
+    Rename File Test
+  </button>
+  <button (click)="copyFileTest()" ion-button>
+    Copy File Test
+  </button>
+  <button (click)="renameDirectoryTest()" ion-button>
+    Rename Directory Test
+  </button>
+  <button (click)="copyDirectoryTest()" ion-button>
+    Copy Directory Test
   </button>
 </ion-content>

--- a/example/src/pages/filesystem/filesystem.html
+++ b/example/src/pages/filesystem/filesystem.html
@@ -44,4 +44,7 @@
   <button (click)="directoryTest()" ion-button>
     Directory Test
   </button>
+  <button (click)="moveCopyTest()" ion-button>
+    Move/Copy Test
+  </button>
 </ion-content>

--- a/example/src/pages/filesystem/filesystem.ts
+++ b/example/src/pages/filesystem/filesystem.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import {IonicPage, NavController, NavParams} from 'ionic-angular';
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import {
   Plugins,
   FilesystemDirectory,

--- a/example/src/pages/filesystem/filesystem.ts
+++ b/example/src/pages/filesystem/filesystem.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import {Component} from '@angular/core';
+import {IonicPage, NavController, NavParams} from 'ionic-angular';
 import {
   Plugins,
   FilesystemDirectory,
@@ -174,5 +174,245 @@ export class FilesystemPage {
       console.error('Unable to write file (press mkdir first, silly)', e);
     }
     console.log('Wrote file');
+  }
+
+  async moveCopyTest() {
+    // Helper function to run the provided promise-returning function on a single item or sequence of items
+    const all = async (item, callback) => {
+      item = Array.isArray(item) ? item : [item];
+      for (let i of item) {
+        await callback(i);
+      }
+    };
+
+    const stat = async (path) => all(path, path => Plugins.Filesystem.stat({path}));
+    const rename = async (from, to) => Plugins.Filesystem.rename({from, to});
+    const copy = async (from, to) => Plugins.Filesystem.copy({from, to});
+    const write = async (path) => all(path, path => Plugins.Filesystem.writeFile({
+      path,
+      data: path,
+      encoding: FilesystemEncoding.UTF8,
+    }));
+    const _delete = async (path) => all(path, path => Plugins.Filesystem.deleteFile({path}));
+    const mkdir = async (path) => all(path, path => Plugins.Filesystem.mkdir({
+      path,
+      createIntermediateDirectories: true,
+    }));
+    const rmdir = async (path) => all(path, path => Plugins.Filesystem.rmdir({path}));
+
+    try {
+      console.log('Check arguments');
+
+      try {
+        // @ts-ignore
+        await rename('fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        // @ts-ignore
+        await copy('fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        // @ts-ignore
+        await rename(undefined, 'fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        // @ts-ignore
+        await copy(undefined, 'fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      console.log('Rename/copy into a subdirectory of itself');
+      await write('fa');
+
+      try {
+        await rename('fa', 'fc/fb');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        await copy('fa', 'fc/fb');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      await _delete('fa');
+
+      console.log('Rename/copy a file to an empty location');
+      await write('fa');
+      await copy('fa', 'fy');
+      await rename('fa', 'fx');
+      try {
+        await stat('fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+      await stat(['fx', 'fy']);
+      await _delete(['fx', 'fy']);
+
+      console.log('Rename/copy a file to overwrite an existing file');
+      await write(['fa', 'fb']);
+      await copy('fa', 'fb');
+      await rename('fa', 'fb');
+      await _delete('fb');
+
+      console.log('Rename/copy a file to itself');
+      await write('fa');
+      await copy('fa', 'fa');
+      await rename('fa', 'fa');
+      await _delete('fa');
+
+      console.log('Rename/copy a file to overwrite a directory');
+      await write('fa');
+      await mkdir('da');
+
+      try {
+        await rename('fa', 'da');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        await copy('fa', 'da');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      await _delete('fa');
+      await rmdir('da');
+
+      console.log('Rename a file into a nonexistent directory');
+      await write('fa');
+      await mkdir('da');
+
+      try {
+        await rename('fa', 'da/db/fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        await copy('fa', 'da/db/fa');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      await _delete('fa');
+      await rmdir('da');
+
+      console.log('Rename a nonexistent file');
+      try {
+        await rename('fa', 'fx');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      console.log('Copy a nonexistent file');
+      try {
+        await copy('fa', 'fx');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      console.log('Rename/copy a file into a subdirectory that is a file');
+      await write('fa');
+      await mkdir('da');
+      await write('da/fa');
+      try {
+        await rename('fa', 'da/fa/fb');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+
+      try {
+        await copy('fa', 'da/fa/fb');
+        throw new Error("call should not succeed");
+      } catch (e) {
+        console.info(e.message);
+      }
+      await _delete(['da/fa', 'fa']);
+      await rmdir('da');
+
+      console.log('Rename/copy a file into a directory');
+      await write('fa');
+      await mkdir('da');
+      await copy('fa', 'da/fb');
+      await rename('fa', 'da/fa');
+      await _delete(['da/fa', 'da/fb']);
+      await rmdir('da');
+
+      console.log('Rename/copy an empty directory into a directory');
+      await mkdir(['da', 'db']);
+      await copy('db', 'da/dc');
+      await rename('db', 'da/db');
+      await stat(['da/db', 'da/dc']);
+      await rmdir(['da/dc', 'da/db', 'da']);
+
+      console.log('Rename/copy a directory tree into a directory');
+      await mkdir(['da', 'db', 'db/dc']);
+      await write(['db/fa', 'db/dc/fb']);
+      await copy('db', 'da/dc');
+      await rename('db', 'da/db');
+      await stat(['da/db', 'da/db/fa', 'da/db/dc', 'da/db/dc/fb', 'da/dc', 'da/dc/fa', 'da/dc/dc', 'da/dc/dc/fb']);
+      await _delete(['da/dc/dc/fb', 'da/dc/fa', 'da/db/dc/fb', 'da/db/fa']);
+      await rmdir(['da/dc/dc', 'da/dc', 'da/db/dc', 'da/db', 'da']);
+
+      console.log('Rename/copy a directory tree out of a directory');
+      await mkdir(['da', 'da/db', 'da/db/df', 'da/dc', 'da/dc/df']);
+      await write(['da/db/fa', 'da/db/fb', 'da/db/df/fc']);
+      await copy('da/db', 'dd');
+      await rename('da/db', 'dc');
+      await stat(['dd', 'dd/fa', 'dd/fb', 'dd/df/fc', 'dc', 'dc/fa', 'dc/fb', 'dc/df/fc', 'da']);
+      await _delete(['dd/fa', 'dd/fb', 'dd/df/fc', 'dc/fa', 'dc/fb', 'dc/df/fc']);
+      await rmdir(['dd/df', 'dd', 'dc/df', 'dc', 'da/dc/df', 'da/dc', 'da']);
+
+      console.log('Rename preserves file mtime');
+      await write('fa');
+      let a = await Plugins.Filesystem.stat({path: "fa"});
+      await rename('fa', 'fb');
+      let b = await Plugins.Filesystem.stat({path: "fb"});
+      if (a.mtime !== b.mtime) {
+        throw new Error("mtime was not preserved");
+      }
+      await _delete('fb');
+
+      console.log('Rename preserves directory mtime');
+      await mkdir('da');
+      a = await Plugins.Filesystem.stat({path: "da"});
+      await mkdir('db');
+      await rename('da', 'db/da');
+      b = await Plugins.Filesystem.stat({path: "db/da"});
+      if (a.mtime !== b.mtime) {
+        throw new Error("mtime was not preserved");
+      }
+      await rmdir(['db/da', 'db']);
+      console.info("No errors");
+    } catch (e) {
+      console.error("An unexpected error occurred", e.message);
+    }
   }
 }

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -54,6 +54,7 @@ CAP_PLUGIN(CAPFilesystemPlugin, "Filesystem",
   CAP_PLUGIN_METHOD(getUri, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(stat, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(rename, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(copy, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPGeolocationPlugin, "Geolocation",

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -361,7 +361,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    var toDirectoryOption = call.get("toDirectory", String.self, DEFAULT_DIRECTORY)!
+    var toDirectoryOption = call.get("toDirectory", String.self, "")!
     
     if (toDirectoryOption == "") {
       toDirectoryOption = directoryOption;

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -336,7 +336,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     ])
     
   }
-  
+
   /**
    * Rename a file or directory.
    */

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -336,29 +336,43 @@ public class CAPFilesystemPlugin : CAPPlugin {
     ])
     
   }
-
+  
   /**
    * Rename a file or directory.
    */
   @objc func rename(_ call: CAPPluginCall) {
-    guard let from = call.get("from", String.self) else {
-      handleError(call, "from must be provided and must be a string.")
-      return
-    }
-    
-    guard let to = call.get("to", String.self) else {
-      handleError(call, "to must be provided and must be a string.")
+    _copy(call: call, doRename: true);
+  }
+  
+  /**
+   * Copy a file or directory.
+   */
+  @objc func copy(_ call: CAPPluginCall) {
+    _copy(call: call, doRename: false);
+  }
+
+  /**
+   * Copy or rename a file or directory.
+   */
+  private func _copy(call: CAPPluginCall, doRename: Bool) {
+    guard let from = call.get("from", String.self), let to = call.get("to", String.self) else {
+      handleError(call, "Both to and from must be provided")
       return
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
+    var toDirectoryOption = call.get("toDirectory", String.self, DEFAULT_DIRECTORY)!
+    
+    if (toDirectoryOption == "") {
+      toDirectoryOption = directoryOption;
+    }
     
     guard let fromUrl = getFileUrl(from, directoryOption) else {
       handleError(call, "Invalid from path")
       return
     }
     
-    guard let toUrl = getFileUrl(to, directoryOption) else {
+    guard let toUrl = getFileUrl(to, toDirectoryOption) else {
       handleError(call, "Invalid to path")
       return
     }
@@ -376,7 +390,11 @@ public class CAPFilesystemPlugin : CAPPlugin {
         }
       }
       
-      try FileManager.default.moveItem(at: fromUrl, to: toUrl)
+      if (doRename) {
+        try FileManager.default.moveItem(at: fromUrl, to: toUrl)
+      } else {
+        try FileManager.default.copyItem(at: fromUrl, to: toUrl);
+      }
       call.success()
     } catch let error as NSError {
       handleError(call, error.localizedDescription, error)

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -125,6 +125,7 @@ async readFilePath() {
 
 async rename() {
   try {
+    // This example moves the file within the same 'directory'
     let ret = await Filesystem.rename({
       from: 'text.txt',
       to: 'text2.txt',
@@ -132,6 +133,33 @@ async rename() {
     });
   } catch(e) {
     console.error('Unable to rename file', e);
+  }
+}
+
+async copy() {
+  try {
+    // This example copies a file from the app directory to the documents directory
+    let ret = await Filesystem.copy({
+      from: 'assets/icon.png',
+      to: 'icon.png',
+      directory: FilesystemDirectory.Application,
+      toDirectory: FilesystemDirectory.Documents
+    });
+  } catch(e) {
+    console.error('Unable to copy file', e);
+  }
+}
+
+async copy() {
+  try {
+    // This example copies a file within the documents directory
+    let ret = await Filesystem.copy({
+      from: 'text.txt',
+      to: 'text2.txt',
+      directory: FilesystemDirectory.Documents
+    });
+  } catch(e) {
+    console.error('Unable to copy file', e);
   }
 }
 ```


### PR DESCRIPTION
Implementation for all platforms, and uses the same copy semantics across all.

This method is called 'copy' (rather than node-style copyFile), since it can copy both directory structures and individual files.

It turns out that a copy operation has almost everything in common with a rename operation, so in each case there is a _copy method that does the bulk of the param checking/error handling etc. so as not to end up with a lot of duplication.

Copy, and now rename support a 'toDirectory' as well as the pre-existing 'directory'. Developers can omit 'directory' to use DEFAULT_DIRECTORY, include only 'directory' to rename/copy within a directory, or include both to rename/copy between directories.

Finally, added a set of tests to the example app to show the move/copy operations working.