### PR TITLE
fix(android): when saving picture to gallery make sure the folder exist

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
@@ -27,6 +27,7 @@ public class CameraUtils {
         if(saveToGallery) {
             Log.d(getLogTag(), "Trying to save image to public external directory");
             storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+            storageDir.mkdirs();
         }  else {
             storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
         }


### PR DESCRIPTION
## Problem
The camera throws "Unable to create photo on disk" error when `saveToGallery` is set to `true` on Android 5.1. This PR fixes the issue by calling the `mkdirs()` to create the directory. Fixes the issue #2013

## Sources
As adopted from cordova-camera-plugin
https://github.com/apache/cordova-plugin-camera/blob/master/src/android/CameraLauncher.java#L610