### PR TITLE
fix(android): proper parsing of plugin integers and doubles

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -168,10 +168,10 @@ public class PluginCall {
       return (Float) value;
     }
     if(value instanceof Double) {
-      return new Float((Double) value);
+      return ((Double) value).floatValue();
     }
     if(value instanceof Integer) {
-      return new Float((Integer) value);
+      return ((Integer) value).floatValue();
     }
     return defaultValue;
   }
@@ -185,6 +185,12 @@ public class PluginCall {
 
     if(value instanceof Double) {
       return (Double) value;
+    }
+    if(value instanceof Float) {
+      return ((Float) value).doubleValue();
+    }
+    if(value instanceof Integer) {
+      return ((Integer) value).doubleValue();
     }
     return defaultValue;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -167,6 +167,12 @@ public class PluginCall {
     if(value instanceof Float) {
       return (Float) value;
     }
+    if(value instanceof Double) {
+      return new Float((Double) value);
+    }
+    if(value instanceof Integer) {
+      return new Float((Integer) value);
+    }
     return defaultValue;
   }
 
@@ -274,4 +280,3 @@ public class PluginCall {
     PluginCallDataTypeException(String m) { super(m); }
   }
 }
-


### PR DESCRIPTION
When passing in a value via JavaScript to Capacitor like this:
`({volume:0.0})`
then Capacitor in Android is parsing this to an *Integer* instead and *getFloat()* will fail since it is expecting a *Float* type.

The same happens when doing this:
`({volume:0.1})`
then Capacitor in Android is parsing this to a *Double* instead.

So I added explicit casting for these 2 use cases.