### PR TITLE
fix(core): return proper Error objects from native

### DIFF
--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -217,6 +217,11 @@
       if (storedCall) {
         // looks like we've got a stored call
 
+        if (result.error) {
+          // ensure stacktraces
+          result.error = Object.assign(new Error(), result.error);
+        }
+
         if (typeof storedCall.callback === 'function') {
           // callback
           if (result.success) {

--- a/core/native-bridge.js
+++ b/core/native-bridge.js
@@ -217,9 +217,12 @@
       if (storedCall) {
         // looks like we've got a stored call
 
-        if (result.error) {
-          // ensure stacktraces
-          result.error = Object.assign(new Error(), result.error);
+        if (result.error && typeof result.error === 'object') {
+          // ensure stacktraces by copying error properties to an Error
+          result.error = Object.keys(result.error).reduce(function(err, key) {
+            err[key] = result.error[key];
+            return err;
+          }, new Error());
         }
 
         if (typeof storedCall.callback === 'function') {


### PR DESCRIPTION
If I receive news of a Capacitor plugin error via sentry, there are no stack traces because `fromNative` (in `native-bridge.js`) throws a deserialized JSON object, not an `Error`. It's not even clear that the error is from a Capacitor plugin, as it's usually something like `{ message: "File not found" }`.

![image](https://user-images.githubusercontent.com/310464/64661153-e2f62880-d486-11e9-9da5-7286c460c5fc.png)

![image](https://user-images.githubusercontent.com/310464/64661248-45e7bf80-d487-11e9-82d8-573da7ff91e0.png)

This pull request transforms the error objects into actual `Errors` before they are thrown (well, passed to the callback/rejected). Now, at least one can see that the error originated from the native bridge:

![image](https://user-images.githubusercontent.com/310464/64661305-74659a80-d487-11e9-80f4-f83040d2da73.png)

Note that this PR uses `Object.assign` - I'm not sure whether Capacitor supports platforms without it. This is the MDN compatibility table:

![image](https://user-images.githubusercontent.com/310464/64661435-efc74c00-d487-11e9-9716-30d9f929e1a9.png)
