### PR TITLE
fix(toast): unify duration across platforms

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Toast.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Toast.java
@@ -16,7 +16,7 @@ public class Toast extends Plugin {
       return;
     }
 
-    String durationType = call.getString("durationType", "short");
+    String durationType = call.getString("duration", "short");
 
     int duration = android.widget.Toast.LENGTH_SHORT;
     if("long".equals(durationType)) {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1619,6 +1619,9 @@ export interface ToastPlugin extends Plugin {
 
 export interface ToastShowOptions {
   text: string;
+  /**
+   * Duration of the toast, either 'short' (2000ms, default) or 'long' (3500ms)
+   */
   duration?: 'short' | 'long';
 }
 

--- a/core/src/web/toast.ts
+++ b/core/src/web/toast.ts
@@ -11,9 +11,9 @@ export class ToastPluginWeb extends WebPlugin implements ToastPlugin {
   }
 
   async show(options: ToastShowOptions) {
-    let duration = 3000;
+    let duration = 2000;
     if (options.duration) {
-      duration = options.duration === 'long' ? 5000 : 3000;
+      duration = options.duration === 'long' ? 3500 : 2000;
     }
     const toast = document.createElement('pwa-toast') as any;
     toast.duration = duration;

--- a/ios/Capacitor/Capacitor/Plugins/Toast.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Toast.swift
@@ -10,8 +10,8 @@ public class CAPToastPlugin : CAPPlugin {
       call.error("text must be provided and must be a string.")
       return
     }
-    let durationStyle = call.get("durationStyle", String.self, "short")!
-    let duration = durationStyle == "long" ? 3500 : 2000
+    let durationType = call.get("duration", String.self, "short")!
+    let duration = durationType == "long" ? 3500 : 2000
     
     DispatchQueue.main.async {
       let vc = self.bridge!.viewController

--- a/ios/Capacitor/Capacitor/Plugins/Toast.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Toast.swift
@@ -10,8 +10,8 @@ public class CAPToastPlugin : CAPPlugin {
       call.error("text must be provided and must be a string.")
       return
     }
-    let durationStyle = call.get("durationStyle", String.self, "long")!
-    let duration = durationStyle == "short" ? 1500 : 3000
+    let durationStyle = call.get("durationStyle", String.self, "short")!
+    let duration = durationStyle == "long" ? 3500 : 2000
     
     DispatchQueue.main.async {
       let vc = self.bridge!.viewController


### PR DESCRIPTION
* use same duration for long and short toasts on ios, android and web (closes #2175 )
* make `short` the default on all platforms
* make android and ios actually use the duration option
* I used this test app to test the toast duration: https://github.com/pwespi/toast-test/