### PR TITLE
fix(electron): correctly read/write file with no encoding

### DIFF
--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -57,21 +57,22 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
 
   writeFile(options: FileWriteOptions): Promise<FileWriteResult> {
     return new Promise((resolve, reject) => {
-      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
+      if (Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      let data = options.data.indexOf(',') >= 0 ? options.data.split(',')[1] : options.data;
+      let data: (Buffer | string) = options.data;
       if (!options.encoding) {
-        data = Buffer.from(data, 'base64')
+        const base64Data = options.data.indexOf(',') >= 0 ? options.data.split(',')[1] : options.data;
+        data = Buffer.from(base64Data, 'base64');
       }
-      this.NodeFS.writeFile(lookupPath, data, options.encoding || 'binary', (err:any) => {
-        if(err) {
+      this.NodeFS.writeFile(lookupPath, data, options.encoding || 'binary', (err: any) => {
+        if (err) {
           reject(err);
           return;
         }
 
         resolve();
-      })
+      });
     });
   }
 

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -39,18 +39,18 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
     this.Path = path;
   }
 
-  readFile(options: FileReadOptions): Promise<FileReadResult>{
+  readFile(options: FileReadOptions): Promise<FileReadResult> {
     return new Promise<FileReadResult>((resolve, reject) => {
-      if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
+      if (Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.readFile(lookupPath, options.encoding || 'binary', (err:any, data:any) => {
-        if(err) {
+      this.NodeFS.readFile(lookupPath, options.encoding || 'binary', (err: any, data: any) => {
+        if (err) {
           reject(err);
           return;
         }
 
-        resolve({ data: options.encoding ? data : data.toString('base64') });
+        resolve({ data: options.encoding ? data : Buffer.from(data, 'binary').toString('base64') });
       });
     });
   }

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -44,13 +44,13 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.readFile(lookupPath, options.encoding, (err:any, data:any) => {
+      this.NodeFS.readFile(lookupPath, options.encoding || 'binary', (err:any, data:any) => {
         if(err) {
           reject(err);
           return;
         }
 
-        resolve({data});
+        resolve({ data: options.encoding ? data : data.toString('base64') });
       });
     });
   }
@@ -60,7 +60,11 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.writeFile(lookupPath, options.data, options.encoding, (err:any) => {
+      let data = options.data.indexOf(',') >= 0 ? options.data.split(',')[1] : options.data;
+      if (!options.encoding) {
+        data = Buffer.from(data, 'base64')
+      }
+      this.NodeFS.writeFile(lookupPath, data, options.encoding || 'binary', (err:any) => {
         if(err) {
           reject(err);
           return;


### PR DESCRIPTION
I was working with the Filesystem plugin and some data URL files encoded in base64 and I stumbled upon the fact that Electron bridge is not implemented like the Android and iOS one. I simply cannot store a PDF file because it always encrypt as UTF8 and break the file.

On iOS and Android, the default encoding when writing files is `base64`. If a data URL is detected it deletes its header before converting it to `binary`. When reading, if no encoding is given, the same thing happens the other way, it converts `binary` to `base64`.

This is a breaking change for Electron users but ATM, Electron filesystem plugin does not behave at all like iOS and Android.
