### PR TITLE
Adds the ability to see whether the Push Notifications permission was allowed/declined

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1469,6 +1469,8 @@ export interface PushNotificationsPlugin extends Plugin {
   addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: PushNotificationActionPerformed) => void): PluginListenerHandle;
+  addListener(eventName: 'permissionAllowed', listenerFunc: () => void): PluginListenerHandle;
+  addListener(eventName: 'permissionDeclined', listenerFunc: () => void): PluginListenerHandle;
 }
 
 //

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -22,6 +22,8 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
    * Request permissions to send notifications
    */
   public func requestPermissions() {
+    let plugin: CAPPlugin = (self.bridge?.getOrLoadPlugin(pluginName: "PushNotifications"))!
+
     // Override point for customization after application launch.
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options:[.badge, .alert, .sound]) { (granted, error) in

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -25,7 +25,11 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
     // Override point for customization after application launch.
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options:[.badge, .alert, .sound]) { (granted, error) in
-      // Enable or disable features based on authorization.
+      if granted {
+        plugin.notifyListeners("permissionAllowed", data: nil)
+      } else {
+        plugin.notifyListeners("permissionDeclined", data: nil)
+      }
     }
 
     DispatchQueue.main.async {


### PR DESCRIPTION
This pr adds the ability to see whether the Push Notifications permission was allowed/declined. Basically this adds an event at the `requestAuthorization()`. This event is *only* fired on iOS since Android allows notifications by default.

This could be useful to determine whether or not the device has notifications enabled, so we don't send notifications to the APNS-token / FCM-token.

Closes #2247 

<img src="https://support.helpshift.com/wp-content/uploads/2017/03/my_app_push_notifications.png" width="300">