### PR TITLE
fix(ios): set dark statusbar style if defined in plist

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -179,8 +179,12 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
         }
       }
       if let statusBarStyle = plist["UIStatusBarStyle"] as? String {
-        if (statusBarStyle != "UIStatusBarStyleDefault" && statusBarStyle != "UIStatusBarStyleDarkContent") {
-          self.statusBarStyle = .lightContent
+        if (statusBarStyle == "UIStatusBarStyleDarkContent") {
+            if #available(iOS 13.0, *) {
+                self.statusBarStyle = .darkContent
+            }
+        } else if (statusBarStyle == "UIStatusBarStyleLightContent") {
+            self.statusBarStyle = .lightContent
         }
       }
     }

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -181,9 +181,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
       if let statusBarStyle = plist["UIStatusBarStyle"] as? String {
         if (statusBarStyle == "UIStatusBarStyleDarkContent") {
             if #available(iOS 13.0, *) {
-                self.statusBarStyle = .darkContent
+                self.statusBarStyle = UIStatusBarStyle.init(rawValue: 3) ?? .default
             }
-        } else if (statusBarStyle == "UIStatusBarStyleLightContent") {
+        } else if (statusBarStyle != "UIStatusBarStyleDefault") {
             self.statusBarStyle = .lightContent
         }
       }

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -180,11 +180,12 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
       }
       if let statusBarStyle = plist["UIStatusBarStyle"] as? String {
         if (statusBarStyle == "UIStatusBarStyleDarkContent") {
-            if #available(iOS 13.0, *) {
-                self.statusBarStyle = UIStatusBarStyle.init(rawValue: 3) ?? .default
-            }
+          if #available(iOS 13.0, *) {
+            // TODO - use .darkContent instead of rawValue once Xcode 10 support is dropped
+            self.statusBarStyle = UIStatusBarStyle.init(rawValue: 3) ?? .default
+          }
         } else if (statusBarStyle != "UIStatusBarStyleDefault") {
-            self.statusBarStyle = .lightContent
+          self.statusBarStyle = .lightContent
         }
       }
     }


### PR DESCRIPTION
When dark status bar style was defined in plist it wasn't remembered  in statusBarStyle and as a result preferredStatusBarStyle always returned .default, which caused flicker of the status bar . Partially closes #1761 (in terms of ios issues).