### PR TITLE
Allow plugins to override navigation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -224,6 +224,19 @@ public class Bridge {
   }
 
   public boolean launchIntent(Uri url) {
+    /*
+    * Give plugins the chance to handle the url
+    */
+    for (Map.Entry<String, PluginHandle> entry : plugins.entrySet()) {
+      Plugin plugin = entry.getValue().getInstance();
+      if (plugin != null) {
+        Boolean result = plugin.shouldOpenExternalUrl(url);
+        if (result != null) {
+          return !result;
+        }
+      }
+    }
+
     if (!url.toString().contains(appUrl) && !appAllowNavigationMask.matches(url.getHost())) {
       try {
         Intent openIntent = new Intent(Intent.ACTION_VIEW, url);

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -547,6 +548,19 @@ public class Plugin {
    * Handle onDestroy
    */
   protected void handleOnDestroy() {}
+
+  /**
+   * Hook for blocking the launching of Intents by the Capacitor application.
+   *
+   * This will be called when the WebView will not navigate to a page, but
+   * could launch an intent to handle the URL. Return false to block this: if
+   * any plugin returns false, Capacitor will block the navigation. If all
+   * plugins return null, the default policy will be enforced. If at least one
+   * plugin returns true, and no plugins return false, then the URL will be
+   * opened in the WebView.
+   */
+  @SuppressWarnings("unused")
+  public Boolean shouldOpenExternalUrl(Uri url) { return null; }
 
   /**
    * Start a new Activity.

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -252,6 +252,24 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DecidePolicyForNavigationAction.name()), object: navigationAction)
     let navUrl = navigationAction.request.url!
+    
+    /*
+     * Give plugins the chance to handle the url
+     */
+    if let plugins = bridge?.plugins {
+      for pluginObject in plugins {
+        let plugin = pluginObject.value
+        let selector = NSSelectorFromString("shouldOverrideLoadWith:navigationType:")
+        if plugin.responds(to: selector) {
+          let shouldAllowRequest = plugin.shouldOverrideLoad(with: navigationAction.request, navigationType: navigationAction.navigationType)
+          if (shouldAllowRequest) {
+            decisionHandler(.allow)
+            return
+          }
+        }
+      }
+    }
+    
     if let allowNavigation = allowNavigationConfig, let requestHost = navUrl.host {
       for pattern in allowNavigation {
         if matchHost(host: requestHost, pattern: pattern.lowercased()) {
@@ -267,8 +285,6 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
       return
     }
 
-    // TODO: Allow plugins to handle this. See
-    // https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/608d64191405b233c01a939f5755f8b1fdd97f8c/src/ios/CDVWKWebViewEngine.m#L609
     decisionHandler(.allow)
   }
 

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -24,6 +24,7 @@
 - (void)addListener:(CAPPluginCall *)call;
 - (void)removeListener:(CAPPluginCall *)call;
 - (void)removeAllListeners:(CAPPluginCall *)call;
+- (BOOL)shouldOverrideLoadWith:(NSURLRequest *)request navigationType:(WKNavigationType)navigationType;
 
 // Called after init if the plugin wants to do
 // some loading so the plugin author doesn't


### PR DESCRIPTION
Allows plugins to override the webview navigation. This functionality was present in cordova so attempting to reimplement it for capacitor.