### PR TITLE
capacitor-admob plugin currently support iOS to remove android only

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -96,7 +96,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
-| AdMob | `capacitor-admob` | <https://github.com/rahadur/capacitor-admob> | Android only (currently) |
+| AdMob | `capacitor-admob` | <https://github.com/rahadur/capacitor-admob> | |
 | AdMob | `@rdlabo/capacitor-admob` | <https://github.com/rdlabo/capacitor-admob> | |
 
 ## Notifications


### PR DESCRIPTION
based on it's [github repo](https://github.com/rahadur/capacitor-admob)