### PR TITLE
fix(ios): read enableHighAccuracy geolocation option

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
@@ -23,7 +23,11 @@ class GetLocationHandler: NSObject, CLLocationManagerDelegate {
     // TODO: Allow user to configure accuracy, request/authorization mode
     self.locationManager.delegate = self
     self.locationManager.requestWhenInUseAuthorization()
-    self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    if call.getBool("enableHighAccuracy", false)! {
+        self.locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+    } else {
+        self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
     
     if let shouldWatch = options["watch"], shouldWatch as? Bool == true {
       self.locationManager.startUpdatingLocation()


### PR DESCRIPTION
Use the best desiredAccuracy (kCLLocationAccuracyBestForNavigation) if enableHighAccuracy is set to true