### PR TITLE
Clarify API usage

### DIFF
--- a/site/docs-md/apis/index.md
+++ b/site/docs-md/apis/index.md
@@ -19,17 +19,17 @@ See the APIs list on the left menu for the full list of available APIs.
 
 To use a Capacitor API, follow these steps:
 
-1) Import the API:
+1) Import the `Plugins` object. It represents the registry of all Capacitor plugins.
 ```typescript
-import { Browser } from '@capacitor/core';
+import { Plugins } from '@capacitor/core';
 ```
 
-2) Extract the API object from `Plugins`:
+2) Get a plugin from the Plugin Registry (`Plugins` object).
 ```typescript
 const { Browser } = Plugins;
 ```
 
-3) Use the API:
+3) Use the plugin API:
 ```typescript
 async openBrowser() {
   // On iOS, for example, open the URL in SFSafariViewController (the in-app browser)
@@ -48,4 +48,4 @@ async openBrowser() {
 }
 ```
 
-By instead leveraging the API object, the native implementation of the API is used first, followed by the web version (if available).
+By using the API correctly, the native implementation of the API is used first, followed by the web version (if available).

--- a/site/docs-md/apis/index.md
+++ b/site/docs-md/apis/index.md
@@ -48,4 +48,4 @@ async openBrowser() {
 }
 ```
 
-By using the API correctly, the native implementation of the API is used first, followed by the web version (if available).
+By using the plugins from the plugin registry (`Plugins` object), the native implementation of the plugin is used (if available), with fallback to the web version.

--- a/site/docs-md/apis/index.md
+++ b/site/docs-md/apis/index.md
@@ -14,3 +14,38 @@ Capacitor includes a number of Native APIs that are available to all Capacitor a
 For those coming from Cordova, the core Capacitor APIs cover much of the core Cordova plugins, and also include some new ones.
 
 See the APIs list on the left menu for the full list of available APIs.
+
+## API Usage
+
+To use a Capacitor API, follow these steps:
+
+1) Import the API:
+```typescript
+import { Browser } from '@capacitor/core';
+```
+
+2) Extract the API object from `Plugins`:
+```typescript
+const { Browser } = Plugins;
+```
+
+3) Use the API:
+```typescript
+async openBrowser() {
+  // On iOS, for example, open the URL in SFSafariViewController (the in-app browser)
+  await Browser.open({ url: "https://ionicframework.com" });
+}
+```
+
+A common mistake is to import an API then reference it immediately, resulting in the web implementation being used:
+```typescript
+import { Browser } from '@capacitor/core';
+
+async openBrowser() {
+  // On iOS, for example, this will open the URL in Safari instead of 
+  // the SFSafariViewController (in-app browser)
+  await Browser.open({ url: "https://ionicframework.com" });
+}
+```
+
+By instead leveraging the API object, the native implementation of the API is used first, followed by the web version (if available).

--- a/site/docs-md/apis/index.md
+++ b/site/docs-md/apis/index.md
@@ -37,7 +37,7 @@ async openBrowser() {
 }
 ```
 
-A common mistake is to import an API then reference it immediately, resulting in the web implementation being used:
+A common mistake is to import a plugin directly, then use the plugin API immediately, resulting in the web implementation being used:
 ```typescript
 import { Browser } from '@capacitor/core';
 


### PR DESCRIPTION
Multiple users (myself including) have been confused by how to leverage Capacitor APIs properly. it's really easy to forget to use the API object itself - here's an attempt to clarify things.