### PR TITLE
docs: Added JS example to iOS custom-code section

### DIFF
--- a/site/docs-md/ios/custom-code.md
+++ b/site/docs-md/ios/custom-code.md
@@ -52,7 +52,15 @@ CAP_PLUGIN(MyPlugin, "MyPlugin",
 )
 ```
 
-This makes `MyPlugin`, and the `echo` method available to the Capacitor web runtime.
+This makes `MyPlugin`, and the `echo` method available to the Capacitor web runtime like this:
+
+```javascript
+import { Plugins } from "@capacitor/core"
+const { MyPlugin } = Plugins
+
+const result = await MyPlugin.echo({ value: "Hello World!" })
+console.log(result.value)
+```
 
 ## Private Native Code
 


### PR DESCRIPTION
It's already well-documented, but adding a JS example means that you can just copy-paste instructions and start playing around right away.