### PR TITLE
fix(android): implement getDeliveredNotifications and removeDeliveredNotifications

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -119,7 +119,14 @@ public class PushNotifications extends Plugin {
         if (notification != null) {
           jsNotif.put("title", notification.extras.getCharSequence(Notification.EXTRA_TITLE));
           jsNotif.put("body", notification.extras.getCharSequence(Notification.EXTRA_TEXT));
-          jsNotif.put("extra", JSONObject.wrap(notification.extras));
+
+          JSObject extras = new JSObject();
+
+          for (String key : notification.extras.keySet()) {
+            extras.put(key, notification.extras.get(key));
+          }
+
+          jsNotif.put("extra", extras);
         }
 
         notifications.put(jsNotif);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -126,7 +126,7 @@ public class PushNotifications extends Plugin {
             extras.put(key, notification.extras.get(key));
           }
 
-          jsNotif.put("extra", extras);
+          jsNotif.put("data", extras);
         }
 
         notifications.put(jsNotif);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -1,10 +1,13 @@
 package com.getcapacitor.plugin;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
+import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
 import android.net.Uri;
 
@@ -25,6 +28,10 @@ import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,12 +106,55 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void getDeliveredNotifications(PluginCall call) {
-    call.unimplemented();
+    JSArray notifications = new JSArray();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      StatusBarNotification[] activeNotifications = notificationManager.getActiveNotifications();
+
+      for (StatusBarNotification notif : activeNotifications) {
+        JSObject jsNotif = new JSObject();
+
+        jsNotif.put("id", notif.getId());
+
+        Notification notification = notif.getNotification();
+        if (notification != null) {
+          jsNotif.put("title", notification.extras.getCharSequence(Notification.EXTRA_TITLE));
+          jsNotif.put("body", notification.extras.getCharSequence(Notification.EXTRA_TEXT));
+          jsNotif.put("extra", JSONObject.wrap(notification.extras));
+        }
+
+        notifications.put(jsNotif);
+      }
+    }
+
+    JSObject result = new JSObject();
+    result.put("notifications", notifications);
+    call.resolve(result);
   }
 
   @PluginMethod()
   public void removeDeliveredNotifications(PluginCall call) {
-    call.unimplemented();
+    JSArray notifications = call.getArray("notifications");
+
+    List<Integer> ids = new ArrayList<>();
+    try {
+      for (Object o : notifications.toList()) {
+        if (o instanceof JSONObject) {
+          JSObject notif = JSObject.fromJSONObject((JSONObject) o);
+          Integer id = notif.getInteger("id");
+          ids.add(id);
+        } else {
+          call.reject("Expected notifications to be a list of notification objects");
+        }
+      }
+    } catch (JSONException e) {
+      call.reject(e.getMessage());
+    }
+
+    for (int id : ids) {
+      notificationManager.cancel(id);
+    }
+
+    call.resolve();
   }
 
   @PluginMethod()


### PR DESCRIPTION
This PR implements the `PushNotifications` plugin `getDeliveredNotifications` and `removeDeliveredNotifications` methods.

The fields available on the objects returned by `getDeliveredNotifications` are a subset of those available on iOS, but otherwise the behaviour should be the same.