### PR TITLE
fix(electron): Check whether the splash screen is already destroyed on close

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -113,7 +113,9 @@ class CapacitorSplashScreen {
     `;
 
     this.mainWindowRef.on('closed', () => {
-      this.splashWindow.close();
+      if (this.splashWindow && !this.splashWindow.isDestroyed) { 
+        this.splashWindow.close(); 
+      }
     });
 
     this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`, {baseURLForDataURL: `file://${rootPath}/splash_assets/`});

--- a/electron/index.js
+++ b/electron/index.js
@@ -113,7 +113,7 @@ class CapacitorSplashScreen {
     `;
 
     this.mainWindowRef.on('closed', () => {
-      if (this.splashWindow && !this.splashWindow.isDestroyed) { 
+      if (this.splashWindow && !this.splashWindow.isDestroyed()) { 
         this.splashWindow.close(); 
       }
     });


### PR DESCRIPTION
Resolves #2010 on MacOS. 

The issue stems from the splash screen being destroyed already, so I'm simply adding a check to ensure that the splash screen reference has a value and that it isn't already destroyed. This seems to solve the problem in a straightforward manner.