### PR TITLE
feat: make possible to configure userAgent

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -376,6 +376,17 @@ public class Bridge {
     if (Config.getBoolean("android.allowMixedContent", false)) {
       settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
     }
+
+    String appendUserAgent = Config.getString("android.appendUserAgent" , Config.getString("appendUserAgent", null));
+    if (appendUserAgent != null) {
+      String defaultUserAgent = settings.getUserAgentString();
+      settings.setUserAgentString(defaultUserAgent + " " + appendUserAgent);
+    }
+    String overrideUserAgent = Config.getString("android.overrideUserAgent" , Config.getString("overrideUserAgent", null));
+    if (overrideUserAgent != null) {
+      settings.setUserAgentString(overrideUserAgent);
+    }
+
     String backgroundColor = Config.getString("android.backgroundColor" , Config.getString("backgroundColor", null));
     try {
       if (backgroundColor != null) {

--- a/electron-template/index.js
+++ b/electron-template/index.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, Menu } = require('electron');
 const isDevMode = require('electron-is-dev');
-const { CapacitorSplashScreen } = require('@capacitor/electron');
+const { CapacitorSplashScreen, configCapacitor } = require('@capacitor/electron');
 
 const path = require('path');
 
@@ -39,6 +39,8 @@ async function createWindow () {
       preload: path.join(__dirname, 'node_modules', '@capacitor', 'electron', 'dist', 'electron-bridge.js')
     }
   });
+
+  configCapacitor(mainWindow);
 
   if (isDevMode) {
     // Set our above template to the Menu Object if we are in development mode, dont want users having the devtools.

--- a/electron/index.js
+++ b/electron/index.js
@@ -26,6 +26,18 @@ const injectCapacitor = async function(url) {
   }
 };
 
+const configCapacitor = async function(mainWindow) {
+  let capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
+  const appendUserAgent = capConfigJson.electron && capConfigJson.electron.appendUserAgent ? capConfigJson.electron.appendUserAgent : capConfigJson.appendUserAgent;
+  if (appendUserAgent) {
+    mainWindow.webContents.setUserAgent(mainWindow.webContents.getUserAgent() + " " + appendUserAgent);
+  }
+  const overrideUserAgent = capConfigJson.electron && capConfigJson.electron.overrideUserAgent ? capConfigJson.electron.overrideUserAgent : capConfigJson.overrideUserAgent;
+  if (overrideUserAgent) {
+    mainWindow.webContents.setUserAgent(overrideUserAgent);
+  }
+}
+
 class CapacitorSplashScreen {
 
   /**
@@ -153,5 +165,6 @@ class CapacitorSplashScreen {
 
 module.exports = {
   injectCapacitor,
+  configCapacitor,
   CapacitorSplashScreen
 };

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -65,7 +65,11 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     webViewConfiguration.userContentController = o
     
     configureWebView(configuration: webViewConfiguration)
-    
+
+    if let appendUserAgent = (capConfig.getValue("ios.appendUserAgent") as? String) ?? (capConfig.getValue("appendUserAgent") as? String) {
+      webViewConfiguration.applicationNameForUserAgent = appendUserAgent
+    }
+
     webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
     webView?.scrollView.bounces = false
     
@@ -83,6 +87,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     if let backgroundColor = (bridge!.config.getValue("ios.backgroundColor") as? String) ?? (bridge!.config.getValue("backgroundColor") as? String) {
       webView?.backgroundColor = UIColor(fromHex: backgroundColor)
       webView?.scrollView.backgroundColor = UIColor(fromHex: backgroundColor)
+    }
+    if let overrideUserAgent = (bridge!.config.getValue("ios.overrideUserAgent") as? String) ?? (bridge!.config.getValue("overrideUserAgent") as? String) {
+      webView?.customUserAgent = overrideUserAgent
     }
   }
 

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -75,9 +75,18 @@ The current ones you might configure are:
       "192.0.2.1"
     ]
   },
+  // User agent of Capacitor WebView for iOS, Android and Electron, unless also declared inside ios, android or electron objects
+  "overrideUserAgent": "my custom user agent",
+  // String to append to the original user agent of Capacitor WebView for iOS, Android and Electron,
+  // unless also declared inside ios, android or electron objects. Only if overrideUserAgent is not set.
+  "appendUserAgent": "string to append",
   // Background color of Capacitor WebView for both iOS and Android unless also declared inside ios or android objects
   "backgroundColor": "#ffffffff",
   "android": {
+    // User agent of Capacitor WebView for Android
+    "overrideUserAgent": "my custom user agent for Android",
+    // String to append to the original user agent of Capacitor WebView for Android.
+    "appendUserAgent": "string to append for Android",
     // Background color of Capacitor WebView for Android only
     "backgroundColor": "#ffffffff",
     // On Android, if you are loading the app from a remote/testing server from https
@@ -95,6 +104,10 @@ The current ones you might configure are:
     "webContentsDebuggingEnabled": true
   },
   "ios": {
+    // User agent of Capacitor WebView for iOS
+    "overrideUserAgent": "my custom user agent for iOS",
+    // String to append to the original user agent of Capacitor WebView for iOS.
+    "appendUserAgent": "string to append for iOS",
     // Background color of Capacitor WebView for iOS only
     "backgroundColor": "#ffffffff",
     // Configure the Swift version to be used for Cordova plugins.
@@ -105,6 +118,12 @@ The current ones you might configure are:
     "minVersion": "11.3",
     // Some Cordova plugins require to configure the linker flags
     "cordovaLinkerFlags": ["-ObjC"]
+  },
+  "electron": {
+    // User agent of Capacitor WebView for Electron
+    "overrideUserAgent": "my custom user agent for Electron",
+    // String to append to the original user agent of Capacitor WebView for Electron.
+    "appendUserAgent": "string to append for Electron",
   }
 }
 ```


### PR DESCRIPTION
Makes possible to configure the userAgent for iOS, Android and Electron from values stored in `capacitor.config.json` file. Can be appended to the original userAgent or totally replaced.

For existing electron apps will require manual changes on the user template.

Closes #2088