### PR TITLE
feat(android): add group and groupSummary to LocalNotifications

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -122,6 +122,8 @@ public class PushNotifications extends Plugin {
         if (notification != null) {
           jsNotif.put("title", notification.extras.getCharSequence(Notification.EXTRA_TITLE));
           jsNotif.put("body", notification.extras.getCharSequence(Notification.EXTRA_TEXT));
+          jsNotif.put("group", notification.getGroup());
+          jsNotif.put("groupSummary", 0 != (notification.flags & Notification.FLAG_GROUP_SUMMARY));
 
           JSObject extras = new JSObject();
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -32,6 +32,8 @@ public class LocalNotification {
   private String sound;
   private String smallIcon;
   private String actionTypeId;
+  private String group;
+  private boolean groupSummary;
   private JSObject extra;
   private List<LocalNotificationAttachment> attachments;
   private LocalNotificationSchedule schedule;
@@ -89,6 +91,14 @@ public class LocalNotification {
     this.actionTypeId = actionTypeId;
   }
 
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
   public JSObject getExtra() {
     return extra;
   }
@@ -103,6 +113,14 @@ public class LocalNotification {
 
   public void setId(Integer id) {
     this.id = id;
+  }
+
+  public boolean isGroupSummary() {
+    return groupSummary;
+  }
+
+  public void setGroupSummary(boolean groupSummary) {
+    this.groupSummary = groupSummary;
   }
 
   /**
@@ -136,10 +154,12 @@ public class LocalNotification {
       activeLocalNotification.setId(notification.getInteger("id"));
       activeLocalNotification.setBody(notification.getString("body"));
       activeLocalNotification.setActionTypeId(notification.getString("actionTypeId"));
+      activeLocalNotification.setGroup(notification.getString("group"));
       activeLocalNotification.setSound(notification.getString("sound"));
       activeLocalNotification.setTitle(notification.getString("title"));
       activeLocalNotification.setSmallIcon(notification.getString("smallIcon"));
       activeLocalNotification.setAttachments(LocalNotificationAttachment.getAttachments(notification));
+      activeLocalNotification.setGroupSummary(notification.getBoolean("groupSummary", false));
       try {
         activeLocalNotification.setSchedule(new LocalNotificationSchedule(notification));
       } catch (ParseException e) {
@@ -234,9 +254,11 @@ public class LocalNotification {
             ", sound='" + sound + '\'' +
             ", smallIcon='" + smallIcon + '\'' +
             ", actionTypeId='" + actionTypeId + '\'' +
+            ", group='" + group + '\'' +
             ", extra=" + extra +
             ", attachments=" + attachments +
             ", schedule=" + schedule +
+            ", groupSummary=" + groupSummary +
             '}';
   }
 
@@ -254,9 +276,11 @@ public class LocalNotification {
     if (smallIcon != null ? !smallIcon.equals(that.smallIcon) : that.smallIcon != null) return false;
     if (actionTypeId != null ? !actionTypeId.equals(that.actionTypeId) : that.actionTypeId != null)
       return false;
+    if (group != null ? !group.equals(that.group) : that.group != null) return false;
     if (extra != null ? !extra.equals(that.extra) : that.extra != null) return false;
     if (attachments != null ? !attachments.equals(that.attachments) : that.attachments != null)
       return false;
+    if (groupSummary != that.groupSummary) return false;
     return schedule != null ? schedule.equals(that.schedule) : that.schedule == null;
   }
 
@@ -268,6 +292,8 @@ public class LocalNotification {
     result = 31 * result + (sound != null ? sound.hashCode() : 0);
     result = 31 * result + (smallIcon != null ? smallIcon.hashCode() : 0);
     result = 31 * result + (actionTypeId != null ? actionTypeId.hashCode() : 0);
+    result = 31 * result + (group != null ? group.hashCode() : 0);
+    result = 31 * result + Boolean.hashCode(groupSummary);
     result = 31 * result + (extra != null ? extra.hashCode() : 0);
     result = 31 * result + (attachments != null ? attachments.hashCode() : 0);
     result = 31 * result + (schedule != null ? schedule.hashCode() : 0);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -149,6 +149,7 @@ public class LocalNotificationManager {
             .setAutoCancel(true)
             .setOngoing(false)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setGroupSummary(localNotification.isGroupSummary())
             .setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE | Notification.DEFAULT_LIGHTS);
 
     String sound = localNotification.getSound();
@@ -159,6 +160,11 @@ public class LocalNotificationManager {
               "com.android.systemui", soundUri,
               Intent.FLAG_GRANT_READ_URI_PERMISSION);
       mBuilder.setSound(soundUri);
+    }
+
+    String group = localNotification.getGroup();
+    if (group != null) {
+      mBuilder.setGroup(group);
     }
 
     mBuilder.setVisibility(Notification.VISIBILITY_PRIVATE);

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginListenerHandle } from './definitions';
+import { Plugin, PluginListenerHandle } from "./definitions";
 
 export interface PluginRegistry {
   Accessibility: AccessibilityPlugin;
@@ -62,7 +62,10 @@ export interface AccessibilityPlugin {
   /**
    * Listen for screen reader state change (on/off)
    */
-  addListener(eventName: 'accessibilityScreenReaderStateChange', listenerFunc: ScreenReaderStateChangeCallback): PluginListenerHandle;
+  addListener(
+    eventName: "accessibilityScreenReaderStateChange",
+    listenerFunc: ScreenReaderStateChangeCallback
+  ): PluginListenerHandle;
 }
 
 export interface AccessibilitySpeakOptions {
@@ -80,7 +83,9 @@ export interface AccessibilitySpeakOptions {
 export interface ScreenReaderEnabledResult {
   value: boolean;
 }
-export type ScreenReaderStateChangeCallback = (state: ScreenReaderEnabledResult) => void;
+export type ScreenReaderStateChangeCallback = (
+  state: ScreenReaderEnabledResult
+) => void;
 
 //
 
@@ -95,12 +100,12 @@ export interface AppPlugin extends Plugin {
   /**
    * Check if an app can be opened with the given URL
    */
-  canOpenUrl(options: { url: string }): Promise<{value: boolean}>;
+  canOpenUrl(options: { url: string }): Promise<{ value: boolean }>;
 
   /**
    * Open an app with the given URL
    */
-  openUrl(options: { url: string }): Promise<{completed: boolean}>;
+  openUrl(options: { url: string }): Promise<{ completed: boolean }>;
 
   /**
    * Get the URL the app was launched with, if any
@@ -110,27 +115,39 @@ export interface AppPlugin extends Plugin {
   /**
    * Listen for changes in the App's active state (whether the app is in the foreground or background)
    */
-  addListener(eventName: 'appStateChange', listenerFunc: (state: AppState) => void): PluginListenerHandle;
+  addListener(
+    eventName: "appStateChange",
+    listenerFunc: (state: AppState) => void
+  ): PluginListenerHandle;
 
   /**
    * Listen for url open events for the app. This handles both custom URL scheme links as well
    * as URLs your app handles (Universal Links on iOS and App Links on Android)
    */
-  addListener(eventName: 'appUrlOpen', listenerFunc: (data: AppUrlOpen) => void): PluginListenerHandle;
+  addListener(
+    eventName: "appUrlOpen",
+    listenerFunc: (data: AppUrlOpen) => void
+  ): PluginListenerHandle;
 
   /**
    * If the app was launched with previously persisted plugin call data, such as on Android
    * when an activity returns to an app that was closed, this call will return any data
    * the app was launched with, converted into the form of a result from a plugin call.
    */
-  addListener(eventName: 'appRestoredResult', listenerFunc: (data: AppRestoredResult) => void): PluginListenerHandle;
+  addListener(
+    eventName: "appRestoredResult",
+    listenerFunc: (data: AppRestoredResult) => void
+  ): PluginListenerHandle;
 
   /**
    * Listen for the hardware back button event (Android only). Listening for this event will disable the
    * default back button behaviour, so you might want to call `window.history.back()` manually.
    * If you want to close the app, call `App.exitApp()`.
    */
-  addListener(eventName: 'backButton', listenerFunc: (data: AppUrlOpen) => void): PluginListenerHandle;
+  addListener(
+    eventName: "backButton",
+    listenerFunc: (data: AppUrlOpen) => void
+  ): PluginListenerHandle;
 }
 
 export interface AppState {
@@ -199,7 +216,7 @@ export interface BackgroundTaskPlugin extends Plugin {
    * Notify the OS that the given task is finished and the OS can continue
    * backgrounding the app.
    */
-  finish(options: {taskId: CallbackID}): void;
+  finish(options: { taskId: CallbackID }): void;
 }
 
 //
@@ -223,8 +240,14 @@ export interface BrowserPlugin extends Plugin {
    */
   close(): Promise<void>;
 
-  addListener(eventName: 'browserFinished', listenerFunc: (info: any) => void): PluginListenerHandle;
-  addListener(eventName: 'browserPageLoaded', listenerFunc: (info: any) => void): PluginListenerHandle;
+  addListener(
+    eventName: "browserFinished",
+    listenerFunc: (info: any) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "browserPageLoaded",
+    listenerFunc: (info: any) => void
+  ): PluginListenerHandle;
 }
 
 export interface BrowserOpenOptions {
@@ -245,10 +268,10 @@ export interface BrowserOpenOptions {
    */
   toolbarColor?: string;
 
-   /**
+  /**
    * iOS only: The presentation style of the browser. Defaults to fullscreen.
    */
-  presentationStyle?: 'fullscreen' | 'popover';
+  presentationStyle?: "fullscreen" | "popover";
 }
 
 export interface BrowserPrefetchOptions {
@@ -311,18 +334,18 @@ export interface CameraOptions {
   /**
    * iOS only: The presentation style of the Camera. Defaults to fullscreen.
    */
-  presentationStyle?: 'fullscreen' | 'popover';
+  presentationStyle?: "fullscreen" | "popover";
 }
 
 export enum CameraSource {
-  Prompt = 'PROMPT',
-  Camera = 'CAMERA',
-  Photos = 'PHOTOS'
+  Prompt = "PROMPT",
+  Camera = "CAMERA",
+  Photos = "PHOTOS"
 }
 
 export enum CameraDirection {
-  Rear = 'REAR',
-  Front = 'FRONT',
+  Rear = "REAR",
+  Front = "FRONT"
 }
 
 export interface CameraPhoto {
@@ -355,9 +378,9 @@ export interface CameraPhoto {
 }
 
 export enum CameraResultType {
-  Uri = 'uri',
-  Base64 = 'base64',
-  DataUrl = 'dataUrl'
+  Uri = "uri",
+  Base64 = "base64",
+  DataUrl = "dataUrl"
 }
 
 //
@@ -381,7 +404,7 @@ export interface ClipboardWrite {
 }
 
 export interface ClipboardRead {
-  type: 'string' | 'url' | 'image';
+  type: "string" | "url" | "image";
 }
 
 export interface ClipboardReadResult {
@@ -401,7 +424,7 @@ export interface DevicePlugin extends Plugin {
   getLanguageCode(): Promise<DeviceLanguageCodeResult>;
 }
 
-export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'unknown';
+export type OperatingSystem = "ios" | "android" | "windows" | "mac" | "unknown";
 
 export interface DeviceInfo {
   /**
@@ -411,7 +434,7 @@ export interface DeviceInfo {
   /**
    * The device platform (lowercase).
    */
-  platform: 'ios' | 'android' | 'electron' | 'web';
+  platform: "ios" | "android" | "electron" | "web";
   /**
    * The UUID of the device as available to the app. This identifier may change
    * on modern mobile platforms that only allow per-app install UUIDs.
@@ -552,33 +575,33 @@ export enum FilesystemDirectory {
   /**
    * The Application directory
    */
-  Application = 'APPLICATION',
+  Application = "APPLICATION",
   /**
    * The Documents directory
    */
-  Documents = 'DOCUMENTS',
+  Documents = "DOCUMENTS",
   /**
    * The Data directory
    */
-  Data = 'DATA',
+  Data = "DATA",
   /**
    * The Cache directory
    */
-  Cache = 'CACHE',
+  Cache = "CACHE",
   /**
    * The external directory (Android only)
    */
-  External = 'EXTERNAL',
+  External = "EXTERNAL",
   /**
    * The external storage directory (Android only)
    */
-  ExternalStorage = 'EXTERNAL_STORAGE'
+  ExternalStorage = "EXTERNAL_STORAGE"
 }
 
 export enum FilesystemEncoding {
-  UTF8 = 'utf8',
-  ASCII = 'ascii',
-  UTF16 = 'utf16'
+  UTF8 = "utf8",
+  ASCII = "ascii",
+  UTF16 = "utf16"
 }
 
 export interface FileWriteOptions {
@@ -750,20 +773,13 @@ export interface RenameOptions extends CopyOptions {}
 export interface FileReadResult {
   data: string;
 }
-export interface FileDeleteResult {
-}
-export interface FileWriteResult {
-}
-export interface FileAppendResult {
-}
-export interface MkdirResult {
-}
-export interface RmdirResult {
-}
-export interface RenameResult {
-}
-export interface CopyResult {
-}
+export interface FileDeleteResult {}
+export interface FileWriteResult {}
+export interface FileAppendResult {}
+export interface MkdirResult {}
+export interface RmdirResult {}
+export interface RenameResult {}
+export interface CopyResult {}
 export interface ReaddirResult {
   files: string[];
 }
@@ -784,12 +800,17 @@ export interface GeolocationPlugin extends Plugin {
   /**
    * Get the current GPS location of the device
    */
-  getCurrentPosition(options?: GeolocationOptions): Promise<GeolocationPosition>;
+  getCurrentPosition(
+    options?: GeolocationOptions
+  ): Promise<GeolocationPosition>;
   /**
    * Set up a watch for location changes. Note that watching for location changes
    * can consume a large amount of energy. Be smart about listening only when you need to.
    */
-  watchPosition(options: GeolocationOptions, callback: GeolocationWatchCallback): CallbackID;
+  watchPosition(
+    options: GeolocationOptions,
+    callback: GeolocationWatchCallback
+  ): CallbackID;
 
   /**
    * Clear a given watch
@@ -854,7 +875,10 @@ export interface GeolocationOptions {
   requireAltitude?: boolean; // default: false
 }
 
-export type GeolocationWatchCallback = (position: GeolocationPosition, err?: any) => void;
+export type GeolocationWatchCallback = (
+  position: GeolocationPosition,
+  err?: any
+) => void;
 
 //
 
@@ -893,9 +917,9 @@ export interface HapticsImpactOptions {
 }
 
 export enum HapticsImpactStyle {
-  Heavy = 'HEAVY',
-  Medium = 'MEDIUM',
-  Light = 'LIGHT'
+  Heavy = "HEAVY",
+  Medium = "MEDIUM",
+  Light = "LIGHT"
 }
 
 export interface HapticsNotificationOptions {
@@ -903,9 +927,9 @@ export interface HapticsNotificationOptions {
 }
 
 export enum HapticsNotificationType {
-  SUCCESS = 'SUCCESS',
-  WARNING = 'WARNING',
-  ERROR = 'ERROR'
+  SUCCESS = "SUCCESS",
+  WARNING = "WARNING",
+  ERROR = "ERROR"
 }
 
 export interface VibrateOptions {
@@ -941,10 +965,22 @@ export interface KeyboardPlugin extends Plugin {
    */
   setResizeMode(options: KeyboardResizeOptions): Promise<void>;
 
-  addListener(eventName: 'keyboardWillShow', listenerFunc: (info: KeyboardInfo) => void): PluginListenerHandle;
-  addListener(eventName: 'keyboardDidShow', listenerFunc: (info: KeyboardInfo) => void): PluginListenerHandle;
-  addListener(eventName: 'keyboardWillHide', listenerFunc: () => void): PluginListenerHandle;
-  addListener(eventName: 'keyboardDidHide', listenerFunc: () => void): PluginListenerHandle;
+  addListener(
+    eventName: "keyboardWillShow",
+    listenerFunc: (info: KeyboardInfo) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "keyboardDidShow",
+    listenerFunc: (info: KeyboardInfo) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "keyboardWillHide",
+    listenerFunc: () => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "keyboardDidHide",
+    listenerFunc: () => void
+  ): PluginListenerHandle;
 }
 
 export interface KeyboardInfo {
@@ -956,8 +992,8 @@ export interface KeyboardStyleOptions {
 }
 
 export enum KeyboardStyle {
-  Dark = 'DARK',
-  Light = 'LIGHT'
+  Dark = "DARK",
+  Light = "LIGHT"
 }
 
 export interface KeyboardResizeOptions {
@@ -965,10 +1001,10 @@ export interface KeyboardResizeOptions {
 }
 
 export enum KeyboardResize {
-  Body = 'body',
-  Ionic = 'ionic',
-  Native = 'native',
-  None = 'none'
+  Body = "body",
+  Ionic = "ionic",
+  Native = "native",
+  None = "none"
 }
 
 //
@@ -981,8 +1017,8 @@ export interface LocalNotificationPendingList {
   notifications: LocalNotificationRequest[];
 }
 
-export interface LocalNotificationScheduleResult extends LocalNotificationPendingList {
-}
+export interface LocalNotificationScheduleResult
+  extends LocalNotificationPendingList {}
 
 export interface LocalNotificationActionType {
   id: string;
@@ -1040,12 +1076,22 @@ export interface LocalNotification {
    * iOS 12+ only: set the summary argument for notification grouping
    */
   summaryArgument?: string;
+  group?: string;
+  groupSummary?: boolean;
 }
 
 export interface LocalNotificationSchedule {
   at?: Date;
   repeats?: boolean;
-  every?: 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
+  every?:
+    | "year"
+    | "month"
+    | "two-weeks"
+    | "week"
+    | "day"
+    | "hour"
+    | "minute"
+    | "second";
   count?: number;
   on?: {
     year?: number;
@@ -1070,15 +1116,24 @@ export interface LocalNotificationEnabledResult {
 }
 
 export interface LocalNotificationsPlugin extends Plugin {
-  schedule(options: { notifications: LocalNotification[] }): Promise<LocalNotificationScheduleResult>;
+  schedule(options: {
+    notifications: LocalNotification[];
+  }): Promise<LocalNotificationScheduleResult>;
   getPending(): Promise<LocalNotificationPendingList>;
-  registerActionTypes(options: { types: LocalNotificationActionType[] }): Promise<void>;
+  registerActionTypes(options: {
+    types: LocalNotificationActionType[];
+  }): Promise<void>;
   cancel(pending: LocalNotificationPendingList): Promise<void>;
   areEnabled(): Promise<LocalNotificationEnabledResult>;
-  addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotification) => void): PluginListenerHandle;
-  addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void): PluginListenerHandle;
+  addListener(
+    eventName: "localNotificationReceived",
+    listenerFunc: (notification: LocalNotification) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "localNotificationActionPerformed",
+    listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void
+  ): PluginListenerHandle;
 }
-
 
 //
 
@@ -1140,9 +1195,9 @@ export interface ActionSheetOptions {
 }
 
 export enum ActionSheetOptionStyle {
-  Default = 'DEFAULT',
-  Destructive = 'DESTRUCTIVE',
-  Cancel = 'CANCEL'
+  Default = "DEFAULT",
+  Destructive = "DESTRUCTIVE",
+  Cancel = "CANCEL"
 }
 
 export interface ActionSheetOption {
@@ -1164,14 +1219,22 @@ export interface MotionPlugin extends Plugin {
   /**
    * Listen for accelerometer data
    */
-  addListener(eventName: 'accel', listenerFunc: (event: MotionEventResult) => void): PluginListenerHandle;
+  addListener(
+    eventName: "accel",
+    listenerFunc: (event: MotionEventResult) => void
+  ): PluginListenerHandle;
   /**
    * Listen for device orientation change (compass heading, etc.)
    */
-  addListener(eventName: 'orientation', listenerFunc: (event: MotionOrientationEventResult) => void): PluginListenerHandle;
+  addListener(
+    eventName: "orientation",
+    listenerFunc: (event: MotionOrientationEventResult) => void
+  ): PluginListenerHandle;
 }
 
-export type MotionWatchOrientationCallback = (accel: MotionOrientationEventResult) => void;
+export type MotionWatchOrientationCallback = (
+  accel: MotionOrientationEventResult
+) => void;
 export type MotionWatchAccelCallback = (accel: MotionEventResult) => void;
 
 export interface MotionOrientationEventResult {
@@ -1199,7 +1262,6 @@ export interface MotionEventResult {
   interval: number;
 }
 
-
 //
 
 export interface NetworkPlugin extends Plugin {
@@ -1211,12 +1273,15 @@ export interface NetworkPlugin extends Plugin {
   /**
    * Listen for network status change events
    */
-  addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle;
+  addListener(
+    eventName: "networkStatusChange",
+    listenerFunc: (status: NetworkStatus) => void
+  ): PluginListenerHandle;
 }
 
 export interface NetworkStatus {
   connected: boolean;
-  connectionType: 'wifi' | 'cellular' | 'none' | 'unknown';
+  connectionType: "wifi" | "cellular" | "none" | "unknown";
 }
 
 export type NetworkStatusChangeCallback = (status: NetworkStatus) => void;
@@ -1224,12 +1289,12 @@ export type NetworkStatusChangeCallback = (status: NetworkStatus) => void;
 //
 
 export enum PermissionType {
-  Camera = 'camera',
-  Photos = 'photos',
-  Geolocation = 'geolocation',
-  Notifications = 'notifications',
-  ClipboardRead = 'clipboard-read',
-  ClipboardWrite = 'clipboard-write'
+  Camera = "camera",
+  Photos = "photos",
+  Geolocation = "geolocation",
+  Notifications = "notifications",
+  ClipboardRead = "clipboard-read",
+  ClipboardWrite = "clipboard-write"
 }
 
 export interface PermissionsOptions {
@@ -1237,7 +1302,7 @@ export interface PermissionsOptions {
 }
 
 export interface PermissionResult {
-  state: 'granted' | 'denied' | 'prompt';
+  state: "granted" | "denied" | "prompt";
 }
 
 export interface PermissionsPlugin extends Plugin {
@@ -1414,15 +1479,15 @@ export enum PhotosAlbumType {
   /**
    * Album is a "smart" album (such as Favorites or Recently Added)
    */
-  Smart = 'smart',
+  Smart = "smart",
   /**
    * Album is a cloud-shared album
    */
-  Shared = 'shared',
+  Shared = "shared",
   /**
    * Album is a user-created album
    */
-  User = 'user'
+  User = "user"
 }
 
 //
@@ -1458,8 +1523,8 @@ export interface PushNotificationChannel {
   name: string;
   description: string;
   sound: string;
-  importance: 1 | 2 | 3 | 4 | 5;
-  visibility?: -1 | 0 | 1 ;
+  importance: 1 | 2 | 3 | 4 | 5;
+  visibility?: -1 | 0 | 1;
 }
 
 export interface PushNotificationChannelList {
@@ -1469,15 +1534,29 @@ export interface PushNotificationChannelList {
 export interface PushNotificationsPlugin extends Plugin {
   register(): Promise<void>;
   getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
-  removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
+  removeDeliveredNotifications(
+    delivered: PushNotificationDeliveredList
+  ): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;
   createChannel(channel: PushNotificationChannel): Promise<void>;
   deleteChannel(channel: PushNotificationChannel): Promise<void>;
   listChannels(): Promise<PushNotificationChannelList>;
-  addListener(eventName: 'registration', listenerFunc: (token: PushNotificationToken) => void): PluginListenerHandle;
-  addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
-  addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;
-  addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: PushNotificationActionPerformed) => void): PluginListenerHandle;
+  addListener(
+    eventName: "registration",
+    listenerFunc: (token: PushNotificationToken) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "registrationError",
+    listenerFunc: (error: any) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "pushNotificationReceived",
+    listenerFunc: (notification: PushNotification) => void
+  ): PluginListenerHandle;
+  addListener(
+    eventName: "pushNotificationActionPerformed",
+    listenerFunc: (notification: PushNotificationActionPerformed) => void
+  ): PluginListenerHandle;
 }
 
 //
@@ -1536,9 +1615,9 @@ export interface SplashScreenShowOptions {
    */
   fadeOutDuration?: number;
   /**
-  * How long to show the splash screen when autoHide is enabled (in ms)
-  * Default is 3000ms
-  */
+   * How long to show the splash screen when autoHide is enabled (in ms)
+   * Default is 3000ms
+   */
   showDuration?: number;
 }
 
@@ -1582,11 +1661,11 @@ export enum StatusBarStyle {
   /**
    * Light text for dark backgrounds.
    */
-  Dark = 'DARK',
+  Dark = "DARK",
   /**
    * Dark text for light backgrounds.
    */
-  Light = 'LIGHT'
+  Light = "LIGHT"
 }
 
 export interface StatusBarBackgroundColorOptions {
@@ -1607,7 +1686,7 @@ export interface StoragePlugin extends Plugin {
   /**
    * Set the value for the given key
    */
-  set(options: { key: string, value: string }): Promise<void>;
+  set(options: { key: string; value: string }): Promise<void>;
   /**
    * Remove the value for this key (if any)
    */
@@ -1628,8 +1707,8 @@ export interface ToastPlugin extends Plugin {
 
 export interface ToastShowOptions {
   text: string;
-  duration?: 'short' | 'long';
-  position?: 'top' | 'center' | 'bottom';
+  duration?: "short" | "long";
+  position?: "top" | "center" | "bottom";
 }
 
 export interface WebViewPlugin extends Plugin {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1502,6 +1502,8 @@ export interface PushNotification {
   data: any;
   click_action?: string;
   link?: string;
+  group?: string;
+  groupSummary?: boolean;
 }
 
 export interface PushNotificationActionPerformed {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1447,7 +1447,15 @@ export interface PushNotification {
   data: any;
   click_action?: string;
   link?: string;
+  /**
+   * Android only: set the group identifier for notification grouping, like
+   * threadIdentifier on iOS.
+   */
   group?: string;
+  /**
+   * Android only: designate this notification as the summary for a group
+   * (should be used with the `group` property).
+   */
   groupSummary?: boolean;
 }
 

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1447,6 +1447,8 @@ export interface PushNotification {
   data: any;
   click_action?: string;
   link?: string;
+  group?: string;
+  groupSummary?: boolean;
 }
 
 export interface PushNotificationActionPerformed {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginListenerHandle } from "./definitions";
+import { Plugin, PluginListenerHandle } from './definitions';
 
 export interface PluginRegistry {
   Accessibility: AccessibilityPlugin;
@@ -62,10 +62,7 @@ export interface AccessibilityPlugin {
   /**
    * Listen for screen reader state change (on/off)
    */
-  addListener(
-    eventName: "accessibilityScreenReaderStateChange",
-    listenerFunc: ScreenReaderStateChangeCallback
-  ): PluginListenerHandle;
+  addListener(eventName: 'accessibilityScreenReaderStateChange', listenerFunc: ScreenReaderStateChangeCallback): PluginListenerHandle;
 }
 
 export interface AccessibilitySpeakOptions {
@@ -83,9 +80,7 @@ export interface AccessibilitySpeakOptions {
 export interface ScreenReaderEnabledResult {
   value: boolean;
 }
-export type ScreenReaderStateChangeCallback = (
-  state: ScreenReaderEnabledResult
-) => void;
+export type ScreenReaderStateChangeCallback = (state: ScreenReaderEnabledResult) => void;
 
 //
 
@@ -100,12 +95,12 @@ export interface AppPlugin extends Plugin {
   /**
    * Check if an app can be opened with the given URL
    */
-  canOpenUrl(options: { url: string }): Promise<{ value: boolean }>;
+  canOpenUrl(options: { url: string }): Promise<{value: boolean}>;
 
   /**
    * Open an app with the given URL
    */
-  openUrl(options: { url: string }): Promise<{ completed: boolean }>;
+  openUrl(options: { url: string }): Promise<{completed: boolean}>;
 
   /**
    * Get the URL the app was launched with, if any
@@ -115,39 +110,27 @@ export interface AppPlugin extends Plugin {
   /**
    * Listen for changes in the App's active state (whether the app is in the foreground or background)
    */
-  addListener(
-    eventName: "appStateChange",
-    listenerFunc: (state: AppState) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'appStateChange', listenerFunc: (state: AppState) => void): PluginListenerHandle;
 
   /**
    * Listen for url open events for the app. This handles both custom URL scheme links as well
    * as URLs your app handles (Universal Links on iOS and App Links on Android)
    */
-  addListener(
-    eventName: "appUrlOpen",
-    listenerFunc: (data: AppUrlOpen) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'appUrlOpen', listenerFunc: (data: AppUrlOpen) => void): PluginListenerHandle;
 
   /**
    * If the app was launched with previously persisted plugin call data, such as on Android
    * when an activity returns to an app that was closed, this call will return any data
    * the app was launched with, converted into the form of a result from a plugin call.
    */
-  addListener(
-    eventName: "appRestoredResult",
-    listenerFunc: (data: AppRestoredResult) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'appRestoredResult', listenerFunc: (data: AppRestoredResult) => void): PluginListenerHandle;
 
   /**
    * Listen for the hardware back button event (Android only). Listening for this event will disable the
    * default back button behaviour, so you might want to call `window.history.back()` manually.
    * If you want to close the app, call `App.exitApp()`.
    */
-  addListener(
-    eventName: "backButton",
-    listenerFunc: (data: AppUrlOpen) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'backButton', listenerFunc: (data: AppUrlOpen) => void): PluginListenerHandle;
 }
 
 export interface AppState {
@@ -216,7 +199,7 @@ export interface BackgroundTaskPlugin extends Plugin {
    * Notify the OS that the given task is finished and the OS can continue
    * backgrounding the app.
    */
-  finish(options: { taskId: CallbackID }): void;
+  finish(options: {taskId: CallbackID}): void;
 }
 
 //
@@ -240,14 +223,8 @@ export interface BrowserPlugin extends Plugin {
    */
   close(): Promise<void>;
 
-  addListener(
-    eventName: "browserFinished",
-    listenerFunc: (info: any) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "browserPageLoaded",
-    listenerFunc: (info: any) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'browserFinished', listenerFunc: (info: any) => void): PluginListenerHandle;
+  addListener(eventName: 'browserPageLoaded', listenerFunc: (info: any) => void): PluginListenerHandle;
 }
 
 export interface BrowserOpenOptions {
@@ -268,10 +245,10 @@ export interface BrowserOpenOptions {
    */
   toolbarColor?: string;
 
-  /**
+   /**
    * iOS only: The presentation style of the browser. Defaults to fullscreen.
    */
-  presentationStyle?: "fullscreen" | "popover";
+  presentationStyle?: 'fullscreen' | 'popover';
 }
 
 export interface BrowserPrefetchOptions {
@@ -334,18 +311,18 @@ export interface CameraOptions {
   /**
    * iOS only: The presentation style of the Camera. Defaults to fullscreen.
    */
-  presentationStyle?: "fullscreen" | "popover";
+  presentationStyle?: 'fullscreen' | 'popover';
 }
 
 export enum CameraSource {
-  Prompt = "PROMPT",
-  Camera = "CAMERA",
-  Photos = "PHOTOS"
+  Prompt = 'PROMPT',
+  Camera = 'CAMERA',
+  Photos = 'PHOTOS'
 }
 
 export enum CameraDirection {
-  Rear = "REAR",
-  Front = "FRONT"
+  Rear = 'REAR',
+  Front = 'FRONT',
 }
 
 export interface CameraPhoto {
@@ -378,9 +355,9 @@ export interface CameraPhoto {
 }
 
 export enum CameraResultType {
-  Uri = "uri",
-  Base64 = "base64",
-  DataUrl = "dataUrl"
+  Uri = 'uri',
+  Base64 = 'base64',
+  DataUrl = 'dataUrl'
 }
 
 //
@@ -404,7 +381,7 @@ export interface ClipboardWrite {
 }
 
 export interface ClipboardRead {
-  type: "string" | "url" | "image";
+  type: 'string' | 'url' | 'image';
 }
 
 export interface ClipboardReadResult {
@@ -424,7 +401,7 @@ export interface DevicePlugin extends Plugin {
   getLanguageCode(): Promise<DeviceLanguageCodeResult>;
 }
 
-export type OperatingSystem = "ios" | "android" | "windows" | "mac" | "unknown";
+export type OperatingSystem = 'ios' | 'android' | 'windows' | 'mac' | 'unknown';
 
 export interface DeviceInfo {
   /**
@@ -434,7 +411,7 @@ export interface DeviceInfo {
   /**
    * The device platform (lowercase).
    */
-  platform: "ios" | "android" | "electron" | "web";
+  platform: 'ios' | 'android' | 'electron' | 'web';
   /**
    * The UUID of the device as available to the app. This identifier may change
    * on modern mobile platforms that only allow per-app install UUIDs.
@@ -575,33 +552,33 @@ export enum FilesystemDirectory {
   /**
    * The Application directory
    */
-  Application = "APPLICATION",
+  Application = 'APPLICATION',
   /**
    * The Documents directory
    */
-  Documents = "DOCUMENTS",
+  Documents = 'DOCUMENTS',
   /**
    * The Data directory
    */
-  Data = "DATA",
+  Data = 'DATA',
   /**
    * The Cache directory
    */
-  Cache = "CACHE",
+  Cache = 'CACHE',
   /**
    * The external directory (Android only)
    */
-  External = "EXTERNAL",
+  External = 'EXTERNAL',
   /**
    * The external storage directory (Android only)
    */
-  ExternalStorage = "EXTERNAL_STORAGE"
+  ExternalStorage = 'EXTERNAL_STORAGE'
 }
 
 export enum FilesystemEncoding {
-  UTF8 = "utf8",
-  ASCII = "ascii",
-  UTF16 = "utf16"
+  UTF8 = 'utf8',
+  ASCII = 'ascii',
+  UTF16 = 'utf16'
 }
 
 export interface FileWriteOptions {
@@ -773,13 +750,20 @@ export interface RenameOptions extends CopyOptions {}
 export interface FileReadResult {
   data: string;
 }
-export interface FileDeleteResult {}
-export interface FileWriteResult {}
-export interface FileAppendResult {}
-export interface MkdirResult {}
-export interface RmdirResult {}
-export interface RenameResult {}
-export interface CopyResult {}
+export interface FileDeleteResult {
+}
+export interface FileWriteResult {
+}
+export interface FileAppendResult {
+}
+export interface MkdirResult {
+}
+export interface RmdirResult {
+}
+export interface RenameResult {
+}
+export interface CopyResult {
+}
 export interface ReaddirResult {
   files: string[];
 }
@@ -800,17 +784,12 @@ export interface GeolocationPlugin extends Plugin {
   /**
    * Get the current GPS location of the device
    */
-  getCurrentPosition(
-    options?: GeolocationOptions
-  ): Promise<GeolocationPosition>;
+  getCurrentPosition(options?: GeolocationOptions): Promise<GeolocationPosition>;
   /**
    * Set up a watch for location changes. Note that watching for location changes
    * can consume a large amount of energy. Be smart about listening only when you need to.
    */
-  watchPosition(
-    options: GeolocationOptions,
-    callback: GeolocationWatchCallback
-  ): CallbackID;
+  watchPosition(options: GeolocationOptions, callback: GeolocationWatchCallback): CallbackID;
 
   /**
    * Clear a given watch
@@ -875,10 +854,7 @@ export interface GeolocationOptions {
   requireAltitude?: boolean; // default: false
 }
 
-export type GeolocationWatchCallback = (
-  position: GeolocationPosition,
-  err?: any
-) => void;
+export type GeolocationWatchCallback = (position: GeolocationPosition, err?: any) => void;
 
 //
 
@@ -917,9 +893,9 @@ export interface HapticsImpactOptions {
 }
 
 export enum HapticsImpactStyle {
-  Heavy = "HEAVY",
-  Medium = "MEDIUM",
-  Light = "LIGHT"
+  Heavy = 'HEAVY',
+  Medium = 'MEDIUM',
+  Light = 'LIGHT'
 }
 
 export interface HapticsNotificationOptions {
@@ -927,9 +903,9 @@ export interface HapticsNotificationOptions {
 }
 
 export enum HapticsNotificationType {
-  SUCCESS = "SUCCESS",
-  WARNING = "WARNING",
-  ERROR = "ERROR"
+  SUCCESS = 'SUCCESS',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR'
 }
 
 export interface VibrateOptions {
@@ -965,22 +941,10 @@ export interface KeyboardPlugin extends Plugin {
    */
   setResizeMode(options: KeyboardResizeOptions): Promise<void>;
 
-  addListener(
-    eventName: "keyboardWillShow",
-    listenerFunc: (info: KeyboardInfo) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "keyboardDidShow",
-    listenerFunc: (info: KeyboardInfo) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "keyboardWillHide",
-    listenerFunc: () => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "keyboardDidHide",
-    listenerFunc: () => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'keyboardWillShow', listenerFunc: (info: KeyboardInfo) => void): PluginListenerHandle;
+  addListener(eventName: 'keyboardDidShow', listenerFunc: (info: KeyboardInfo) => void): PluginListenerHandle;
+  addListener(eventName: 'keyboardWillHide', listenerFunc: () => void): PluginListenerHandle;
+  addListener(eventName: 'keyboardDidHide', listenerFunc: () => void): PluginListenerHandle;
 }
 
 export interface KeyboardInfo {
@@ -992,8 +956,8 @@ export interface KeyboardStyleOptions {
 }
 
 export enum KeyboardStyle {
-  Dark = "DARK",
-  Light = "LIGHT"
+  Dark = 'DARK',
+  Light = 'LIGHT'
 }
 
 export interface KeyboardResizeOptions {
@@ -1001,10 +965,10 @@ export interface KeyboardResizeOptions {
 }
 
 export enum KeyboardResize {
-  Body = "body",
-  Ionic = "ionic",
-  Native = "native",
-  None = "none"
+  Body = 'body',
+  Ionic = 'ionic',
+  Native = 'native',
+  None = 'none'
 }
 
 //
@@ -1017,8 +981,8 @@ export interface LocalNotificationPendingList {
   notifications: LocalNotificationRequest[];
 }
 
-export interface LocalNotificationScheduleResult
-  extends LocalNotificationPendingList {}
+export interface LocalNotificationScheduleResult extends LocalNotificationPendingList {
+}
 
 export interface LocalNotificationActionType {
   id: string;
@@ -1076,22 +1040,22 @@ export interface LocalNotification {
    * iOS 12+ only: set the summary argument for notification grouping
    */
   summaryArgument?: string;
+  /**
+   * Android only: set the group identifier for notification grouping, like
+   * threadIdentifier on iOS.
+   */
   group?: string;
+  /**
+   * Android only: designate this notification as the summary for a group
+   * (should be used with the `group` property).
+   */
   groupSummary?: boolean;
 }
 
 export interface LocalNotificationSchedule {
   at?: Date;
   repeats?: boolean;
-  every?:
-    | "year"
-    | "month"
-    | "two-weeks"
-    | "week"
-    | "day"
-    | "hour"
-    | "minute"
-    | "second";
+  every?: 'year'|'month'|'two-weeks'|'week'|'day'|'hour'|'minute'|'second';
   count?: number;
   on?: {
     year?: number;
@@ -1116,24 +1080,15 @@ export interface LocalNotificationEnabledResult {
 }
 
 export interface LocalNotificationsPlugin extends Plugin {
-  schedule(options: {
-    notifications: LocalNotification[];
-  }): Promise<LocalNotificationScheduleResult>;
+  schedule(options: { notifications: LocalNotification[] }): Promise<LocalNotificationScheduleResult>;
   getPending(): Promise<LocalNotificationPendingList>;
-  registerActionTypes(options: {
-    types: LocalNotificationActionType[];
-  }): Promise<void>;
+  registerActionTypes(options: { types: LocalNotificationActionType[] }): Promise<void>;
   cancel(pending: LocalNotificationPendingList): Promise<void>;
   areEnabled(): Promise<LocalNotificationEnabledResult>;
-  addListener(
-    eventName: "localNotificationReceived",
-    listenerFunc: (notification: LocalNotification) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "localNotificationActionPerformed",
-    listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotification) => void): PluginListenerHandle;
+  addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void): PluginListenerHandle;
 }
+
 
 //
 
@@ -1195,9 +1150,9 @@ export interface ActionSheetOptions {
 }
 
 export enum ActionSheetOptionStyle {
-  Default = "DEFAULT",
-  Destructive = "DESTRUCTIVE",
-  Cancel = "CANCEL"
+  Default = 'DEFAULT',
+  Destructive = 'DESTRUCTIVE',
+  Cancel = 'CANCEL'
 }
 
 export interface ActionSheetOption {
@@ -1219,22 +1174,14 @@ export interface MotionPlugin extends Plugin {
   /**
    * Listen for accelerometer data
    */
-  addListener(
-    eventName: "accel",
-    listenerFunc: (event: MotionEventResult) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'accel', listenerFunc: (event: MotionEventResult) => void): PluginListenerHandle;
   /**
    * Listen for device orientation change (compass heading, etc.)
    */
-  addListener(
-    eventName: "orientation",
-    listenerFunc: (event: MotionOrientationEventResult) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'orientation', listenerFunc: (event: MotionOrientationEventResult) => void): PluginListenerHandle;
 }
 
-export type MotionWatchOrientationCallback = (
-  accel: MotionOrientationEventResult
-) => void;
+export type MotionWatchOrientationCallback = (accel: MotionOrientationEventResult) => void;
 export type MotionWatchAccelCallback = (accel: MotionEventResult) => void;
 
 export interface MotionOrientationEventResult {
@@ -1262,6 +1209,7 @@ export interface MotionEventResult {
   interval: number;
 }
 
+
 //
 
 export interface NetworkPlugin extends Plugin {
@@ -1273,15 +1221,12 @@ export interface NetworkPlugin extends Plugin {
   /**
    * Listen for network status change events
    */
-  addListener(
-    eventName: "networkStatusChange",
-    listenerFunc: (status: NetworkStatus) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'networkStatusChange', listenerFunc: (status: NetworkStatus) => void): PluginListenerHandle;
 }
 
 export interface NetworkStatus {
   connected: boolean;
-  connectionType: "wifi" | "cellular" | "none" | "unknown";
+  connectionType: 'wifi' | 'cellular' | 'none' | 'unknown';
 }
 
 export type NetworkStatusChangeCallback = (status: NetworkStatus) => void;
@@ -1289,12 +1234,12 @@ export type NetworkStatusChangeCallback = (status: NetworkStatus) => void;
 //
 
 export enum PermissionType {
-  Camera = "camera",
-  Photos = "photos",
-  Geolocation = "geolocation",
-  Notifications = "notifications",
-  ClipboardRead = "clipboard-read",
-  ClipboardWrite = "clipboard-write"
+  Camera = 'camera',
+  Photos = 'photos',
+  Geolocation = 'geolocation',
+  Notifications = 'notifications',
+  ClipboardRead = 'clipboard-read',
+  ClipboardWrite = 'clipboard-write'
 }
 
 export interface PermissionsOptions {
@@ -1302,7 +1247,7 @@ export interface PermissionsOptions {
 }
 
 export interface PermissionResult {
-  state: "granted" | "denied" | "prompt";
+  state: 'granted' | 'denied' | 'prompt';
 }
 
 export interface PermissionsPlugin extends Plugin {
@@ -1479,15 +1424,15 @@ export enum PhotosAlbumType {
   /**
    * Album is a "smart" album (such as Favorites or Recently Added)
    */
-  Smart = "smart",
+  Smart = 'smart',
   /**
    * Album is a cloud-shared album
    */
-  Shared = "shared",
+  Shared = 'shared',
   /**
    * Album is a user-created album
    */
-  User = "user"
+  User = 'user'
 }
 
 //
@@ -1502,8 +1447,6 @@ export interface PushNotification {
   data: any;
   click_action?: string;
   link?: string;
-  group?: string;
-  groupSummary?: boolean;
 }
 
 export interface PushNotificationActionPerformed {
@@ -1525,8 +1468,8 @@ export interface PushNotificationChannel {
   name: string;
   description: string;
   sound: string;
-  importance: 1 | 2 | 3 | 4 | 5;
-  visibility?: -1 | 0 | 1;
+  importance: 1 | 2 | 3 | 4 | 5;
+  visibility?: -1 | 0 | 1 ;
 }
 
 export interface PushNotificationChannelList {
@@ -1536,29 +1479,15 @@ export interface PushNotificationChannelList {
 export interface PushNotificationsPlugin extends Plugin {
   register(): Promise<void>;
   getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
-  removeDeliveredNotifications(
-    delivered: PushNotificationDeliveredList
-  ): Promise<void>;
+  removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;
   createChannel(channel: PushNotificationChannel): Promise<void>;
   deleteChannel(channel: PushNotificationChannel): Promise<void>;
   listChannels(): Promise<PushNotificationChannelList>;
-  addListener(
-    eventName: "registration",
-    listenerFunc: (token: PushNotificationToken) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "registrationError",
-    listenerFunc: (error: any) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "pushNotificationReceived",
-    listenerFunc: (notification: PushNotification) => void
-  ): PluginListenerHandle;
-  addListener(
-    eventName: "pushNotificationActionPerformed",
-    listenerFunc: (notification: PushNotificationActionPerformed) => void
-  ): PluginListenerHandle;
+  addListener(eventName: 'registration', listenerFunc: (token: PushNotificationToken) => void): PluginListenerHandle;
+  addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
+  addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;
+  addListener(eventName: 'pushNotificationActionPerformed', listenerFunc: (notification: PushNotificationActionPerformed) => void): PluginListenerHandle;
 }
 
 //
@@ -1617,9 +1546,9 @@ export interface SplashScreenShowOptions {
    */
   fadeOutDuration?: number;
   /**
-   * How long to show the splash screen when autoHide is enabled (in ms)
-   * Default is 3000ms
-   */
+  * How long to show the splash screen when autoHide is enabled (in ms)
+  * Default is 3000ms
+  */
   showDuration?: number;
 }
 
@@ -1663,11 +1592,11 @@ export enum StatusBarStyle {
   /**
    * Light text for dark backgrounds.
    */
-  Dark = "DARK",
+  Dark = 'DARK',
   /**
    * Dark text for light backgrounds.
    */
-  Light = "LIGHT"
+  Light = 'LIGHT'
 }
 
 export interface StatusBarBackgroundColorOptions {
@@ -1688,7 +1617,7 @@ export interface StoragePlugin extends Plugin {
   /**
    * Set the value for the given key
    */
-  set(options: { key: string; value: string }): Promise<void>;
+  set(options: { key: string, value: string }): Promise<void>;
   /**
    * Remove the value for this key (if any)
    */
@@ -1709,8 +1638,8 @@ export interface ToastPlugin extends Plugin {
 
 export interface ToastShowOptions {
   text: string;
-  duration?: "short" | "long";
-  position?: "top" | "center" | "bottom";
+  duration?: 'short' | 'long';
+  position?: 'top' | 'center' | 'bottom';
 }
 
 export interface WebViewPlugin extends Plugin {


### PR DESCRIPTION
This PR adds `group` and `groupSummary` options in `LocalNotifications.schedule()`, which allows you to group notifications together on Android.

I noticed a TODO comment in `LocalNotificationManager.Build` for groups, which says to implement `setGroup`, `setGroupSummary`, and `setNumber`. This PR only implements the first 2, should I also add `setNumber`?