### PR TITLE
fix(core): update FileWriteOptions and FileAppendOptions encoding description

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -587,7 +587,10 @@ export interface FileWriteOptions {
    */
   directory?: FilesystemDirectory;
   /**
-   * The encoding to write the file in (defautls to utf8)
+   * The encoding to write the file in. If not provided, data
+   * is written as base64 encoded data.
+   *
+   * Pass FilesystemEncoding.UTF8 to write data as string
    */
   encoding?: FilesystemEncoding;
 }
@@ -606,7 +609,10 @@ export interface FileAppendOptions {
    */
   directory?: FilesystemDirectory;
   /**
-   * The encoding to write the file in (defautls to utf8)
+   * The encoding to write the file in. If not provided, data
+   * is written as base64 encoded data.
+   *
+   * Pass FilesystemEncoding.UTF8 to write data as string
    */
   encoding?: FilesystemEncoding;
 }


### PR DESCRIPTION
As can be seen in for example https://github.com/ionic-team/capacitor/blob/master/ios/Capacitor/Capacitor/Plugins/Filesystem.swift#L107-L116, the current implementation treats file as binary if encoding is left out.