### PR TITLE
fix(core/web): avoid appendFile/writeFile to overwrite existing directory entry

### DIFF
--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -144,6 +144,11 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
   async writeFile(options: FileWriteOptions): Promise<FileWriteResult> {
     const path: string = this.getPath(options.directory, options.path);
     const data = options.data;
+
+    let occupiedEntry = await this.dbRequest('get', [path]) as EntryObj;
+    if (occupiedEntry && occupiedEntry.type === 'directory')
+      throw('The supplied path is a directory.');
+
     // const encoding = options.encoding;
     const parentPath = path.substr(0, path.lastIndexOf('/'));
 

--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -182,12 +182,17 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
 
     const now = Date.now();
     let ctime = now;
+
+    let occupiedEntry = await this.dbRequest('get', [path]) as EntryObj;
+    if (occupiedEntry && occupiedEntry.type === 'directory')
+      throw('The supplied path is a directory.');
+
     let parentEntry = await this.dbRequest('get', [parentPath]) as EntryObj;
     if (parentEntry === undefined) {
       const parentArgPath = parentPath.substr(parentPath.indexOf('/', 1));
       await this.mkdir({path: parentArgPath, directory: options.directory, createIntermediateDirectories: true})
     }
-    let occupiedEntry = await this.dbRequest('get', [path]) as EntryObj;
+
     if (occupiedEntry !== undefined) {
       data = occupiedEntry.content + data;
       ctime = occupiedEntry.ctime;


### PR DESCRIPTION
This fix corrects a problem where an appendFile/writeFile could corrupt a directory entry if given a directory entry path.