### PR TITLE
[FEATURE] Add openPackage function for android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
@@ -104,6 +104,24 @@ public class App extends Plugin {
     }
   }
 
+  @PluginMethod()
+  public void openPackage(PluginCall call) {
+    String packageName = call.getString("packageName");
+    if (packageName == null) {
+      call.error("Must provide a packageName to open");
+      return;
+    }
+
+    final PackageManager manager = getContext().getPackageManager();
+    final Intent launchIntent = manager.getLaunchIntentForPackage(packageName);
+
+    try {
+      getActivity().startActivity(launchIntent);
+    } catch(Exception ex) {
+      call.error("Unable to open package", ex);
+    }
+  }
+
   /**
    * Handle ACTION_VIEW intents to store a URL that was used to open the app
    * @param intent

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -103,6 +103,11 @@ export interface AppPlugin extends Plugin {
   openUrl(options: { url: string }): Promise<{completed: boolean}>;
 
   /**
+   * Opens the main activity of an app with the given package name (Android Only)
+   */
+  openPackage(options: { packageName: string }): Promise<{ completed: boolean }>;
+
+  /**
    * Get the URL the app was launched with, if any
    */
   getLaunchUrl(): Promise<AppLaunchUrl>;

--- a/core/src/web/app.ts
+++ b/core/src/web/app.ts
@@ -26,6 +26,10 @@ export class AppPluginWeb extends WebPlugin implements AppPlugin {
     return Promise.resolve({ completed: true });
   }
 
+  openPackage(_options: { packageName: string; }): Promise<{ completed: boolean; }> {
+    return Promise.resolve({ completed: true });
+  }
+
   getLaunchUrl(): Promise<AppLaunchUrl> {
     return Promise.resolve({ url: '' });
   }

--- a/site/docs-md/apis/app/index.md
+++ b/site/docs-md/apis/app/index.md
@@ -47,6 +47,10 @@ console.log('Can open url: ', ret.value);
 ret = await App.openUrl({ url: 'com.getcapacitor.myapp://page?id=ionicframework' });
 console.log('Open url response: ', ret);
 
+// Android Only
+ret = await App.openPackage({ packageName: 'com.instagram.android' });
+console.log('Open package response: ', ret);
+
 ret = await App.getLaunchUrl();
 if(ret && ret.url) {
   console.log('App opened with URL: ' + ret.url);


### PR DESCRIPTION
Currently there is no way to open the main activity for an android app. If that app does not handle a `VIEW` intent from a url then it is impossible to open the app at all (for example the instagram app). 
This PR adds a function to the `App` plugin so that it is able to open an app via its package name. If the app is not installed, the call to the plugin will fail just like `App.openUrl`