### PR TITLE
feat(cli): Add --deployment option for update and sync commands

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -52,16 +52,18 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
 
   program
     .command('sync [platform]')
-    .description('updates + copy')
-    .action(platform => {
-      return syncCommand(config, platform);
+    .description('copy + update')
+    .option('--deployment', 'Optional: if provided, Podfile.lock won\'t be deleted and pod install will use --deployment option')
+    .action((platform, { deployment }) => {
+      return syncCommand(config, platform, deployment);
     });
 
   program
     .command('update [platform]')
     .description(`updates the native plugins and dependencies based in package.json`)
-    .action(platform => {
-      return updateCommand(config, platform);
+    .option('--deployment', 'Optional: if provided, Podfile.lock won\'t be deleted and pod install will use --deployment option')
+    .action((platform, { deployment }) => {
+      return updateCommand(config, platform, deployment);
     });
 
   program

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -41,7 +41,7 @@ export async function addCommand(config: Config, selectedPlatformName: string) {
     await editPlatforms(config, platformName);
 
     if (shouldSync(config, platformName)) {
-      await sync(config, platformName);
+      await sync(config, platformName, false);
     }
 
     if (platformName === config.ios.name || platformName === config.android.name) {

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -8,7 +8,7 @@ import { allSerial } from '../util/promise';
 /**
  * Sync is a copy and an update in one.
  */
-export async function syncCommand(config: Config, selectedPlatform: string) {
+export async function syncCommand(config: Config, selectedPlatform: string, deployment: boolean) {
   const then = +new Date;
   const platforms = config.selectPlatforms(selectedPlatform);
   if (platforms.length === 0) {
@@ -17,7 +17,7 @@ export async function syncCommand(config: Config, selectedPlatform: string) {
   }
   try {
     await check(config, [checkPackage, checkWebDir, ...updateChecks(config, platforms)]);
-    await allSerial(platforms.map(platformName => () => sync(config, platformName)));
+    await allSerial(platforms.map(platformName => () => sync(config, platformName, deployment)));
     const now = +new Date;
     const diff = (now - then) / 1000;
     log(`Sync finished in ${diff}s`);
@@ -26,11 +26,11 @@ export async function syncCommand(config: Config, selectedPlatform: string) {
   }
 }
 
-export async function sync(config: Config, platformName: string) {
+export async function sync(config: Config, platformName: string, deployment: boolean) {
   try {
     await copy(config, platformName);
   } catch (e) {
     logError(e);
   }
-  await update(config, platformName);
+  await update(config, platformName, deployment);
 }

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -6,7 +6,7 @@ import { CheckFunction, check, checkPackage, log, logError, logFatal, logInfo, r
 
 import chalk from 'chalk';
 
-export async function updateCommand(config: Config, selectedPlatformName: string) {
+export async function updateCommand(config: Config, selectedPlatformName: string, deployment: boolean) {
   const then = +new Date;
   const platforms = config.selectPlatforms(selectedPlatformName);
   if (platforms.length === 0) {
@@ -19,7 +19,7 @@ export async function updateCommand(config: Config, selectedPlatformName: string
       [checkPackage, ...updateChecks(config, platforms)]
     );
 
-    await allSerial(platforms.map(platformName => async () => await update(config, platformName)));
+    await allSerial(platforms.map(platformName => async () => await update(config, platformName, deployment)));
     const now = +new Date;
     const diff = (now - then) / 1000;
     log(`Update finished in ${diff}s`);
@@ -46,11 +46,11 @@ export function updateChecks(config: Config, platforms: string[]): CheckFunction
   return checks;
 }
 
-export async function update(config: Config, platformName: string) {
+export async function update(config: Config, platformName: string, deployment: boolean) {
   try {
     await runTask(chalk`{green {bold update}} {bold ${platformName}}`, async () => {
       if (platformName === config.ios.name) {
-        await updateIOS(config);
+        await updateIOS(config, deployment);
       } else if (platformName === config.android.name) {
         await updateAndroid(config);
       }

--- a/cli/test/update.android.spec.ts
+++ b/cli/test/update.android.spec.ts
@@ -15,7 +15,7 @@ describe.each([false, true])('Update: Android (monoRepoLike: %p)', (monoRepoLike
     await run(appDir, `init "${APP_NAME}" "${APP_ID}" --npm-client npm`);
     await run(appDir, `add android`);
     // Redundant, because add does this, but called explicitly for thoroughness
-    await updateCommand(makeConfig(appDir), 'android');
+    await updateCommand(makeConfig(appDir), 'android', false);
     FS = new MappedFS(appDir);
   });
 

--- a/cli/test/update.ios.spec.ts
+++ b/cli/test/update.ios.spec.ts
@@ -15,7 +15,7 @@ describe.each([false, true])('Update: iOS (monoRepoLike: %p)', (monoRepoLike) =>
     await run(appDir, `init "${APP_NAME}" "${APP_ID}" --npm-client npm`);
     await run(appDir, `add ios`);
     // Redundant, because add does this, but called explicitly for thoroughness
-    await updateCommand(makeConfig(appDir), 'ios');
+    await updateCommand(makeConfig(appDir), 'ios', false);
     FS = new MappedFS(appDir);
   });
 


### PR DESCRIPTION
 Add --deployment option for update and sync commands that doesn't remove the Podfile.lock file and also pass --deployment option to the pod install command

Closes #2200