### PR TITLE
Handle custom WebViewClient (#1848)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -39,7 +39,6 @@ import com.getcapacitor.plugin.App;
 import com.getcapacitor.plugin.Browser;
 import com.getcapacitor.plugin.Camera;
 import com.getcapacitor.plugin.Clipboard;
-import com.getcapacitor.plugin.Console;
 import com.getcapacitor.plugin.Device;
 import com.getcapacitor.plugin.Filesystem;
 import com.getcapacitor.plugin.Geolocation;

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -285,9 +285,10 @@ public class Bridge {
 
       @Override
       public void onFormResubmission(WebView view, Message dontResend, Message resend) {
-        super.onFormResubmission(view, dontResend, resend);
         if(customWebViewClient != null) {
           customWebViewClient.onFormResubmission(view, dontResend, resend);
+        } else {
+          super.onFormResubmission(view, dontResend, resend);
         }
       }
 

--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -87,6 +87,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
 | AdMob | `capacitor-admob` | <https://github.com/rahadur/capacitor-admob> | Android only (currently) |
+| AdMob | `@rdlabo/capacitor-admob` | <https://github.com/rdlabo/capacitor-admob> | |
 
 ## Notifications
 


### PR DESCRIPTION
Add means to set custom WebViewClient that will be called along with internal one. This PR is to help with #1848 

## Usage
In your `MainActivity` get instance of the `Bridge` and call `setCustomWebViewClient` passing new `WebViewClient` implementation.

**Note** This will NOT replace original implementation, it will be called by original implementation.

```JAVA
public class MainActivity extends BridgeActivity {
  @Override
  public void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);

    // Initializes the Bridge
    this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
      // Additional plugins you've installed go here
      // Ex: add(TotallyAwesomePlugin.class);
    }});

    // Setup custom WebViewClient to reload when net::ERR_CONNECTION_REFUSED occurs
    this.getBridge().setCustomWebViewClient(new WebViewClient(){
      @SuppressWarnings("deprecation")
      @Override
      public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
        Log.e(LogUtils.getCoreTag("MainActivity"), "onReceivedError: "+errorCode+", "+ description+", "+failingUrl);
        if(errorCode == -6) {
          // errorCode: -6, description: net::ERR_CONNECTION_REFUSED
          try {
            view.stopLoading();
          } catch ( Exception e ) {
            // ignore
          } finally {
            // reload
            Uri failingUri = Uri.parse(failingUrl);
            if(failingUri.getQueryParameter("cap_reloaded") == null) {
              Uri.Builder reloadUri = failingUri.buildUpon();
              reloadUri.appendQueryParameter("cap_reloaded", "true");
              view.loadUrl(reloadUri.build().toString());
            }
          }
        }
      }
      @TargetApi(android.os.Build.VERSION_CODES.M)
      @Override
      public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError error) {
        // Redirect to deprecated method, so you can use it in all SDK versions
        onReceivedError(view, error.getErrorCode(), error.getDescription().toString(), req.getUrl().toString());
      }
    });
  }
}
```