### PR TITLE
fix(electron): make apps work on electron 7

### DIFF
--- a/electron-template/package.json
+++ b/electron-template/package.json
@@ -10,7 +10,7 @@
     "electron-is-dev": "^1.1.0"
   },
   "devDependencies": {
-    "electron": "^6.0.0"
+    "electron": "^7.0.0"
   },
   "keywords": [
     "capacitor",

--- a/electron-template/package.json
+++ b/electron-template/package.json
@@ -10,7 +10,7 @@
     "electron-is-dev": "^1.1.0"
   },
   "devDependencies": {
-    "electron": "^4.0.0"
+    "electron": "^6.0.0"
   },
   "keywords": [
     "capacitor",

--- a/electron/index.js
+++ b/electron/index.js
@@ -67,7 +67,7 @@ class CapacitorSplashScreen {
       let capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
       this.splashOptions = Object.assign(
         this.splashOptions,
-        capConfigJson.plugins.SplashScreen
+        capConfigJson.plugins.SplashScreen || {}
       );
     } catch (e) {
       console.error(e.message);
@@ -100,11 +100,17 @@ class CapacitorSplashScreen {
       frame: false,
       show: false,
       transparent: this.splashOptions.transparentWindow,
+      webPreferences: {
+        // Required to load file:// splash screen
+        webSecurity: false  
+      }
     });
+
+    let imagePath = path.join(rootPath,'splash_assets', this.splashOptions.imageFileName);
 
     let splashHtml = this.splashOptions.customHtml || `
       <html style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-        <body style="background-image: url('./${this.splashOptions.imageFileName}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">
+        <body style="background-image: url('file://${imagePath}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">
           <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
             ${this.splashOptions.loadingText}
           </div>
@@ -118,7 +124,7 @@ class CapacitorSplashScreen {
       }
     });
 
-    this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`, {baseURLForDataURL: `file://${rootPath}/splash_assets/`});
+    this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`);
 
     this.splashWindow.webContents.on('dom-ready', async () => {
       this.splashWindow.show();

--- a/electron/index.js
+++ b/electron/index.js
@@ -1,26 +1,27 @@
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 const { app, ipcMain, BrowserWindow } = require('electron');
 
 function getURLFileContents(path) {
   console.trace();
   return new Promise((resolve, reject) => {
     fs.readFile(path, (err, data) => {
-      if(err)
+      if (err)
         reject(err);
       resolve(data.toString());
     });
   });
 }
 
-const injectCapacitor = async function(url) {
+const injectCapacitor = async function (url) {
   console.warn('\nWARNING: injectCapacitor method is deprecated and will be removed in next major release. Check release notes for migration instructions\n')
   try {
     let urlFileContents = await getURLFileContents(url.substr(url.indexOf('://') + 3));
     let pathing = path.join(url.substr(url.indexOf('://') + 3), '../../node_modules/@capacitor/electron/dist/electron-bridge.js');
-    urlFileContents = urlFileContents.replace('<body>', `<body><script>window.require('${pathing.replace(/\\/g,'\\\\')}')</script>`);
+    urlFileContents = urlFileContents.replace('<body>', `<body><script>window.require('${pathing.replace(/\\/g, '\\\\')}')</script>`);
     return 'data:text/html;charset=UTF-8,' + urlFileContents;
-  } catch(e) {
+  } catch (e) {
     console.error(e);
     return url;
   }
@@ -45,7 +46,7 @@ class CapacitorSplashScreen {
     this.mainWindowRef = null;
     this.splashWindow = null;
 
-    if(!splashOptions) {
+    if (!splashOptions) {
       splashOptions = {};
     }
 
@@ -75,8 +76,8 @@ class CapacitorSplashScreen {
 
     ipcMain.on('showCapacitorSplashScreen', (event, options) => {
       this.show();
-      if(options) {
-        if(options.autoHide) {
+      if (options) {
+        if (options.autoHide) {
           let showTime = options.showDuration || 3000;
           setTimeout(() => {
             this.hide();
@@ -93,7 +94,6 @@ class CapacitorSplashScreen {
   init(inject = true) {
     let rootPath = app.getAppPath();
 
-
     this.splashWindow = new BrowserWindow({
       width: this.splashOptions.windowWidth,
       height: this.splashOptions.windowHeight,
@@ -102,16 +102,16 @@ class CapacitorSplashScreen {
       transparent: this.splashOptions.transparentWindow,
       webPreferences: {
         // Required to load file:// splash screen
-        webSecurity: false  
+        webSecurity: false
       }
     });
 
-    let imagePath = path.join(rootPath,'splash_assets', this.splashOptions.imageFileName);
+    let imagePath = path.join(rootPath, 'splash_assets', this.splashOptions.imageFileName);
+    let imageUrl = url.pathToFileURL(imagePath);
 
     let splashHtml = this.splashOptions.customHtml || `
       <html style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-        <body style="background-image: url('file://${imagePath}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">
-          <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
+      <body style="background-image: url('${imageUrl.href}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">       <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
             ${this.splashOptions.loadingText}
           </div>
         </body>
@@ -119,8 +119,8 @@ class CapacitorSplashScreen {
     `;
 
     this.mainWindowRef.on('closed', () => {
-      if (this.splashWindow && !this.splashWindow.isDestroyed()) { 
-        this.splashWindow.close(); 
+      if (this.splashWindow && !this.splashWindow.isDestroyed()) {
+        this.splashWindow.close();
       }
     });
 
@@ -130,14 +130,14 @@ class CapacitorSplashScreen {
       this.splashWindow.show();
       setTimeout(async () => {
         if (inject) {
-          this.mainWindowRef.loadURL(await injectCapacitor(`file://${rootPath}/app/index.html`), {baseURLForDataURL: `file://${rootPath}/app/`});
+          this.mainWindowRef.loadURL(await injectCapacitor(`file://${rootPath}/app/index.html`), { baseURLForDataURL: `file://${rootPath}/app/` });
         } else {
           this.mainWindowRef.loadURL(`file://${rootPath}/app/index.html`);
         }
       }, 4500);
     });
 
-    if(this.splashOptions.autoHideLaunchSplash) {
+    if (this.splashOptions.autoHideLaunchSplash) {
       this.mainWindowRef.webContents.on('dom-ready', () => {
         this.mainWindowRef.show();
         this.splashWindow.hide();

--- a/electron/index.js
+++ b/electron/index.js
@@ -107,11 +107,18 @@ class CapacitorSplashScreen {
     });
 
     let imagePath = path.join(rootPath, 'splash_assets', this.splashOptions.imageFileName);
-    let imageUrl = url.pathToFileURL(imagePath);
+    let imageUrl = '';
+    let useFallback = false;
+    try {
+      imageUrl = url.pathToFileURL(imagePath).href;
+    } catch (err) {
+      useFallback = true;
+      imageUrl = `./${this.splashOptions.imageFileName}`;
+    }
 
     let splashHtml = this.splashOptions.customHtml || `
       <html style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-      <body style="background-image: url('${imageUrl.href}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">       <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
+      <body style="background-image: url('${imageUrl}'); background-position: center center; background-repeat: no-repeat; width: 100%; height: 100%; margin: 0; overflow: hidden;">       <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: ${this.splashOptions.textColor}; position: absolute; top: ${this.splashOptions.textPercentageFromTop}%; text-align: center; font-size: 10vw; width: 100vw;">
             ${this.splashOptions.loadingText}
           </div>
         </body>
@@ -124,7 +131,11 @@ class CapacitorSplashScreen {
       }
     });
 
-    this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`);
+    if (useFallback) {
+      this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`, {baseURLForDataURL: `file://${rootPath}/splash_assets/`});
+    } else {
+      this.splashWindow.loadURL(`data:text/html;charset=UTF-8,${splashHtml}`);
+    }
 
     this.splashWindow.webContents.on('dom-ready', async () => {
       this.splashWindow.show();


### PR DESCRIPTION
Given that Electron is now at v7, this PR is to support that in Capacitor, and also provides a minor fix in the SplashScreen that is a response to a recently-reported Electron bug.