### PR TITLE
feat(PushNotifications): Make register method to return if permission was granted

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -94,7 +94,9 @@ public class PushNotifications extends Plugin {
         sendError(e.getLocalizedMessage());
       }
     });
-    call.success();
+    JSObject result = new JSObject();
+    result.put("granted", true);
+    call.success(result);
   }
 
   @PluginMethod()

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1457,8 +1457,12 @@ export interface PushNotificationChannelList {
   channels: PushNotificationChannel[];
 }
 
+export interface PushNotificationRegistrationResponse {
+  granted: boolean;
+}
+
 export interface PushNotificationsPlugin extends Plugin {
-  register(): Promise<void>;
+  register(): Promise<PushNotificationRegistrationResponse>;
   getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
   removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -21,15 +21,17 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
   /**
    * Request permissions to send notifications
    */
-  public func requestPermissions() {
+  public func requestPermissions(with completion: ((Bool, Error?) -> Void)? = nil) {
     // Override point for customization after application launch.
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options:[.badge, .alert, .sound]) { (granted, error) in
-      // Enable or disable features based on authorization.
-    }
+        if granted {
+            DispatchQueue.main.async {
+              UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
 
-    DispatchQueue.main.async {
-      UIApplication.shared.registerForRemoteNotifications()
+        completion?(granted, error)
     }
   }
 

--- a/site/src/assets/docs-content/apis/push-notifications/api.html
+++ b/site/src/assets/docs-content/apis/push-notifications/api.html
@@ -66,13 +66,13 @@
 <div class="avc-code-method">
                     <h3 class="avc-code-method-header" id="method-register-0">register</h3>
                     <div class="avc-code-method-signature">
-                      <span class="avc-code-method-name">register</span><span class="avc-code-paren">(</span><span class="avc-code-paren">)</span><span class="avc-code-return-type-colon">:</span> Promise<span class="avc-code-typearg-bracket">&lt;</span>void<span class="avc-code-typearg-bracket">&gt;</span>
+                      <span class="avc-code-method-name">register</span><span class="avc-code-paren">(</span><span class="avc-code-paren">)</span><span class="avc-code-return-type-colon">:</span> Promise<span class="avc-code-typearg-bracket">&lt;</span><avc-code-type type-id="861">PushNotificationRegistrationResponse</avc-code-type><span class="avc-code-typearg-bracket">&gt;</span>
     </div>
     
   <div class="avc-code-method-params">
 
   <div class="avc-code-method-returns-info">
-    <span class="avc-code-method-returns-label">Returns:</span> Promise<span class="avc-code-typearg-bracket">&lt;</span>void<span class="avc-code-typearg-bracket">&gt;</span>
+    <span class="avc-code-method-returns-label">Returns:</span> Promise<span class="avc-code-typearg-bracket">&lt;</span><avc-code-type type-id="861">PushNotificationRegistrationResponse</avc-code-type><span class="avc-code-typearg-bracket">&gt;</span>
   </div>
   
 </div></div>


### PR DESCRIPTION
Rather than simply calling `call.success()` on iOS as soon as a user requests permissions (regardless of result), this adds a completion that allows the user to `await` the result in their app and passes back the response or error.