### PR TITLE
fix(plugin/camera): Fix scaling when setting only height

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -33,7 +33,7 @@ public class ImageUtils {
     } else if (width > 0) {
       return Bitmap.createScaledBitmap(bitmap, width, (int) (width * 1/aspect), false);
     } else if (height > 0) {
-      return Bitmap.createScaledBitmap(bitmap, (int)(height * 1/aspect), height, false);
+      return Bitmap.createScaledBitmap(bitmap, (int) (height * aspect), height, false);
     }
 
     return bitmap;

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -265,7 +265,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
       if settings.width > 0 {
         size = CGSize.init(width: Int(settings.width), height: Int(settings.width * (1/aspect)))
       } else if settings.height > 0 {
-        size = CGSize.init(width: Int(settings.height * (1/aspect)), height: Int(settings.height))
+        size = CGSize.init(width: Int(settings.height * aspect), height: Int(settings.height))
       }
     }
 


### PR DESCRIPTION
This fixes a bug where giving a prescribed `height` when scaling results in an image with inverted aspect ratio (i.e. trying to scale a portrait image would yield a landscape result and vice versa).