### PR TITLE
docs(usage): change example function definition

### DIFF
--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -52,7 +52,7 @@ import { Plugins, CameraResultType } from '@capacitor/core';
 
 const { Camera } = Plugins;
 
-async takePicture() {
+async function takePicture() {
   const image = await Camera.getPhoto({
     quality: 90,
     allowEditing: true,


### PR DESCRIPTION
As it is in the example session, it most probably should be a function, not a method of a class notation