### PR TITLE
fix(cordova): patch CDVCapture bundle path

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -288,8 +288,9 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
           fileContent = fileContent.replace('@import Firebase;', '#import <Firebase/Firebase.h>');
           writeFileSync(fileDest, fileContent, 'utf8');
         }
-        if (fileContent.includes('[NSBundle bundleForClass:[self class]]')) {
+        if (fileContent.includes('[NSBundle bundleForClass:[self class]]') || fileContent.includes('[NSBundle bundleForClass:[CDVCapture class]]')) {
           fileContent = fileContent.replace('[NSBundle bundleForClass:[self class]]', '[NSBundle mainBundle]');
+          fileContent = fileContent.replace('[NSBundle bundleForClass:[CDVCapture class]]', '[NSBundle mainBundle]');
           writeFileSync(fileDest, fileContent, 'utf8');
         }
       }


### PR DESCRIPTION
In Capacitor the bundles are in the main bundle, we had patched the path for `[self class]`, but media-capture uses `[CDVCapture class]`, so patching that too.

closes #2185 