### PR TITLE
fix(ios): improve CAPLog variadic logging

### DIFF
--- a/ios/Capacitor/Capacitor/CAPLog.swift
+++ b/ios/Capacitor/Capacitor/CAPLog.swift
@@ -2,10 +2,10 @@ public class CAPLog {
 
   public static let config = CAPConfig()
   
-  public static func print(_ items: Any..., separator: String = " ", terminator: String = "") {
+  public static func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {
     if !self.hideLogs() {
-      for item in items {
-        Swift.print(item, separator, terminator)
+      for i in 0..<items.count {
+        Swift.print(items[i], terminator: i == items.count - 1 ? terminator : separator)
       }
     }
   }


### PR DESCRIPTION
The changes in 1a6239bea1793d8237878a97f3eb97be76555cfd made the log
output super annoying multi-line debug messages when more than one
argument was passed to print().