### PR TITLE
fix(cli): move Android Studio detection to avoid displaying registry errors

### DIFF
--- a/cli/src/android/open.ts
+++ b/cli/src/android/open.ts
@@ -1,7 +1,7 @@
 import { Config } from '../config';
 import { OS } from '../definitions';
-import { logError, logInfo } from '../common';
-import { existsAsync } from '../util/fs';
+import { logError, logInfo, runCommand } from '../common';
+import { existsAsync, existsSync } from '../util/fs';
 import { resolve } from 'path';
 
 export async function openAndroid(config: Config) {
@@ -20,10 +20,29 @@ export async function openAndroid(config: Config) {
       await opn(dir, { app: 'android studio', wait: false });
       break;
     case OS.Windows:
-      if (config.windows.androidStudioPath) {
-        opn(dir, { app: config.windows.androidStudioPath, wait: false });
+      let androidStudioPath = config.windows.androidStudioPath;
+      try {
+        if (!existsSync(androidStudioPath)) {
+          let commandResult = await runCommand('REG QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio" /v Path');
+          commandResult = commandResult.replace(/(\r\n|\n|\r)/gm, '');
+          const ix = commandResult.indexOf('REG_SZ');
+          if (ix > 0) {
+            androidStudioPath = commandResult.substring(ix + 6).trim() + '\\bin\\studio64.exe';
+          }
+        }
+      } catch (e) {
+        androidStudioPath = '';
+      }
+      if (androidStudioPath) {
+        opn(dir, { app: androidStudioPath, wait: false });
       } else {
-        logError('Unable to launch Android Studio. Make sure the latest version of Android Studio is installed');
+        logError('Android Studio not found. Make sure it\'s installed and configure "windowsAndroidStudioPath" ' +
+                 'in your capacitor.config.json to point to the location of studio64.exe, using JavaScript-escaped paths:\n' +
+
+                 'Example:\n' +
+                 '{\n' +
+                    '  "windowsAndroidStudioPath": "C:\\\\Program Files\\\\Android\\\\Android Studio\\\\bin\\\\studio64.exe"\n' +
+                  '}');
       }
       break;
     case OS.Linux:

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,8 +1,7 @@
-import { accessSync, existsSync, readFileSync } from 'fs';
+import { accessSync, readFileSync } from 'fs';
 import { basename, join, resolve } from 'path';
 import { logFatal, readJSON } from './common';
 import { CliConfig, ExternalConfig, OS, PackageJson } from './definitions';
-import { execSync } from 'child_process';
 
 let Package: PackageJson;
 let ExtConfig: ExternalConfig;
@@ -197,21 +196,7 @@ export class Config implements CliConfig {
     if (this.cli.os !== OS.Windows) {
         return;
     }
-    if (this.app.windowsAndroidStudioPath) {
-      try {
-        if (!existsSync(this.app.windowsAndroidStudioPath)) {
-          const buffer = execSync('REG QUERY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Android Studio" /v Path');
-          const bufferString = buffer.toString('utf-8').replace(/(\r\n|\n|\r)/gm, '');
-          const ix = bufferString.indexOf('REG_SZ');
-          if (ix > 0) {
-            this.app.windowsAndroidStudioPath = bufferString.substring(ix + 6).trim() + '\\bin\\studio64.exe';
-          }
-        }
-        this.windows.androidStudioPath = this.app.windowsAndroidStudioPath;
-      } catch (e) {
-         this.windows.androidStudioPath = '';
-      }
-    }
+    this.windows.androidStudioPath = this.app.windowsAndroidStudioPath;
   }
 
   private initLinuxConfig() {


### PR DESCRIPTION
`execSync` is displaying a registry error if the Android Studio key is not found

This PR moves the Android Studio detection logic from config (which is executed every time) to open (that is only executed when open is called), and also uses `runCommand` instead of `execSync` so the registry message is not displayed, and also improves the error message is the Android Studio registry is not found so users can configure `windowsAndroidStudioPath`


Closes #2031