### PR TITLE
docs: Add how to determine installed plugin version in project

### DIFF
--- a/site/docs-md/cordova/using-cordova-plugins.md
+++ b/site/docs-md/cordova/using-cordova-plugins.md
@@ -51,9 +51,9 @@ npx cap update
 
 If you don't want to risk to introduce breaking changes, use `npm update cordova-plugin-name` instead of `@latest`.
 
-## Determining Plugin Version Numbers
+## Determining Installed Plugin Version
 
-See the list of Capacitor and Cordova plugins installed in your project with:
+See the list of Capacitor and Cordova plugins (and their exact version numbers) installed in your project with:
 
 ```bash
 npx cap ls

--- a/site/docs-md/cordova/using-cordova-plugins.md
+++ b/site/docs-md/cordova/using-cordova-plugins.md
@@ -51,6 +51,14 @@ npx cap update
 
 If you don't want to risk to introduce breaking changes, use `npm update cordova-plugin-name` instead of `@latest`.
 
+## Determining Plugin Version Numbers
+
+See the list of Capacitor and Cordova plugins installed in your project with:
+
+```bash
+npx cap ls
+```
+
 ## Important: Configuration 
 
 Capacitor does not support Cordova install variables, auto configuration, or hooks, due to our philosophy of letting you control your native project source code (meaning things like hooks are unnecessary). If your plugin requires variables or settings to be set, you'll need to apply those configuration settings manually by mapping between the plugin's `plugin.xml` and required settings on iOS and Android.


### PR DESCRIPTION
Useful in many ways, but recently found it handy when cloning someone's project then double-checking that the plugin version they thought they had actually was the latest.