### PR TITLE
feat(android): add splashFullScreen configuration option

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -33,6 +33,7 @@ public class Splash {
   public static final int DEFAULT_FADE_OUT_DURATION = 200;
   public static final int DEFAULT_SHOW_DURATION = 3000;
   public static final boolean DEFAULT_AUTO_HIDE = true;
+  public static final boolean DEFAULT_SPLASH_FULL_SCREEN = false;
 
   private static ImageView splashImage;
   private static ProgressBar spinnerBar;
@@ -52,7 +53,14 @@ public class Splash {
       }
 
       splashImage = new ImageView(c);
+      
+      // Hide status bar during splash screen.
+      Boolean splashFullScreen = Config.getBoolean(CONFIG_KEY_PREFIX + "splashFullScreen", DEFAULT_SPLASH_FULL_SCREEN);
+      if(splashFullScreen){
+        splashImage.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+      }
 
+      
       // Stops flickers dead in their tracks
       // https://stackoverflow.com/a/21847579/32140
       splashImage.setDrawingCacheEnabled(true);


### PR DESCRIPTION
For android, it is useful to hide the status bar right from the start. 
The user can add following setting:
    "SplashScreen": {
      "splashFullScreen": true
    }