### PR TITLE
fix(ios): don't override notification delegate if already set

### DIFF
--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -10,7 +10,9 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
   public override init(){
     super.init()
     let center = UNUserNotificationCenter.current()
-    center.delegate = self
+    if center.delegate == nil {
+      center.delegate = self
+    }
   }
 
   public func setBridge(bridge: CAPBridge) {


### PR DESCRIPTION
Closes #1631 