### PR TITLE
fix(ios): fire appStateChange in incoming calls

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -176,7 +176,7 @@ enum BridgeError: Error {
       self.isActive = true
       appStatePlugin?.fireChange(isActive: self.isActive)
     }
-    NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: OperationQueue.main) { (notification) in
+    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { (notification) in
       CAPLog.print("APP INACTIVE")
       self.isActive = false
       appStatePlugin?.fireChange(isActive: self.isActive)


### PR DESCRIPTION
I changed the monitoring event because with the previous one it is not possible to intercept the action of entry on the task manager or the arrival of telephone calls, with this event instead it is possible to have the various events (for the purposes I have undertaken with the above plugin is essential to make this change).