### PR TITLE
feat(core): add appBuild to device getInfo

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
@@ -30,6 +30,7 @@ public class Device extends Plugin {
     r.put("model", android.os.Build.MODEL);
     r.put("osVersion", android.os.Build.VERSION.RELEASE);
     r.put("appVersion", getAppVersion());
+    r.put("appBuild", getAppBuild());
     r.put("platform", getPlatform());
     r.put("manufacturer", android.os.Build.MANUFACTURER);
     r.put("uuid", getUuid());
@@ -67,6 +68,15 @@ public class Device extends Plugin {
     try {
       PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
       return pinfo.versionName;
+    } catch(Exception ex) {
+      return null;
+    }
+  }
+
+  private String getAppBuild() {
+    try {
+      PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
+      return Integer.toString(pinfo.versionCode);
     } catch(Exception ex) {
       return null;
     }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -418,6 +418,10 @@ export interface DeviceInfo {
    */
   appVersion: string;
   /**
+   * The current bundle build of the app
+   */
+  appBuild: string;
+  /**
    * The version of the device OS
    */
   osVersion: string;

--- a/core/src/web/device.ts
+++ b/core/src/web/device.ts
@@ -33,6 +33,7 @@ export class DevicePluginWeb extends WebPlugin implements DevicePlugin {
       model: uaFields.model,
       platform: <'web'> 'web',
       appVersion: '',
+      appBuild: '',
       osVersion: uaFields.osVersion,
       manufacturer: navigator.vendor,
       isVirtual: false,

--- a/electron/src/electron/device.ts
+++ b/electron/src/electron/device.ts
@@ -18,6 +18,7 @@ export class DevicePluginElectron extends WebPlugin implements DevicePlugin {
       model: info.model,
       platform: <'electron'> 'electron',
       appVersion: '',
+      appBuild: '',
       osVersion: info.osVersion,
       manufacturer: navigator.vendor,
       isVirtual: false,

--- a/ios/Capacitor/Capacitor/Plugins/Device.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Device.swift
@@ -25,6 +25,7 @@ public class CAPDevicePlugin: CAPPlugin {
       "model": UIDevice.current.model,
       "osVersion": UIDevice.current.systemVersion,
       "appVersion": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+      "appBuild": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
       "platform": "ios",
       "manufacturer": "Apple",
       "uuid": UIDevice.current.identifierForVendor!.uuidString,

--- a/site/docs-md/apis/device/index.md
+++ b/site/docs-md/apis/device/index.md
@@ -30,6 +30,7 @@ console.log(info);
 {
   "diskFree": 12228108288,
   "appVersion": "1.0.2",
+  "appBuild": "123",
   "osVersion": "11.2",
   "platform": "ios",
   "memUsed": 93851648,

--- a/site/src/assets/docs-content/apis/device/api.html
+++ b/site/src/assets/docs-content/apis/device/api.html
@@ -61,6 +61,14 @@
     
 
           <div class="avc-code-interface-param">
+            <div class="avc-code-param-comment">// The current bundle build of the app</div>
+            <div class="avc-code-line"><span class="avc-code-param-name">appBuild</span>
+              :
+              <avc-code-type>string</avc-code-type>;
+            </div>
+          </div>
+
+          <div class="avc-code-interface-param">
             <div class="avc-code-param-comment">// The current bundle verison of the app</div>
             <div class="avc-code-line"><span class="avc-code-param-name">appVersion</span>
               :


### PR DESCRIPTION
Adds the app bundle build number to the `Device.getInfo()` payload. Currently you can only get the bundle version number, but developers may wish to display the build number in their app as well.

iOS:
```
Bundle.main.infoDictionary?["CFBundleVersion"]
```
Android:
```
getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0).versionCode
```