### PR TITLE
fix(core/web): make LocalNotifications.requestPermissions() work on Safari

### DIFF
--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -98,7 +98,7 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
 
   requestPermissions(): Promise<PermissionsRequestResult> {
     return new Promise((resolve, reject) => {
-      Notification.requestPermission().then((result) => {
+      Notification.requestPermission((result) => {
         if (result === 'denied' || result === 'default') {
           reject(result);
           return;

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -106,8 +106,6 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
         resolve({
           results: [ result ]
         });
-      }).catch((e) => {
-        reject(e);
       });
     });
   }


### PR DESCRIPTION
Request Permission for Local Notification on safari for mac OSX returning this error.
"undefined is not an object (evaluating 'Notification.requestPermission().then')"

Change From: 
Notification.requestPermission().then((result) => {})
To:
Notification.requestPermission((result) => {})