### PR TITLE
feat(Filesystem): Deprecate createIntermediateDirectories in mkdir

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -327,6 +327,10 @@ public class Filesystem extends Plugin {
     String path = call.getString("path");
     String directory = getDirectoryParameter(call);
     boolean intermediate = call.getBoolean("createIntermediateDirectories", false).booleanValue();
+    if (call.getBoolean("createIntermediateDirectories") != null) {
+      Log.w(getLogTag(),"createIntermediateDirectories is deprecated, use recursive");
+    }
+    boolean recursive = call.getBoolean("recursive", false).booleanValue();
 
     File fileObject = getFileObject(path, directory);
 
@@ -338,7 +342,7 @@ public class Filesystem extends Plugin {
     if (!isPublicDirectory(directory)
             || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       boolean created = false;
-      if (intermediate) {
+      if (intermediate || recursive) {
         created = fileObject.mkdirs();
       } else {
         created = fileObject.mkdir();

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -650,9 +650,16 @@ export interface MkdirOptions {
    */
   directory?: FilesystemDirectory;
   /**
+   * @deprecated - use recursive
    * Whether to create any missing parent directories as well
+   * Defaults to false
    */
-  createIntermediateDirectories: boolean;
+  createIntermediateDirectories?: boolean;
+  /**
+   * Whether to create any missing parent directories as well.
+   * Defaults to false
+   */
+  recursive?: boolean;
 }
 
 export interface RmdirOptions {
@@ -665,7 +672,8 @@ export interface RmdirOptions {
    */
   directory?: FilesystemDirectory;
   /**
-   * Whether to recursively remove the contents of the directory (defaults to false)
+   * Whether to recursively remove the contents of the directory
+   * Defaults to false
    */
   recursive?: boolean;
 }

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -113,7 +113,11 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.mkdir(lookupPath, { recursive: options.createIntermediateDirectories }, (err:any) => {
+      if (options.createIntermediateDirectories !== undefined) {
+        console.warn('createIntermediateDirectories is deprecated, use recursive');
+      }
+      const doRecursive = options.createIntermediateDirectories || options.recursive;
+      this.NodeFS.mkdir(lookupPath, { recursive: doRecursive }, (err:any) => {
         if(err) {
           reject(err);
           return;

--- a/example/src/pages/filesystem/filesystem.ts
+++ b/example/src/pages/filesystem/filesystem.ts
@@ -73,7 +73,7 @@ export class FilesystemPage {
       let ret = await Plugins.Filesystem.mkdir({
         path: 'secrets',
         directory: FilesystemDirectory.Documents,
-        createIntermediateDirectories: false
+        recursive: false
       });
       console.log('Made dir', ret);
     } catch(e) {
@@ -207,7 +207,7 @@ export class FilesystemPage {
   mkdirAll(paths) {
     return this.doAll(paths, path => Plugins.Filesystem.mkdir({
       path,
-      createIntermediateDirectories: true,
+      recursive: true,
     }));
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -223,6 +223,10 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let createIntermediateDirectories = call.get("createIntermediateDirectories", Bool.self, false)!
+    if let _ = call.get("createIntermediateDirectories", Bool.self) {
+        CAPLog.print("createIntermediateDirectories is deprecated, use recursive")
+    }
+    let recursive = call.get("recursive", Bool.self, false)!
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
     guard let fileUrl = getFileUrl(path, directoryOption) else {
       handleError(call, "Invalid path")
@@ -230,7 +234,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     do {
-      try FileManager.default.createDirectory(at: fileUrl, withIntermediateDirectories: createIntermediateDirectories, attributes: nil)
+      try FileManager.default.createDirectory(at: fileUrl, withIntermediateDirectories: createIntermediateDirectories || recursive, attributes: nil)
       call.success()
     } catch let error as NSError {
       handleError(call, error.localizedDescription, error)

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -72,7 +72,7 @@ async mkdir() {
     let ret = await Filesystem.mkdir({
       path: 'secrets',
       directory: FilesystemDirectory.Documents,
-      createIntermediateDirectories: false // like mkdir -p
+      recursive: false // like mkdir -p
     });
   } catch(e) {
     console.error('Unable to make directory', e);


### PR DESCRIPTION
Deprecate `createIntermediateDirectories` in mkdir in favour of `recursive`.

Show warning when `createIntermediateDirectories` is used.

Add `recursive` option that replaces `createIntermediateDirectories`

Closes #1936 