### PR TITLE
fix(cli): make plugin generator run pod install on plugin creation

### DIFF
--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -1,10 +1,10 @@
 import { Config } from '../config';
 import { log, logFatal, logInfo, runCommand, runTask, writePrettyJSON, logWarn } from '../common';
+import { OS } from '../definitions';
 import { emoji } from '../util/emoji';
 import { existsAsync, mkdirAsync, writeFileAsync, readFileAsync } from '../util/fs';
 import { fixName, removeScope } from '../plugin'
-
-import { copy, move, mkdirs, unlink } from 'fs-extra';
+import { copy, mkdirs, unlink } from 'fs-extra';
 import { dirname, join } from 'path';
 import { isInteractive } from '../util/term';
 
@@ -127,6 +127,13 @@ export async function newPlugin(config: Config) {
     await runTask('Installing NPM dependencies', async () => {
       return  runCommand(`cd "${pluginPath}" && npm install`);
     });
+
+    if (config.cli.os === OS.Mac) {
+      await runTask('Building iOS project', async () => {
+        const iosPath = join(pluginPath, 'ios');
+        return  runCommand(`cd "${iosPath}" && pod install`);
+      });
+    }
 
     logInfo(`Your Capacitor plugin was created at ${pluginPath}`);
 

--- a/plugin-template/ios/Podfile
+++ b/plugin-template/ios/Podfile
@@ -1,13 +1,16 @@
 platform :ios, '11.0'
 
-target 'Plugin' do
+def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
+  pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
+end
+
+target 'Plugin' do
+  capacitor_pods
 end
 
 target 'PluginTests' do
-  use_frameworks!
-
-  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
+  capacitor_pods
 end


### PR DESCRIPTION
The plugin generator should run pod install so the xcworkspace is generated as the docs say.
Also the Podfile should include CapacitorCordova.

closes #1836