### PR TITLE
fix(ios/cordova): return proper pathForResource in CDVCommandDelegate

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVCommandDelegateImpl.m
@@ -51,9 +51,14 @@
     [directoryParts removeLastObject];
 
     NSString* directoryPartsJoined = [directoryParts componentsJoinedByString:@"/"];
+    NSString* baseFolder = @"public";
+    NSString* directoryStr = baseFolder;
 
+    if ([directoryPartsJoined length] > 0) {
+        directoryStr = [NSString stringWithFormat:@"%@/%@", baseFolder, [directoryParts componentsJoinedByString:@"/"]];
+    }
 
-    return [mainBundle pathForResource:filename ofType:@"" inDirectory:@"www"];
+    return [mainBundle pathForResource:filename ofType:@"" inDirectory:directoryStr];
 }
 
 - (void)flushCommandQueueWithDelayedJs


### PR DESCRIPTION
It was hardcoded to www, but that doesn't work as Capacitor uses public folder, and was ignoring possible subfolders. 