### PR TITLE
fix(electron): use proper quotes on splashHtml style font

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -105,7 +105,7 @@ class CapacitorSplashScreen {
     let splashHtml = this.splashOptions.customHtml || `
       <html style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
         <body style="background-image: url('./${this.splashOptions.imageFileName}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">
-          <div style="font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;>
+          <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
             ${this.splashOptions.loadingText}
           </div>
         </body>


### PR DESCRIPTION
The splash screen's HTML had a bad quote. The opening `"` on `"Helvetica Neue"` actually closed the style attribute. Changing `"Helvetica Neue"` to `'Helvetica Neue'` and properly closing the style attribute solves this, and the splash HTML renders correctly.
