### PR TITLE
fix(android): allow fetch to local files on livereload

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -191,9 +191,16 @@ public class Bridge {
         authorities.add(appUrlObject.getAuthority());
       } catch (Exception ex) {
       }
-
+      localUrl = appUrlConfig;
+      appUrl = appUrlConfig;
       if (BuildConfig.DEBUG) {
-        Toast.show(getContext(), "Using app server " + appUrlConfig.toString());
+        Toast.show(getContext(), "Using app server " + appUrlConfig);
+      }
+    } else {
+      appUrl = localUrl;
+      // custom URL schemes requires path ending with /
+      if (!scheme.equals(Bridge.CAPACITOR_HTTP_SCHEME) && !scheme.equals(CAPACITOR_HTTPS_SCHEME)) {
+        appUrl += "/";
       }
     }
 
@@ -202,16 +209,6 @@ public class Bridge {
     // Start the local web server
     localServer = new WebViewLocalServer(context, this, getJSInjector(), authorities, html5mode);
     localServer.hostAssets(DEFAULT_WEB_ASSET_DIR);
-
-    if (appUrlConfig == null) {
-      appUrl = localUrl;
-      // custom URL schemes requires path ending with /
-      if (!scheme.equals(Bridge.CAPACITOR_HTTP_SCHEME) && !scheme.equals(CAPACITOR_HTTPS_SCHEME)) {
-        appUrl += "/";
-      }
-    } else {
-      appUrl = appUrlConfig;
-    }
 
     Log.d(LOG_TAG, "Loading app at " + appUrl);
 

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -172,7 +172,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(loadingUrl) || loadingUrl.toString().startsWith(bridge.getLocalUrl())) {
+    if (isLocalFile(loadingUrl) || Config.getString("server.url") == null) {
       Log.d(LogUtils.getCoreTag(), "Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {


### PR DESCRIPTION
Use the server.url as localUrl if defined so requests have the same origin and fetch works

closes #2042 
closes #1776 
closes #2043 