### PR TITLE
chore(example): update example app to work with latest Capacitor

### DIFF
--- a/example/ios/IonicRunner/IonicRunner.xcodeproj/project.pbxproj
+++ b/example/ios/IonicRunner/IonicRunner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F5B4AFF22E629A900E58281 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2F5B4AFE22E629A900E58281 /* config.xml */; };
 		50379B2A2058CDC7000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B292058CDC6000EE86E /* capacitor.config.json */; };
 		50473AD71FF2A6F600C17FC9 /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50473AD61FF2A6F500C17FC9 /* public */; };
 		A3729E091E83246400B7334A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3729E081E83246400B7334A /* AppDelegate.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2F5B4AFE22E629A900E58281 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		50379B292058CDC6000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		503ACBFD1FE98C0C00C5E136 /* Avocado.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Avocado.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/IonicRunner-dtawthqbknkuwzeomrletvvwmolw/Build/Products/Debug-iphonesimulator/Avocado.framework"; sourceTree = "<group>"; };
 		50473AD61FF2A6F500C17FC9 /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 		A3729DFC1E83246400B7334A = {
 			isa = PBXGroup;
 			children = (
+				2F5B4AFE22E629A900E58281 /* config.xml */,
 				50473AD61FF2A6F500C17FC9 /* public */,
 				A3729E071E83246400B7334A /* IonicRunner */,
 				A3729E061E83246400B7334A /* Products */,
@@ -177,7 +180,6 @@
 				TargetAttributes = {
 					A3729E041E83246400B7334A = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 9YN2HU59K8;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -187,6 +189,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -238,6 +241,7 @@
 				50473AD71FF2A6F600C17FC9 /* public in Resources */,
 				A3729E131E83246400B7334A /* LaunchScreen.storyboard in Resources */,
 				50379B2A2058CDC7000EE86E /* capacitor.config.json in Resources */,
+				2F5B4AFF22E629A900E58281 /* config.xml in Resources */,
 				A3729E101E83246400B7334A /* Assets.xcassets in Resources */,
 				A3729E0E1E83246400B7334A /* Main.storyboard in Resources */,
 			);
@@ -420,7 +424,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = 9YN2HU59K8;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IonicRunner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -438,7 +442,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = 9YN2HU59K8;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IonicRunner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/example/ios/IonicRunner/Podfile.lock
+++ b/example/ios/IonicRunner/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Capacitor (1.0.0):
-    - CapacitorCordova (= 1.0.0)
-  - CapacitorCordova (1.0.0)
+  - Capacitor (1.1.1):
+    - CapacitorCordova (= 1.1.1)
+  - CapacitorCordova (1.1.1)
 
 DEPENDENCIES:
   - Capacitor (from `../../../`)
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: "../../../"
 
 SPEC CHECKSUMS:
-  Capacitor: 48e6d22d3d2fe9fd95f6c128136a7b538b7fd50d
-  CapacitorCordova: dd5a5a6ca827445b1f97ed0bb9ca4dbf424802c3
+  Capacitor: f245413edff86ebf3d18bf76cadaee4be58b4a04
+  CapacitorCordova: 25811fd90c0ea23ea135a42a217d1918873fa566
 
 PODFILE CHECKSUM: cf3dd73a42bef0923c014a1179dc29d10aa5cae0
 
-COCOAPODS: 1.6.2
+COCOAPODS: 1.7.2

--- a/example/ios/IonicRunner/config.xml
+++ b/example/ios/IonicRunner/config.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <access origin="*" />
+</widget>


### PR DESCRIPTION
The generated config.xml is required by Capacitor, but the example app didn't have it.

Closes #1787 