### PR TITLE
Android LocalNotifications: Add extra data to notification

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -26,6 +26,7 @@ import org.json.JSONObject;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Iterator;
 
 /**
  * Contains implementations for all notification actions
@@ -165,6 +166,29 @@ public class LocalNotificationManager {
     String group = localNotification.getGroup();
     if (group != null) {
       mBuilder.setGroup(group);
+    }
+
+    JSObject extra = localNotification.getExtra();
+    if (extra != null) {
+      Iterator<String> keys = extra.keys();
+      Bundle bundle = new Bundle();
+
+      while (keys.hasNext()) {
+        String key = keys.next();
+
+        try {
+          Object value = extra.get(key);
+
+          if (value != null) {
+            bundle.putString(key, value.toString());
+          }
+        } catch (JSONException e) {
+          call.reject("Failed to get extras at key '" + key + "': " + e.getMessage());
+          return;
+        }
+      }
+
+      mBuilder.addExtras(bundle);
     }
 
     mBuilder.setVisibility(Notification.VISIBILITY_PRIVATE);

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1031,7 +1031,7 @@ export interface LocalNotification {
   smallIcon?: string;
   attachments?: LocalNotificationAttachment[];
   actionTypeId?: string;
-  extra?: any;
+  extra?: Record<string, string>;
   /**
    * iOS only: set the thread identifier for notification grouping
    */

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1031,7 +1031,7 @@ export interface LocalNotification {
   smallIcon?: string;
   attachments?: LocalNotificationAttachment[];
   actionTypeId?: string;
-  extra?: Record<string, string>;
+  extra?: Record<string, any>;
   /**
    * iOS only: set the thread identifier for notification grouping
    */


### PR DESCRIPTION
There is an `extra` property on the `LocalNotification` class, but it is not used anywhere. This PR adds it to the `extras` bundle when building a Notification object.