### PR TITLE
Adding a note about CocoaPod command in iOS plugin doc

### DIFF
--- a/site/docs-md/plugins/ios.md
+++ b/site/docs-md/plugins/ios.md
@@ -19,6 +19,8 @@ To get started, first generate a plugin as shown in the [Getting Started](./#get
 
 Next, open `your-plugin/ios/Plugin.xcworkspace` in Xcode.
 
+**Note**: You may need to run `pod repo update` or `pod install` before the `.xcworkspace` file will show up in the iOS directory.
+
 ## Building your Plugin in Swift
 
 A Capacitor plugin for iOS is a simple Swift class that extends `CAPPlugin` and

--- a/site/docs-md/plugins/ios.md
+++ b/site/docs-md/plugins/ios.md
@@ -19,7 +19,7 @@ To get started, first generate a plugin as shown in the [Getting Started](./#get
 
 Next, open `your-plugin/ios/Plugin.xcworkspace` in Xcode.
 
-**Note**: You may need to run `pod repo update` or `pod install` before the `.xcworkspace` file will show up in the iOS directory.
+**Note**: You may need to run `pod repo update` or `pod install` in your `your-plugin/ios` directory before the `.xcworkspace` file will show up in the iOS directory.
 
 ## Building your Plugin in Swift
 


### PR DESCRIPTION
### Changes

- Added a note about running `pod repo update` and/or `pod install` when walking through the iOS setup for creating a Capacitor plugin
- Made one small modification to clarify where to run said command(s)