### PR TITLE
docs(Filesystem): use await in writeFile example

### DIFF
--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -31,7 +31,7 @@ const { Filesystem } = Plugins;
 
 fileWrite() {
   try {
-    Filesystem.writeFile({
+    await Filesystem.writeFile({
       path: 'secrets/text.txt',
       data: "This is a test",
       directory: FilesystemDirectory.Documents,

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -29,7 +29,7 @@ import { Plugins, FilesystemDirectory, FilesystemEncoding } from '@capacitor/cor
 
 const { Filesystem } = Plugins;
 
-fileWrite() {
+async fileWrite() {
   try {
     await Filesystem.writeFile({
       path: 'secrets/text.txt',


### PR DESCRIPTION
Updated the example-code for the `Filesystem.writeFile({ ... })`-method to include the `await` keyword.