### PR TITLE
fix(android): avoid crash on SplashScreen.show()

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -233,7 +233,11 @@ public class Splash {
         // Required to enable the view to actually fade
         params.format = PixelFormat.TRANSLUCENT;
 
-        wm.addView(splashImage, params);
+        try {
+          wm.addView(splashImage, params);
+        } catch (IllegalStateException ex) {
+          Log.d(LogUtils.getCoreTag(), "Could not add splash view");
+        }
 
         splashImage.setAlpha(0f);
 


### PR DESCRIPTION
In some cases `wm.addView(splashImage, params);` causes `IllegalStateException` (like calling show twice at once) anda makes the app to crash.
This PR prevents those crashes. 