### PR TITLE
fix(android/splash): don't hardcode spinner size

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -252,8 +252,8 @@ public class Splash {
             wm.removeView(spinnerBar);
           }
 
-          params.height = 120;
-          params.width = 120;
+          params.height = WindowManager.LayoutParams.WRAP_CONTENT;
+          params.width = WindowManager.LayoutParams.WRAP_CONTENT;
 
           wm.addView(spinnerBar, params);
 


### PR DESCRIPTION
I don't understand why you hard-code the spinner size to 120x120 pixels. It does not depend on the screen DPI and if there is a difference between `androidSpinnerStyle` `large` and `small`, I can't see it.

Why not let the spinner decide how large is should be?
