### PR TITLE
fix(ios/Camera): implement saveToGallery

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -28,6 +28,7 @@ struct CameraSettings {
   var width: Float = 0
   var height: Float = 0
   var resultType = "base64"
+  var saveToGallery = false
 }
 
 @objc(CAPCameraPlugin)
@@ -70,6 +71,8 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     settings.source = CameraSource(rawValue: call.getString("source") ?? DEFAULT_SOURCE.rawValue) ?? DEFAULT_SOURCE
     settings.direction = CameraDirection(rawValue: call.getString("direction") ?? DEFAULT_DIRECTION.rawValue) ?? DEFAULT_DIRECTION
     settings.resultType = call.get("resultType", String.self, "base64")!
+    settings.saveToGallery = call.get("saveToGAllery", Bool.self, false)!
+    
     // Get the new image dimensions if provided
     settings.width = Float(call.get("width", Int.self, 0)!)
     settings.height = Float(call.get("height", Int.self, 0)!)
@@ -210,7 +213,11 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
       }
       image = convertedImage
     }
-
+    
+    if settings.saveToGallery {
+        UIImageWriteToSavedPhotoAlbum(image, nil, nil, nil);
+    }
+    
     guard let jpeg = image!.jpegData(compressionQuality: CGFloat(settings.quality/100)) else {
       self.call?.error("Unable to convert image to jpeg")
       return

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -215,7 +215,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }
     
     if settings.saveToGallery {
-        UIImageWriteToSavedPhotoAlbum(image, nil, nil, nil);
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
     }
     
     guard let jpeg = image!.jpegData(compressionQuality: CGFloat(settings.quality/100)) else {

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -71,7 +71,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     settings.source = CameraSource(rawValue: call.getString("source") ?? DEFAULT_SOURCE.rawValue) ?? DEFAULT_SOURCE
     settings.direction = CameraDirection(rawValue: call.getString("direction") ?? DEFAULT_DIRECTION.rawValue) ?? DEFAULT_DIRECTION
     settings.resultType = call.get("resultType", String.self, "base64")!
-    settings.saveToGallery = call.get("saveToGAllery", Bool.self, false)!
+    settings.saveToGallery = call.get("saveToGallery", Bool.self, false)!
     
     // Get the new image dimensions if provided
     settings.width = Float(call.get("width", Int.self, 0)!)

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -215,7 +215,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }
     
     if settings.saveToGallery {
-        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
+        UIImageWriteToSavedPhotosAlbum(image!, nil, nil, nil);
     }
     
     guard let jpeg = image!.jpegData(compressionQuality: CGFloat(settings.quality/100)) else {


### PR DESCRIPTION
The iOS implementation of the Camera plugin did not implement saving to the photo gallery. 

closes #2076 