### PR TITLE
feat(LocalNotifications): Add support for count to work with every on LocalNotificationSchedule

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationSchedule.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationSchedule.java
@@ -44,7 +44,7 @@ public class LocalNotificationSchedule {
   }
 
   private void buildCountElement(JSObject schedule) {
-    this.count = schedule.getInteger("count");
+    this.count = schedule.getInteger("count", 1);
   }
 
   private void buildAtElement(JSObject schedule) throws ParseException {
@@ -128,28 +128,24 @@ public class LocalNotificationSchedule {
    * Get constant long value representing specific interval of time (weeks, days etc.)
    */
   public Long getEveryInterval() {
-    Integer value = count;
-    if (value == null) {
-      value = 1;
-    }
     switch (every) {
       case "year":
-        return value * DateUtils.YEAR_IN_MILLIS;
+        return count * DateUtils.YEAR_IN_MILLIS;
       case "month":
         // This case is just approximation as months have different number of days
-        return value * 30 * DateUtils.DAY_IN_MILLIS;
+        return count * 30 * DateUtils.DAY_IN_MILLIS;
       case "two-weeks":
-        return value * 2 * DateUtils.WEEK_IN_MILLIS;
+        return count * 2 * DateUtils.WEEK_IN_MILLIS;
       case "week":
-        return value * DateUtils.WEEK_IN_MILLIS;
+        return count * DateUtils.WEEK_IN_MILLIS;
       case "day":
-        return value * DateUtils.DAY_IN_MILLIS;
+        return count * DateUtils.DAY_IN_MILLIS;
       case "hour":
-        return value * DateUtils.HOUR_IN_MILLIS;
+        return count * DateUtils.HOUR_IN_MILLIS;
       case "minute":
-        return value * DateUtils.MINUTE_IN_MILLIS;
+        return count * DateUtils.MINUTE_IN_MILLIS;
       case "second":
-        return value * DateUtils.SECOND_IN_MILLIS;
+        return count * DateUtils.SECOND_IN_MILLIS;
       default:
         return null;
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationSchedule.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationSchedule.java
@@ -16,6 +16,7 @@ public class LocalNotificationSchedule {
   private Date at;
   private Boolean repeats;
   private String every;
+  private Integer count;
 
   private DateMatch on;
 
@@ -25,6 +26,8 @@ public class LocalNotificationSchedule {
     if (schedule != null) {
       // Every specific unit of time (always constant)
       buildEveryElement(schedule);
+      // Count of units of time from every to repeat on
+      buildCountElement(schedule);
       // At specific moment of time (with repeating option)
       buildAtElement(schedule);
       // Build on - recurring times. For e.g. every 1st day of the month at 8:30.
@@ -38,6 +41,10 @@ public class LocalNotificationSchedule {
   private void buildEveryElement(JSObject schedule) {
     // 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
     this.every = schedule.getString("every");
+  }
+
+  private void buildCountElement(JSObject schedule) {
+    this.count = schedule.getInteger("count");
   }
 
   private void buildAtElement(JSObject schedule) throws ParseException {
@@ -94,6 +101,14 @@ public class LocalNotificationSchedule {
     this.every = every;
   }
 
+  public int getCount() {
+    return count;
+  }
+
+  public void setCount(int count) {
+    this.count = count;
+  }
+
   public boolean isRepeating() {
     return Boolean.TRUE.equals(this.repeats);
   }
@@ -113,24 +128,28 @@ public class LocalNotificationSchedule {
    * Get constant long value representing specific interval of time (weeks, days etc.)
    */
   public Long getEveryInterval() {
+    Integer value = count;
+    if (value == null) {
+      value = 1;
+    }
     switch (every) {
       case "year":
-        return DateUtils.YEAR_IN_MILLIS;
+        return value * DateUtils.YEAR_IN_MILLIS;
       case "month":
         // This case is just approximation as months have different number of days
-        return 30 * DateUtils.DAY_IN_MILLIS;
+        return value * 30 * DateUtils.DAY_IN_MILLIS;
       case "two-weeks":
-        return 2 * DateUtils.WEEK_IN_MILLIS;
+        return value * 2 * DateUtils.WEEK_IN_MILLIS;
       case "week":
-        return DateUtils.WEEK_IN_MILLIS;
+        return value * DateUtils.WEEK_IN_MILLIS;
       case "day":
-        return DateUtils.DAY_IN_MILLIS;
+        return value * DateUtils.DAY_IN_MILLIS;
       case "hour":
-        return DateUtils.HOUR_IN_MILLIS;
+        return value * DateUtils.HOUR_IN_MILLIS;
       case "minute":
-        return DateUtils.MINUTE_IN_MILLIS;
+        return value * DateUtils.MINUTE_IN_MILLIS;
       case "second":
-        return DateUtils.SECOND_IN_MILLIS;
+        return value * DateUtils.SECOND_IN_MILLIS;
       default:
         return null;
     }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1032,6 +1032,7 @@ export interface LocalNotificationSchedule {
   at?: Date;
   repeats?: boolean;
   every?: 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
+  count?: number;
   on?: {
     year?: number;
     month?: number;

--- a/example/src/pages/local-notifications/local-notifications.html
+++ b/example/src/pages/local-notifications/local-notifications.html
@@ -32,6 +32,9 @@
   <button (click)="scheduleRepeatingEvery()" ion-button>
     Schedule every minute
   </button>
+  <button (click)="scheduleRepeatingEveryWithValue(2)" ion-button>
+    Schedule every 2 minutes
+  </button>
   <br/><br/>
   <button (click)="scheduleRepeatingOn()" ion-button>
     Schedule when clock matches next minute 

--- a/example/src/pages/local-notifications/local-notifications.ts
+++ b/example/src/pages/local-notifications/local-notifications.ts
@@ -161,7 +161,6 @@ export class LocalNotificationsPage {
   }
 
   async scheduleRepeatingEveryWithValue(value: number) {
-    var now = new Date();
     this.notifs = await Plugins.LocalNotifications.schedule({
       notifications: [{
         title: 'Happy Holidays! Last couple minutes.',
@@ -169,7 +168,7 @@ export class LocalNotificationsPage {
         id: 4,
         schedule: {
           every: 'minute',
-          count: 2
+          count: value
         }
       }]
     });

--- a/example/src/pages/local-notifications/local-notifications.ts
+++ b/example/src/pages/local-notifications/local-notifications.ts
@@ -160,6 +160,21 @@ export class LocalNotificationsPage {
     });
   }
 
+  async scheduleRepeatingEveryWithValue(value: number) {
+    var now = new Date();
+    this.notifs = await Plugins.LocalNotifications.schedule({
+      notifications: [{
+        title: 'Happy Holidays! Last couple minutes.',
+        body: 'Swipe to learn more',
+        id: 4,
+        schedule: {
+          every: 'minute',
+          count: 2
+        }
+      }]
+    });
+  }
+
   cancelNotification() {
     this.pendingNotifs && Plugins.LocalNotifications.cancel(this.pendingNotifs);
   }

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -194,7 +194,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
   func handleScheduledNotification(_ call: CAPPluginCall, _ schedule: [String:Any]) throws -> UNNotificationTrigger? {
     let at = schedule["at"] as? Date
     let every = schedule["every"] as? String
-    let count = schedule["count"] as? Int
+    let count = schedule["count"] as? Int ?? 1
     let on = schedule["on"] as? [String:Int]
     let repeats = schedule["repeats"] as? Bool ?? false
 
@@ -207,7 +207,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
         return nil
       }
     
-      var dateInterval = DateInterval(start: Date(), end: dateInfo.date!)
+      let dateInterval = DateInterval(start: Date(), end: dateInfo.date!)
       
       // Notifications that repeat have to be at least a minute between each other
       if repeats && dateInterval.duration < 60 {
@@ -268,34 +268,33 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
    * interval and today. For example, if every is "month", then we
    * return the interval between today and a month from today.
    */
-  func getRepeatDateInterval(_ every: String, _ count: Int?) -> DateInterval? {
-    let value = count ?? 1
+  func getRepeatDateInterval(_ every: String, _ count: Int) -> DateInterval? {
     let cal = Calendar.current
     let now = Date()
     switch every {
     case "year":
-      let newDate = cal.date(byAdding: .year, value: value, to: now)!
+      let newDate = cal.date(byAdding: .year, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "month":
-      let newDate = cal.date(byAdding: .month, value: value, to: now)!
+      let newDate = cal.date(byAdding: .month, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "two-weeks":
-      let newDate = cal.date(byAdding: .weekOfYear, value: 2 * value, to: now)!
+      let newDate = cal.date(byAdding: .weekOfYear, value: 2 * count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "week":
-      let newDate = cal.date(byAdding: .weekOfYear, value: value, to: now)!
+      let newDate = cal.date(byAdding: .weekOfYear, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "day":
-      let newDate = cal.date(byAdding: .day, value: value, to: now)!
+      let newDate = cal.date(byAdding: .day, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "hour":
-      let newDate = cal.date(byAdding: .hour, value: value, to: now)!
+      let newDate = cal.date(byAdding: .hour, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "minute":
-      let newDate = cal.date(byAdding: .minute, value: value, to: now)!
+      let newDate = cal.date(byAdding: .minute, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     case "second":
-      let newDate = cal.date(byAdding: .second, value: value, to: now)!
+      let newDate = cal.date(byAdding: .second, value: count, to: now)!
       return DateInterval(start: now, end: newDate)
     default:
       return nil

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -194,6 +194,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
   func handleScheduledNotification(_ call: CAPPluginCall, _ schedule: [String:Any]) throws -> UNNotificationTrigger? {
     let at = schedule["at"] as? Date
     let every = schedule["every"] as? String
+    let count = schedule["count"] as? Int
     let on = schedule["on"] as? [String:Int]
     let repeats = schedule["repeats"] as? Bool ?? false
 
@@ -216,7 +217,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       return UNTimeIntervalNotificationTrigger(timeInterval: dateInterval.duration, repeats: repeats)
     }
     
-    // If this notification should repeat every day/month/week/etc. or on a certain
+    // If this notification should repeat every count of day/month/week/etc. or on a certain
     // matching set of date components
     if on != nil {
       let dateComponents = getDateComponents(on!)
@@ -224,7 +225,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     }
     
     if every != nil {
-      if let repeatDateInterval = getRepeatDateInterval(every!) {
+      if let repeatDateInterval = getRepeatDateInterval(every!, count) {
         return UNTimeIntervalNotificationTrigger(timeInterval: repeatDateInterval.duration, repeats: true)
       }
     }
@@ -267,33 +268,34 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
    * interval and today. For example, if every is "month", then we
    * return the interval between today and a month from today.
    */
-  func getRepeatDateInterval(_ every: String) -> DateInterval? {
+  func getRepeatDateInterval(_ every: String, _ count: Int?) -> DateInterval? {
+    let value = count ?? 1
     let cal = Calendar.current
     let now = Date()
     switch every {
     case "year":
-      let newDate = cal.date(byAdding: .year, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .year, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "month":
-      let newDate = cal.date(byAdding: .month, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .month, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "two-weeks":
-      let newDate = cal.date(byAdding: .weekOfYear, value: 2, to: now)!
+      let newDate = cal.date(byAdding: .weekOfYear, value: 2 * value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "week":
-      let newDate = cal.date(byAdding: .weekOfYear, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .weekOfYear, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "day":
-      let newDate = cal.date(byAdding: .day, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .day, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "hour":
-      let newDate = cal.date(byAdding: .hour, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .hour, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "minute":
-      let newDate = cal.date(byAdding: .minute, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .minute, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     case "second":
-      let newDate = cal.date(byAdding: .second, value: 1, to: now)!
+      let newDate = cal.date(byAdding: .second, value: value, to: now)!
       return DateInterval(start: now, end: newDate)
     default:
       return nil


### PR DESCRIPTION
The notification schedule already has support for repeating on a period of time, via the `every` option. However, it only allows the user to specify one of the options in the enum, with no support for repeating at multiples of the unit of time. This adds a `count` option to LocalNotificationSchedule (inspired by the structure of the notification trigger in https://github.com/katzer/cordova-plugin-local-notifications), which works in concert with the `every` option to set repeating notifications on multiples of the units of time. If no `count` is provided, it defaults to one, so this change should be backwards compatible. Implemented support for iOS and Android, but the web plugin didn't have support for `every`, so I didn't add any support for `count` there.

I'm open to suggestions on the exact structure. I prioritized a structure that would not break any code for people who have already implemented reminders with the `every` option.

- [x] Add `count` to type definition of LocalNotificationSchedule
- [x] Support `count` on iOS
- [x] Support `count` on Android
- [x] Add button to example app for testing `count`
- [ ] Add documentation for `count` option