### PR TITLE
fix(ios): set camera configuration in main thread

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -128,25 +128,26 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
 
     AVCaptureDevice.requestAccess(for: .video) { granted in
         if granted {
-          let presentationStyle = call.getString("presentationStyle")
-          if presentationStyle != nil && presentationStyle == "popover" {
-            self.configurePicker()
-          } else {
-            self.imagePicker!.modalPresentationStyle = .fullScreen
-          }
-
-          self.imagePicker!.sourceType = .camera
-
-          if self.settings.direction.rawValue == "REAR" {
-            if UIImagePickerController.isCameraDeviceAvailable(.rear) {
-              self.imagePicker!.cameraDevice = .rear
-            }
-          } else if self.settings.direction.rawValue == "FRONT" {
-            if UIImagePickerController.isCameraDeviceAvailable(.front) {
-              self.imagePicker!.cameraDevice = .front
-            }
-          }
           DispatchQueue.main.async {
+            let presentationStyle = call.getString("presentationStyle")
+            if presentationStyle != nil && presentationStyle == "popover" {
+              self.configurePicker()
+            } else {
+              self.imagePicker!.modalPresentationStyle = .fullScreen
+            }
+
+            self.imagePicker!.sourceType = .camera
+
+            if self.settings.direction.rawValue == "REAR" {
+              if UIImagePickerController.isCameraDeviceAvailable(.rear) {
+                self.imagePicker!.cameraDevice = .rear
+              }
+            } else if self.settings.direction.rawValue == "FRONT" {
+              if UIImagePickerController.isCameraDeviceAvailable(.front) {
+                self.imagePicker!.cameraDevice = .front
+              }
+            }
+
             self.bridge.viewController.present(self.imagePicker!, animated: true, completion: nil)
           }
         } else {


### PR DESCRIPTION
On iOS 13 the camera is taking a few seconds to appear because of some configurations being done in a background thread, which shows 3 background thread warnings on Xcode and delay the code execution.

This PR moves all the camera configuration code to be executed in main thread.