### PR TITLE
fix(android): return empty string if appVersion or appBuild fail

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
@@ -69,7 +69,7 @@ public class Device extends Plugin {
       PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
       return pinfo.versionName;
     } catch(Exception ex) {
-      return null;
+      return "";
     }
   }
 
@@ -78,7 +78,7 @@ public class Device extends Plugin {
       PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
       return Integer.toString(pinfo.versionCode);
     } catch(Exception ex) {
-      return null;
+      return "";
     }
   }
 


### PR DESCRIPTION
appVersion and appBuild are not optional fields, but in case they are null they won't be added to the resulting object. Changing the null to empty string so they are properly returned. 