### PR TITLE
fix(android-livereload-localhost):

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -821,6 +821,9 @@ public class Bridge {
     });
   }
 
+  public String getAppUrl() {
+    return appUrl;
+  }
 
   public String getLocalUrl() {
     return localUrl;


### PR DESCRIPTION
* Use request proxy handler when livereload and appUrl localhost:8100
* Reconnect when connection has not been established

This will allow users run:

```bash
ionic capacitor run android -l
```

and let connect the app to `localhost:8100` without the need to use `--address=0.0.0.0`