### PR TITLE
docs(ios-plugin-guide): Change getBoolean to getBool

### DIFF
--- a/site/docs-md/plugins/ios.md
+++ b/site/docs-md/plugins/ios.md
@@ -62,7 +62,7 @@ For example, here is how you'd get data passed to your method:
 @objc func storeContact(_ call: CAPPluginCall) {
   let name = call.getString("yourName") ?? "default name"
   let address = call.getObject("address") ?? [:]
-  let isAwesome = call.getBoolean("isAwesome") ?? false
+  let isAwesome = call.getBool("isAwesome") ?? false
 
   guard let id = call.options["id"] as? String else {
     call.reject("Must provide an id")


### PR DESCRIPTION
The source code for `CAPPluginCall` show that the proper method name is `getBool` rather than `getBoolean`.