### PR TITLE
fix(cli): use proper kebab-case name for npm package

### DIFF
--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -30,7 +30,7 @@ export async function newPlugin(config: Config) {
     {
       type: 'input',
       name: 'name',
-      message: 'Plugin NPM name (snake-case):',
+      message: 'Plugin NPM name (kebab-case):',
       validate: function(input) {
         if (!input || input.trim() === '') {
           return false;

--- a/site/docs-md/plugins/index.md
+++ b/site/docs-md/plugins/index.md
@@ -34,7 +34,7 @@ This starts a wizard prompting you for information about your new plugin. For ex
 ```bash
 npx @capacitor/cli plugin:generate
 ✏️  Creating new Capacitor plugin
-? Plugin NPM name (snake-case): my-plugin
+? Plugin NPM name (kebab-case): my-plugin
 ? Plugin id (domain-style syntax. ex: com.example.plugin) com.ionicframework.myplugin
 ? Plugin class name (ex: AwesomePlugin) MyPlugin
 ? description:
@@ -44,7 +44,7 @@ npx @capacitor/cli plugin:generate
 ? package.json will be created, do you want to continue? (Y/n)
 ```
 
- - `Plugin NPM name`: a snake-case name of a package that will be available on npm (not a strict requirement if your package will be on a private npm repo).
+ - `Plugin NPM name`: a kebab-case name of a package that will be available on npm (not a strict requirement if your package will be on a private npm repo).
  - `Plugin ID`: a domain-style identifier. It is primarily used for the package name in Java.
  - `Plugin Class Name`: the initial name of the class used in Java and Swift. See the additional note about class names in the [iOS Plugin](ios/) section of this guide.
  - `description`: a brief introduction about the plugin.


### PR DESCRIPTION
The recommended case of the plugin-name is actually
[kebab-case][wikipedia] not snake-case.

[wikipedia]: https://en.wikipedia.org/wiki/Letter_case#Special_case_styles