### PR TITLE
[FEATURE] Android send intent support

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Bundle;
 import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -129,6 +129,12 @@ export interface AppPlugin extends Plugin {
    * Listen for the hardware back button event (Android only). If you want to close the app, call `App.exitApp()`
    */
   addListener(eventName: 'backButton', listenerFunc: (data: AppUrlOpen) => void): PluginListenerHandle;
+
+/**
+ * Listen for send action intent events (Android only). The extras will be passed as a key value pair
+ * directly from the Android intent.
+ */
+  addListener(eventName: 'appSendActionIntent', listenerFunc: (data: AppSendActionIntentResult) => void): PluginListenerHandle;
 }
 
 export interface AppState {
@@ -172,6 +178,13 @@ export interface AppRestoredResult {
    * expect from normally calling the plugin method. For example, `CameraPhoto`
    */
   data: any;
+}
+
+export interface AppSendActionIntentResult {
+  /**
+   * An object with keys for Android intent names (like 'android.intent.extra.SUBJECT') and their value passed from the Android intent
+   */
+  extras: any;
 }
 
 //

--- a/site/docs-md/apis/app/index.md
+++ b/site/docs-md/apis/app/index.md
@@ -81,6 +81,7 @@ App.addListener('appRestoredResult', (data: any) => {
 App.addListener('appSendActionIntent', (data: any) => {
   const { extras } = data;
 
+  // The key is the constant value of the intent extra. You can find all of the options here: https://developer.android.com/reference/android/content/Intent#standard-extra-data
   const intentSubject = extras['android.intent.extra.SUBJECT'];
   const intentText = extras['android.intent.extra.TEXT'];
 

--- a/site/docs-md/apis/app/index.md
+++ b/site/docs-md/apis/app/index.md
@@ -24,6 +24,22 @@ To use `canOpenUrl`, you need to set the URL schemes your app will query for in 
 
 Read more about [LSApplicationQueriesSchemes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14) and [configuring Info.plist](../ios/configuration).
 
+## Note about `appSendActionIntent` event 
+This event is for Android only and it is useful when your application was opened via an intent of type 'send'. This enables you to react to values provided by the intent in your application. 
+
+For example, you might want to add your application as a target for receiving text from other applications. In this case you would need to add an intent filter to your `AndroidManifest.xml` under the `<activity>` node like so:
+
+```xml
+<intent-filter>
+  <action android:name="android.intent.action.SEND" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <data android:mimeType="text/plain" />
+</intent-filter>
+```
+
+Without this intent filter, your application will not show as a target in the Android share list when sharing the appropriate type (in this case text) from another application.
+Also note that the `mimeType` could be something other than `text/plain`. See [here for more information](https://developer.android.com/guide/topics/manifest/data-element#mime).
+
 ## Example
 
 ```typescript
@@ -59,6 +75,17 @@ App.addListener('appUrlOpen', (data: any) => {
 
 App.addListener('appRestoredResult', (data: any) => {
   console.log('Restored state:', data);
+});
+
+// Android Only
+App.addListener('appSendActionIntent', (data: any) => {
+  const { extras } = data;
+
+  const intentSubject = extras['android.intent.extra.SUBJECT'];
+  const intentText = extras['android.intent.extra.TEXT'];
+
+  console.log('Intent Subject', intentSubject);
+  console.log('Intent Text', intentText);
 });
 ```
 


### PR DESCRIPTION
The motivation for this PR is that handling send intents with cordova is a pain. There are some plugins out there but they are all convoluted and hard to understand. Also the API is usually not very good leading to confusion.
The `App` plugin already handles the intent lifecycle right now for handling `VIEW` intents for deep linking. So instead of creating a plugin with another listener I figured this would be a good place to handle a `SEND` intent as well.
If this is not the right place or if I miss anything please let me know. This is my very first PR so feedback is welcome.