### PR TITLE
fix(ios/Filesystem): make readdir return only content names

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -282,7 +282,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
       let directoryContents = try FileManager.default.contentsOfDirectory(at: fileUrl, includingPropertiesForKeys: nil, options: [])
       
       let directoryPathStrings = directoryContents.map {(url: URL) -> String in
-        return url.path
+        return url.lastPathComponent
       }
       
       call.success([


### PR DESCRIPTION
readdir returns the full file/folder path instead of just the name (as all other platforms do).
This change makes it return only the name of the file/folder.
