### PR TITLE
docs: Add note about Browser plugin not providing URI in callback

### DIFF
--- a/site/docs-md/apis/browser/index.md
+++ b/site/docs-md/apis/browser/index.md
@@ -26,6 +26,10 @@ const { Browser } = Plugins;
 await Browser.open({ url: 'http://capacitor.ionicframework.com/' });
 ```
 
+## Note about `browserPageLoaded`
+
+In constrast to Cordova's `InAppBrowserEvent`, the `info` object does not contain a URL. You must use the [App](https://capacitor.ionicframework.com/docs/apis/app/) plugin's `appUrlOpen` to get the URL when the user navigates, or DOM events when in the browser to listen for a page load.
+
 ## API
 
 <plugin-api name="browser"></plugin-api>


### PR DESCRIPTION
Coming from Cordova this was a point of confusion for me, I’m used to being able to access the url from the `InAppBrowser` callback. I thought it might be helpful for developers migrating to be aware of this.

I also included a note about using the DOM events when deploying your app in the browser because it worked for me, you may be able to use the `Browser` from `@capacitor/core` but I haven’t tried myself. :)

I haven’t submitted a PR to a open source project in a really long time, so please let me know if anything should be changed either with the doc itself or the PR format.