### PR TITLE
Fix browserFinished not fired on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
@@ -31,6 +31,7 @@ public class Browser extends Plugin {
 
   private CustomTabsClient customTabsClient;
   private CustomTabsSession currentSession;
+  private boolean appIsPaused = false;
 
   @PluginMethod()
   public void open(PluginCall call) {
@@ -117,6 +118,7 @@ public class Browser extends Plugin {
   }
 
   protected void handleOnResume() {
+    appIsPaused = false;
     boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
     if (!ok) {
       Log.e(getLogTag(), "Error binding to custom tabs service");
@@ -124,6 +126,7 @@ public class Browser extends Plugin {
   }
 
   protected void handleOnPause() {
+    appIsPaused = true;
     getContext().unbindService(connection);
   }
 
@@ -139,6 +142,11 @@ public class Browser extends Plugin {
           switch (navigationEvent) {
             case NAVIGATION_FINISHED:
               notifyListeners("browserPageLoaded", new JSObject());
+              break;
+            case TAB_HIDDEN:
+              if (!appIsPaused) {
+                notifyListeners("browserFinished", new JSObject());
+              }
               break;
           }
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
@@ -31,7 +31,6 @@ public class Browser extends Plugin {
 
   private CustomTabsClient customTabsClient;
   private CustomTabsSession currentSession;
-  private boolean appIsPaused = false;
 
   @PluginMethod()
   public void open(PluginCall call) {
@@ -118,7 +117,6 @@ public class Browser extends Plugin {
   }
 
   protected void handleOnResume() {
-    appIsPaused = false;
     boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
     if (!ok) {
       Log.e(getLogTag(), "Error binding to custom tabs service");
@@ -126,7 +124,6 @@ public class Browser extends Plugin {
   }
 
   protected void handleOnPause() {
-    appIsPaused = true;
     getContext().unbindService(connection);
   }
 
@@ -144,9 +141,7 @@ public class Browser extends Plugin {
               notifyListeners("browserPageLoaded", new JSObject());
               break;
             case TAB_HIDDEN:
-              if (!appIsPaused) {
                 notifyListeners("browserFinished", new JSObject());
-              }
               break;
           }
         }


### PR DESCRIPTION
This adds the missing `browserFinished` event not being fired on the Android version of the Browser plugin.

This also uses a flag to ensure that the event isn't fired when the browser is open, but the user backgrounds the entire app.

Resolves #2202 