### PR TITLE
docs: add note on plugins that require PWA Elements

### DIFF
--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -41,6 +41,10 @@ Read about [Setting Android Permissions](../../android/configuration/) in the [A
 Additionally, because the Camera API launches a separate Activity to handle taking the photo, you should listen for `appRestoredResult` in the `App` plugin
 to handle any camera data that was sent in the case your app was terminated by the operating system while the Activity was running.
 
+## PWA/Electron Notes
+
+[PWA Elements](/docs/pwa-elements) are required for Camera plugin to work.
+
 ## Example
 
 ```typescript

--- a/site/docs-md/apis/toast/index.md
+++ b/site/docs-md/apis/toast/index.md
@@ -15,6 +15,10 @@ The Toast API provides a notification pop up for displaying important informatio
 
 <plugin-api index="true" name="toast"></plugin-api>
 
+## PWA/Electron Notes
+
+[PWA Elements](/docs/pwa-elements) are required for Toast plugin to work.
+
 ## Example
 
 ```typescript

--- a/site/docs-md/web/pwa-elements.md
+++ b/site/docs-md/web/pwa-elements.md
@@ -9,13 +9,13 @@ contributors:
 
 # PWA Elements
 
-<p class="intro">Some Capacitor plugins, such as <code>Camera</code>, have web-based UI available when not running natively. For example, calling <code>Camera.getPhoto()</code> will 
+<p class="intro">Some Capacitor plugins, such as <code>Camera</code> or <code>Toast</code>, have web-based UI available when not running natively. For example, calling <code>Camera.getPhoto()</code> will 
 load a responsive photo-taking experience when running on the web or electron:</p>
 
 <img src="/assets/img/docs/pwa-elements.png" style="height: 200px" />
 
-This UI is implemented using a subset of the [Ionic Framework](http://ionicframework.com/) web components. Due to the magic of Shadow DOM, these components should not conflict
-with your own UI whether you choose to use Ionic or not.
+This UI is implemented using web components. Due to the magic of Shadow DOM, these components should not conflict
+with your own UI.
 
 ## Installation
 


### PR DESCRIPTION
Add note on Toast and Camera about requiring PWA Elements to work.
Also removed the Ionic part of PWA Elements since it no longer uses Ionic components but regular web components.

Closes #1934 