### PR TITLE
Update electron to 6.0.0

### DIFF
--- a/electron-template/package.json
+++ b/electron-template/package.json
@@ -10,7 +10,7 @@
     "electron-is-dev": "^1.1.0"
   },
   "devDependencies": {
-    "electron": "^4.0.0"
+    "electron": "^6.0.0"
   },
   "keywords": [
     "capacitor",


### PR DESCRIPTION
### Changes

-  [package.json](https://github.com/ionic-team/capacitor/blob/master/electron-template/package.json) Electron version 4.0.0 -> 6.0.0

#### Description

This is more as a temporary solution for convenience so that new users don't get the depreciation warning from Electron 4.0.0 as I have. I'm not sure if this was ever meant to happen but if not, I will look to see if I could add a `postinstall` script which simply runs `npm install` and ensures Electron stays up-to-date (if that's of interest to anyone).

comments welcome! ✌️ 

| Before | After |
| :--: |:--:|
| ![Before](https://i.gyazo.com/7a98a49a89ca291f1d3e1c29be2b743c.png)| ![After](https://i.gyazo.com/0bac51a68101b7146f24b0e32dba404d.png)|

