### PR TITLE
fix(android): handle input file with multiple accept mimetypes

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -302,6 +302,10 @@ public class BridgeWebChromeClient extends WebChromeClient {
     if (fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
       intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
     }
+    if (fileChooserParams.getAcceptTypes().length > 1) {
+      intent.setType("*/*");
+      intent.putExtra(Intent.EXTRA_MIME_TYPES, fileChooserParams.getAcceptTypes());
+    }
     try {
       bridge.cordovaInterface.startActivityForResult(new CordovaPlugin() {
         @Override


### PR DESCRIPTION
Currently when you add a file input with multiple mime-types in the accept attribute Capacitor will only use the first mimetype, this change make the file picker correctly use all specified mime-types.

Example of input thats currently broken:

`<input type="file" accept="image/jpeg,image/png,application/pdf">`

the example file input will only accept jpeg images instead of also accepting png and pdf's