### PR TITLE
feat(cordova): move Cordova prefs from config.xml to capacitor.config.json

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -347,7 +347,7 @@ export async function getCordovaPreferences(config: Config) {
       cordova.preferences[pref.$.name] = pref.$.value;
     });
   }
-  if (config.app.extConfig.cordova && config.app.extConfig.cordova.preferences && cordova.preferences) {
+  if (config.app.extConfig && config.app.extConfig.cordova && config.app.extConfig.cordova.preferences && cordova.preferences) {
     const answer = await inquirer.prompt({
       type: 'confirm',
       name: 'confirm',

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -173,11 +173,19 @@ export async function autoGenerateConfig(config: Config, cordovaPlugins: Plugin[
     const xmlString = await writeXML(item);
     return xmlString;
   }));
+  let pluginPreferencesString: Array<string> = [];
+  if (config.app.extConfig.cordova && config.app.extConfig.cordova.preferences) {
+    pluginPreferencesString = await Promise.all(Object.keys(config.app.extConfig.cordova.preferences).map(async (key): Promise<string> => {
+      return `
+  <preference name="${key}" value="${config.app.extConfig.cordova.preferences[key]}" />`;
+    }));
+  }
   const content = `<?xml version='1.0' encoding='utf-8'?>
-  <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <access origin="*" />
-  ${pluginEntriesString.join('\n')}
-  </widget>`;
+  ${pluginEntriesString.join('')}
+  ${pluginPreferencesString.join('')}
+</widget>`;
   await writeFileAsync(cordovaConfigXMLFile, content);
 }
 

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -174,7 +174,7 @@ export async function autoGenerateConfig(config: Config, cordovaPlugins: Plugin[
     return xmlString;
   }));
   let pluginPreferencesString: Array<string> = [];
-  if (config.app.extConfig.cordova && config.app.extConfig.cordova.preferences) {
+  if (config.app.extConfig && config.app.extConfig.cordova && config.app.extConfig.cordova.preferences) {
     pluginPreferencesString = await Promise.all(Object.keys(config.app.extConfig.cordova.preferences).map(async (key): Promise<string> => {
       return `
   <preference name="${key}" value="${config.app.extConfig.cordova.preferences[key]}" />`;
@@ -357,7 +357,7 @@ export async function getCordovaPreferences(config: Config) {
       cordova = config.app.extConfig.cordova;
     }
   }
-  if (!cordova.preferences) {
+  if (config.app.extConfig && !cordova.preferences) {
     cordova = config.app.extConfig.cordova;
   }
   return cordova;

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -7,6 +7,7 @@ import { copy as fsCopy, existsSync } from 'fs-extra';
 import { getAndroidPlugins } from './android/common';
 import { getIOSPlugins } from './ios/common';
 import { copy } from './tasks/copy';
+import * as inquirer from 'inquirer';
 
 const plist = require('plist');
 const chalk = require('chalk');
@@ -317,7 +318,7 @@ export async function checkAndInstallDependencies(config: Config, plugins: Plugi
   return needsUpdate;
 }
 
-export function getIncompatibleCordovaPlugins(platform: string){
+export function getIncompatibleCordovaPlugins(platform: string) {
   let pluginList = ["cordova-plugin-statusbar", "cordova-plugin-splashscreen", "cordova-plugin-ionic-webview",
   "cordova-plugin-crosswalk-webview", "cordova-plugin-wkwebview-engine", "cordova-plugin-console",
   "cordova-plugin-compat", "cordova-plugin-music-controls", "cordova-plugin-add-swift-support",
@@ -326,4 +327,30 @@ export function getIncompatibleCordovaPlugins(platform: string){
     pluginList.push("cordova-plugin-googlemaps");
   }
   return pluginList;
+}
+
+export async function getCordovaPreferences(config: Config) {
+  const configXml = join(config.app.rootDir, 'config.xml');
+  let cordova: any = {};
+  if (existsSync(configXml)) {
+    cordova.preferences = {};
+    const xmlMeta = await readXML(configXml);
+    xmlMeta.widget.preference.map((pref: any) => {
+      cordova.preferences[pref.$.name] = pref.$.value;
+    });
+  }
+  if (config.app.extConfig.cordova && config.app.extConfig.cordova.preferences && cordova.preferences) {
+    const answer = await inquirer.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: 'capacitor.config.json already contains cordova preferences. Overwrite with values from config.xml?'
+    });
+    if (!answer.confirm) {
+      cordova = config.app.extConfig.cordova;
+    }
+  }
+  if (!cordova.preferences) {
+    cordova = config.app.extConfig.cordova;
+  }
+  return cordova;
 }

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -23,6 +23,7 @@ export interface ExternalConfig {
     cordovaLinkerFlags?: string[];
   };
   npmClient?: string;
+  cordova?: any;
 }
 
 export interface AppPluginsConfig {

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -14,6 +14,7 @@ import {
   printNextSteps,
   runTask,
 } from '../common';
+import { getCordovaPreferences } from '../cordova';
 import { emoji as _e } from '../util/emoji';
 import { checkInteractive } from '../util/term';
 
@@ -43,6 +44,8 @@ export async function initCommand(config: Config, name: string, id: string, webD
       ]
     );
 
+    const cordova = await getCordovaPreferences(config);
+
     await runTask(`Initializing Capacitor project in ${chalk.blue(config.app.rootDir)}`, async () => {
       config.app.appId = appId;
       config.app.appName = appName;
@@ -55,7 +58,8 @@ export async function initCommand(config: Config, name: string, id: string, webD
         appId,
         appName,
         webDir,
-        npmClient
+        npmClient,
+        cordova
       });
     });
 


### PR DESCRIPTION
On init command, the existing config.xml preferences will be migrated to capacitor.config.json.

Those preferences will be copied to the platform generated config.xml on copy/update commands. 

Closes #1944 