### PR TITLE
Initial support for allowing plugins to modify the Webview Configuration

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -240,6 +240,20 @@ enum BridgeError: Error {
   func reset() {
     storedCalls = [String:CAPPluginCall]()
   }
+
+  /**
+   * Give all plugins that will be registered a chance to modify the Web View configuration before creating it
+   */
+  static func runWKWebViewConfigurationHooks(configuration: WKWebViewConfiguration) {
+    var numClasses = UInt32(0);
+    let classes = objc_copyClassList(&numClasses)
+    for i in 0..<Int(numClasses) {
+      let c: AnyClass = classes![i]
+      if class_conformsToProtocol(c, CAPBridgedPlugin.self) {
+        c.configureWKWebView?(configuration)
+      }
+    }
+  }
   
   /**
    * Register all plugins that have been declared

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -65,6 +65,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     webViewConfiguration.userContentController = o
     
     configureWebView(configuration: webViewConfiguration)
+    CAPBridge.runWKWebViewConfigurationHooks(configuration: webViewConfiguration)
     
     webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
     webView?.scrollView.bounces = false

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -28,6 +28,8 @@
 // some loading so the plugin author doesn't
 // need to override init()
 -(void) load;
+// Called before init to allow the plugin to modify the configuration of the main webview
++(void) configureWKWebView:(WKWebViewConfiguration *) configuration;
 -(NSString *)getId;
 -(BOOL)getBool:(CAPPluginCall*) call field:(NSString *)field defaultValue:(BOOL)defaultValue;
 -(NSString *) getString:(CAPPluginCall *)call field:(NSString *)field defaultValue:(NSString *)defaultValue;


### PR DESCRIPTION
Solves https://github.com/ionic-team/capacitor/issues/1097

Allows a plugin to modify the WKWebViewConfiguration as follows:
```
import Foundation
import Capacitor

@objc(IgnoreViewPortScaleLimitsPlugin)
public class IgnoreViewPortScaleLimitsPlugin: CAPPlugin {
    public static override func configureWKWebView(configuration: WKWebViewConfiguration) {
        configuration.ignoresViewportScaleLimits = true
    }
}
```

Drawbacks at the moment is nothing stops two conflicting modifications from conflicting, no simple way of warning the user that a plugin is overwriting another plugin, not sure if plugins are loaded consistently so it's hard to say if things will fail in consistent ways.

Not sure where to document this, seems it should be documented in the same place as `load` but I can't find where load is documented… Maybe It should be here? https://capacitor.ionicframework.com/docs/plugins/ios But that's a guide not really documentation…

If someone from the capacitor team could let me know where to document it along with if they're interested in merging this / know of a better way to go about this please let me know then I'll finish it up and remove the draft status.