### PR TITLE
docs(splash screen): fix typo for options

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1500,7 +1500,7 @@ export interface SplashScreenShowOptions {
    */
   fadeOutDuration?: number;
   /**
-  * How long to show the splash screen when authHide is enabled (in ms)
+  * How long to show the splash screen when autoHide is enabled (in ms)
   * Default is 3000ms
   */
   showDuration?: number;

--- a/site/src/assets/docs-content/apis/splash-screen/api.html
+++ b/site/src/assets/docs-content/apis/splash-screen/api.html
@@ -122,7 +122,7 @@
           </div>
 
           <div class="avc-code-interface-param">
-            <div class="avc-code-param-comment">// How long to show the splash screen when authHide is enabled (in ms)
+            <div class="avc-code-param-comment">// How long to show the splash screen when autoHide is enabled (in ms)
 Default is 3000ms</div>
             <div class="avc-code-line"><span class="avc-code-param-name">showDuration</span>
               <span class="avc-code-param-optional">?</span>:


### PR DESCRIPTION
Just a minor typo fix, changing `authHide` -> `autoHide`