### PR TITLE
fix(android): Send cookies on proxied requests

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -18,6 +18,7 @@ package com.getcapacitor;
 import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
+import android.webkit.CookieManager;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 
@@ -297,6 +298,7 @@ public class WebViewLocalServer {
         for (Map.Entry<String, String> header : headers.entrySet()) {
           conn.setRequestProperty(header.getKey(), header.getValue());
         }
+        conn.setRequestProperty("Cookie", CookieManager.getInstance().getCookie(request.getUrl().toString()));
         conn.setRequestMethod(method);
         conn.setReadTimeout(30 * 1000);
         conn.setConnectTimeout(30 * 1000);


### PR DESCRIPTION
This sends cookies along with requests to proxied urls, brings the behaviour in line with what happens on iOS.

This is important for us as we change the html being served to the app based on the cookies.