### PR TITLE
Allow contentMode to be configured in SplashScreen

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -19,6 +19,8 @@ public class CAPSplashScreenPlugin: CAPPlugin {
   let defaultShowDuration = 3000
   let defaultAutoHide = true
 
+  let defaultContentMode = UIView.ContentMode.scaleAspectFill.rawValue
+
   public override func load() {
     buildViews()
     showOnLaunch()
@@ -101,7 +103,11 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     }
     imageView.image = image
     imageView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: window.bounds.size)
-    imageView.contentMode = .scaleAspectFill
+
+    let contentModeConfig = getConfigValue("contentMode") as? Int ?? defaultContentMode
+    let contentMode = UIView.ContentMode(rawValue: contentModeConfig)
+
+    imageView.contentMode = contentMode!
   }
 
   public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change _: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {


### PR DESCRIPTION
It's not currently possible to use SplashScreen plugin with any size constraints but aspect fill. This adds a new config param to SplashScreen called "contentMode" which is an Int representing a `UIView.ContentMode` enum.

First time writing swift, so forgive me if this is off. Happy to be enlightened.