### PR TITLE
fix(electron): createIntermediateDirectories option not being used in mkdir

### DIFF
--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -105,7 +105,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.mkdir(lookupPath, (err:any) => {
+      this.NodeFS.mkdir(lookupPath, { recursive: options.createIntermediateDirectories }, (err:any) => {
         if(err) {
           reject(err);
           return;


### PR DESCRIPTION
Will only work in electron 5 or newer because it was added in node 10.12, but it's better than ignoring it. 