### PR TITLE
fix(android): properly proxy requests to domains in allowNavigation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -886,4 +886,8 @@ public class Bridge {
   public WebViewLocalServer getLocalServer() {
     return localServer;
   }
+
+  public HostMask getAppAllowNavigationMask() {
+    return appAllowNavigationMask;
+  }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -172,7 +172,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(loadingUrl) || Config.getString("server.url") == null) {
+    if (isLocalFile(loadingUrl) || (Config.getString("server.url") == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
       Log.d(LogUtils.getCoreTag(), "Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {


### PR DESCRIPTION
When there are urls in allowNavigation object, requests to those domains are being treated as local request instead of being proxied. This PR solves that.

Closes #2132 