### PR TITLE
fix(ios): avoid lock of subsequent plugin calls

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -447,11 +447,10 @@ enum BridgeError: Error {
         return
       }
 
-      dispatchQueue.sync {
-        let arguments = call.options["options"] as! [Any]
-        let pluginCall = CDVInvokedUrlCommand(arguments: arguments, callbackId: call.callbackId, className: plugin.className, methodName: call.method)
-        plugin.perform(selector, with: pluginCall)
-      }
+      let arguments = call.options["options"] as! [Any]
+      let pluginCall = CDVInvokedUrlCommand(arguments: arguments, callbackId: call.callbackId, className: plugin.className, methodName: call.method)
+      plugin.perform(selector, with: pluginCall)
+
     } else {
       CAPLog.print("Error: Cordova Plugin mapping not found")
       return


### PR DESCRIPTION
The `dispatchQueue.sync` is causing problems on subsequent plugin calls where the reference is retained (see https://github.com/ionic-team/capacitor/issues/2315 as example)
I don't think it's really needed, it fixes the issue and other plugins keep working, so I think it's safe to remove. 

Closes https://github.com/ionic-team/capacitor/issues/2315