### PR TITLE
fix(android): return proper mimeType for wasm files

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -330,6 +330,8 @@ public class WebViewLocalServer {
         if (path.endsWith(".js")) {
           // Make sure JS files get the proper mimetype to support ES modules
           mimeType = "application/javascript";
+        } else if (path.endsWith(".wasm")) {
+          mimeType = "application/wasm";
         } else {
           mimeType = URLConnection.guessContentTypeFromStream(stream);
         }


### PR DESCRIPTION
The local web server is not able to guess the proper mimeType for wasm files, so do it ourselves based on the extension.

Closes #1864