### PR TITLE
feat(ios): make didRegisterForRemoteNotificationsWithDeviceToken handle Data and String push tokens

### DIFF
--- a/ios/Capacitor/Capacitor/CAPNotifications.swift
+++ b/ios/Capacitor/Capacitor/CAPNotifications.swift
@@ -6,7 +6,6 @@
   case UniversalLinkOpen
   case ContinueActivity
   case DidRegisterForRemoteNotificationsWithDeviceToken
-  case DidRegisterForRemoteNotificationsWithFCMToken
   case DidFailToRegisterForRemoteNotificationsWithError
   case DecidePolicyForNavigationAction
   
@@ -18,7 +17,6 @@
       case .DidRegisterForRemoteNotificationsWithDeviceToken: return "CAPDidRegisterForRemoteNotificationsWithDeviceToken"
       case .DidFailToRegisterForRemoteNotificationsWithError: return "CAPDidFailToRegisterForRemoteNotificationsWithError"
       case .DecidePolicyForNavigationAction: return "CAPDecidePolicyForNavigationAction"
-      case .DidRegisterForRemoteNotificationsWithFCMToken: return "CAPDidRegisterForRemoteNotificationsWithFCMToken"
     }
   }
 }

--- a/ios/Capacitor/Capacitor/CAPNotifications.swift
+++ b/ios/Capacitor/Capacitor/CAPNotifications.swift
@@ -6,6 +6,7 @@
   case UniversalLinkOpen
   case ContinueActivity
   case DidRegisterForRemoteNotificationsWithDeviceToken
+  case DidRegisterForRemoteNotificationsWithFCMToken
   case DidFailToRegisterForRemoteNotificationsWithError
   case DecidePolicyForNavigationAction
   
@@ -17,6 +18,7 @@
       case .DidRegisterForRemoteNotificationsWithDeviceToken: return "CAPDidRegisterForRemoteNotificationsWithDeviceToken"
       case .DidFailToRegisterForRemoteNotificationsWithError: return "CAPDidFailToRegisterForRemoteNotificationsWithError"
       case .DecidePolicyForNavigationAction: return "CAPDecidePolicyForNavigationAction"
+      case .DidRegisterForRemoteNotificationsWithFCMToken: return "CAPDidRegisterForRemoteNotificationsWithFCMToken"
     }
   }
 }

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -2,7 +2,7 @@ import Foundation
 import UserNotifications
 
 enum PushNotificationError: Error {
-  case tokenIsNull
+  case tokenParsingFailed
 }
 
 /**
@@ -91,7 +91,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
       ])
     } else {
       notifyListeners("registrationError", data: [
-        "error": PushNotificationError.tokenIsNull.localizedDescription
+        "error": PushNotificationError.tokenParsingFailed.localizedDescription
       ])
     }
   }

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -1,6 +1,10 @@
 import Foundation
 import UserNotifications
 
+enum PushNotificationError: Error {
+  case tokenIsNull
+}
+
 /**
  * Implement three common modal types: alert, confirm, and prompt
  */
@@ -12,6 +16,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
   
   public override func load() {
     NotificationCenter.default.addObserver(self, selector: #selector(self.didRegisterForRemoteNotificationsWithDeviceToken(notification:)), name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(self.didRegisterForRemoteNotificationsWithFCMToken(notification:)), name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithFCMToken.name()), object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(self.didFailToRegisterForRemoteNotificationsWithError(notification:)), name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: nil)
   }
 
@@ -74,16 +79,32 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
   @objc func listChannels(_ call: CAPPluginCall) {
     call.unimplemented()
   }
+  
+  func handleMissingTokenData() {
+    notifyListeners("registrationError", data: [
+      "error": (PushNotificationError.tokenIsNull).localizedDescription
+      ])
+  }
 
   @objc public func didRegisterForRemoteNotificationsWithDeviceToken(notification: NSNotification){
     guard let deviceToken = notification.object as? Data else {
+      self.handleMissingTokenData()
       return
     }
     let deviceTokenString = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
     notifyListeners("registration", data:[
       "value": deviceTokenString
     ])
-
+  }
+    
+  @objc public func didRegisterForRemoteNotificationsWithFCMToken(notification: NSNotification) {
+    guard let fcmToken = notification.object as? String else {
+      self.handleMissingTokenData()
+      return
+    }
+    notifyListeners("registration", data:[
+      "value": fcmToken
+    ])
   }
 
   @objc public func didFailToRegisterForRemoteNotificationsWithError(notification: NSNotification){

--- a/site/docs-md/guides/push-notifications-firebase.md
+++ b/site/docs-md/guides/push-notifications-firebase.md
@@ -357,7 +357,7 @@ If you would like to recieve the firebase FCM token from iOS instead of the raw 
             if let error = error {
                 NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
             } else if let result = result {
-                NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithFCMToken.name()), object: result.token)
+                NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: result.token)
             }
         }
     }

--- a/site/docs-md/guides/push-notifications-firebase.md
+++ b/site/docs-md/guides/push-notifications-firebase.md
@@ -349,6 +349,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return true
   }
 ```
+If you would like to recieve the firebase FCM token from iOS instead of the raw APNS token, you will need to also change your `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` code to look like this:
+```swift
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+        InstanceID.instanceID().instanceID { (result, error) in
+            if let error = error {
+                NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
+            } else if let result = result {
+                NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithFCMToken.name()), object: result.token)
+            }
+        }
+    }
+```
+
 
 ### Upload the APNS Certificate or Key to Firebase
 


### PR DESCRIPTION
This PR enables passing strings to the `PushNotifications` `registration` event callback. This will enable user projects to pass any 3rd party token to the same event so they don't need to check which platform it is in JS to get the right kind of token.

This also includes a change to the push notifications firebase guide that adds the necessary lines to the user `AppDelegate.swift` to receive their FCM token in JS instead of the APNS one if they choose.

I have successfully built and tested this code locally to verify that it solves this problem (FCM token is passed through the same event on iOS and android). @jcesarmobile  Let me know if there's anything about this implementation that might be inconsistent with the rest of the repo or some other reason why it shouldn't be merged.