### PR TITLE
fix(android): return proper mimeType for .mjs files

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -326,7 +326,7 @@ public class WebViewLocalServer {
         Log.d(LogUtils.getCoreTag(), "We shouldn't be here");
       }
       if (mimeType == null) {
-        if (path.endsWith(".js")) {
+        if (path.endsWith(".js") || path.endsWith(".mjs")) {
           // Make sure JS files get the proper mimetype to support ES modules
           mimeType = "application/javascript";
         } else if (path.endsWith(".wasm")) {


### PR DESCRIPTION
Some node modules provides ES module script with .mjs extension.
