### PR TITLE
fix(android/splash): Avoid glitches on slow devices and respect keep fullscreen flag

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -228,6 +228,7 @@ public class Splash {
 
         WindowManager.LayoutParams params = new WindowManager.LayoutParams();
         params.gravity = Gravity.CENTER;
+        params.flags = a.getWindow().getAttributes().flags & (WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
         // Required to enable the view to actually fade
         params.format = PixelFormat.TRANSLUCENT;
@@ -242,6 +243,8 @@ public class Splash {
                 .setDuration(fadeInDuration)
                 .setListener(listener)
                 .start();
+
+        splashImage.setVisibility(View.VISIBLE);
 
         if (spinnerBar != null) {
           Boolean showSpinner = Config.getBoolean(CONFIG_KEY_PREFIX + "showSpinner", false);
@@ -347,6 +350,8 @@ public class Splash {
     }
 
     if (splashImage != null && splashImage.getParent() != null) {
+      splashImage.setVisibility(View.INVISIBLE);
+
       wm.removeView(splashImage);
     }
 


### PR DESCRIPTION
On slow devices, there is a visual glitch when the splash screen is hidden, which can be avoided by changing the visibility before removing the view.

Additionally, the `FLAG_FULLSCREEN` should be copied from the window so that the status bar does not appear during the splash, in case `<item name="android:windowFullscreen">true</item>` was specified in `styles.xml`.
