### PR TITLE
added WKNavigationDelegate notifications

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -233,8 +233,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     configuration.allowsAirPlayForMediaPlayback = true
     configuration.mediaTypesRequiringUserActionForPlayback = []
   }
-
+    
   public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidStartProvisionalNavigation.name()), object: navigation)
     // Reset the bridge on each navigation
     bridge!.reset()
   }
@@ -264,16 +265,19 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
 
   public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
     CAPLog.print("⚡️  WebView loaded")
+    NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFinishNavigation.name()), object: navigation)
   }
 
   public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
     CAPLog.print("⚡️  WebView failed to load")
     CAPLog.print("⚡️  Error: " + error.localizedDescription)
+    NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailNavigation.name()), object: [ "navigation": navigation, "error": error])
   }
 
   public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
     CAPLog.print("⚡️  WebView failed provisional navigation")
     CAPLog.print("⚡️  Error: " + error.localizedDescription)
+    NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailProvisionalNavigation.name()), object: [ "navigation": navigation, "error": error])
   }
 
   public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {

--- a/ios/Capacitor/Capacitor/CAPNotifications.swift
+++ b/ios/Capacitor/Capacitor/CAPNotifications.swift
@@ -8,6 +8,10 @@
   case DidRegisterForRemoteNotificationsWithDeviceToken
   case DidFailToRegisterForRemoteNotificationsWithError
   case DecidePolicyForNavigationAction
+  case DidStartProvisionalNavigation
+  case DidFinishNavigation
+  case DidFailNavigation
+  case DidFailProvisionalNavigation
   
   public func name() -> String {
     switch self {
@@ -17,6 +21,10 @@
       case .DidRegisterForRemoteNotificationsWithDeviceToken: return "CAPDidRegisterForRemoteNotificationsWithDeviceToken"
       case .DidFailToRegisterForRemoteNotificationsWithError: return "CAPDidFailToRegisterForRemoteNotificationsWithError"
       case .DecidePolicyForNavigationAction: return "CAPDecidePolicyForNavigationAction"
+      case .DidStartProvisionalNavigation: return "CAPDidStartProvisionalNavigation"
+      case .DidFinishNavigation: return "CAPDidFinishNavigation"
+      case .DidFailNavigation: return "CAPDidFailNavigation"
+      case .DidFailProvisionalNavigation: return "CAPDidFailProvisionalNavigation"
     }
   }
 }


### PR DESCRIPTION
Closes #2349 

Plugins cannot react to navigation events. This pull request would make it possible for plugins to react to things like a failed navigation, the start of a navigation when navigation is finished.

The reason plugins can not react to navigation events is that WKWebview only allows for one navigation delegate. In the capacitor code CAPBridgeViewController is this delegate. 

If plugins would set themeselves as delegates they would override  the CAPBridgeViewController functionality.

Also it would be impossible to have multiple plugins as a delegate as only one can be the assigned delegate.

The solution is to keep CAPBridgeViewController as the WKNavigationDelegate but add some notifications in the functions that implement the WKNavigationDelegate protocol.

This was already done for decidePolicyFor delegate method. I added notifications for the other delegate methods.