### PR TITLE
fix(cli): check for plugins in devDependencies

### DIFF
--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -11,6 +11,7 @@ export interface PackageJson {
   name: string;
   version: string;
   dependencies: any;
+  devDependencies: any;
 }
 
 export interface ExternalConfig {

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -81,11 +81,9 @@ export async function resolvePlugin(config: Config, name: string): Promise<Plugi
 }
 
 export function getDependencies(config: Config): string[] {
-  const dependencies = config.app.package.dependencies;
-  if (!dependencies) {
-    return [];
-  }
-  return Object.keys(dependencies);
+  const dependencies = config.app.package.dependencies ? config.app.package.dependencies : [];
+  const devDependencies = config.app.package.devDependencies ? config.app.package.devDependencies : [];
+  return Object.keys(dependencies).concat(Object.keys(devDependencies));
 }
 
 export function fixName(name: string): string {


### PR DESCRIPTION
In some cases Cordova puts the plugins in devDependencies instead of in dependencies, so Capacitor doesn't find them, this will check in both places. 