### PR TITLE
fix(android): add missing format field in CameraPhoto

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -359,6 +359,7 @@ public class Camera extends Plugin {
       bis = new ByteArrayInputStream(bitmapOutputStream.toByteArray());
       Uri newUri = saveTemporaryImage(bitmap, u, bis);
       JSObject ret = new JSObject();
+      ret.put("format", "jpeg");
       ret.put("exif", exif.toJson());
       ret.put("path", newUri.toString());
       ret.put("webPath", FileUtils.getPortablePath(getContext(), bridge.getLocalUrl(), newUri));
@@ -409,6 +410,7 @@ public class Camera extends Plugin {
     String encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
 
     JSObject data = new JSObject();
+    data.put("format", "jpeg");
     data.put("dataUrl", "data:image/jpeg;base64," + encoded);
     data.put("exif", exif.toJson());
     call.resolve(data);
@@ -419,6 +421,7 @@ public class Camera extends Plugin {
     String encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
 
     JSObject data = new JSObject();
+    data.put("format", "jpeg");
     data.put("base64String", encoded);
     data.put("exif", exif.toJson());
     call.resolve(data);


### PR DESCRIPTION
According to the typescript definitions the CameraPhoto object should contain a field "format", but it doesn't on android. This PR adds that field and sets its value to "jpeg".