### PR TITLE
fix(ios): incorrect behavior of appendingPathComponent when framework is present

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -22,6 +22,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   private var hostname: String?
   private var allowNavigationConfig: [String]?
   private var basePath: String = ""
+  private let assetsFolder = "public"
   
   private var isStatusBarVisible = true
   private var statusBarStyle: UIStatusBarStyle = .default
@@ -94,8 +95,12 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   }
 
   private func getStartPath() -> String? {
-    let fullStartPath = URL(fileURLWithPath: "public").appendingPathComponent(startDir)
-    guard var startPath = Bundle.main.path(forResource: fullStartPath.relativePath, ofType: nil) else {
+    var resourcesPath = assetsFolder
+    if !startDir.isEmpty {
+      resourcesPath = URL(fileURLWithPath: resourcesPath).appendingPathComponent(startDir).relativePath
+    }
+
+    guard var startPath = Bundle.main.path(forResource: resourcesPath, ofType: nil) else {
       printLoadError()
       return nil
     }
@@ -145,7 +150,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   }
 
   func printLoadError() {
-    let fullStartPath = URL(fileURLWithPath: "public").appendingPathComponent(startDir)
+    let fullStartPath = URL(fileURLWithPath: assetsFolder).appendingPathComponent(startDir)
     
     CAPLog.print("⚡️  ERROR: Unable to load \(fullStartPath.relativePath)/index.html")
     CAPLog.print("⚡️  This file is the root of your web app and must exist before")
@@ -159,7 +164,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   }
 
   func loadWebView() {
-    let fullStartPath = URL(fileURLWithPath: "public").appendingPathComponent(startDir).appendingPathComponent("index")
+    let fullStartPath = URL(fileURLWithPath: assetsFolder).appendingPathComponent(startDir).appendingPathComponent("index")
     if Bundle.main.path(forResource: fullStartPath.relativePath, ofType: "html") == nil {
       fatalLoadError()
     }


### PR DESCRIPTION
So, when a project has a .framework, for some reason appendingPathComponent works in a different way when you append an empty string

if no framework is present, appending empty string to "public" results in "public"
if a framework is present, appending empty string to "public" results in "public/" and makes the app to crash as it doesn't find the public folder.

This PR only appends `startDir` if not empty
Also uses a new assetsFolder variable to be used instead of hardcoded "public" value

closes #2262