### PR TITLE
Update plugins.md

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -103,7 +103,6 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
 | Filesharer | `@byteowls/capacitor-filesharer` | <https://github.com/moberwasserlechner/capacitor-filesharer> | |
-| Downloader | `capacitor-downloader` | <https://github.com/triniwiz/capacitor-downloader> | |
 | Zip | `capacitor-zip` | <https://github.com/triniwiz/capacitor-zip> | |
 
 ## Bluetooth


### PR DESCRIPTION
The developer of capacitor-downloader is unresponsive to issues. Until this plugin actually works and is tested, it should not be listed on the official plugins page.