### PR TITLE
iOS LocalNotifications: Added threadIdentifier and summaryArgument options

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1032,6 +1032,12 @@ export interface LocalNotification {
   attachments?: LocalNotificationAttachment[];
   actionTypeId?: string;
   extra?: any;
+  /**
+   * iOS only: set the thread identifier and summary argument for notification
+   * grouping
+   */
+  threadIdentifier?: string;
+  summaryArgument?: string;
 }
 
 export interface LocalNotificationSchedule {

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -165,6 +165,8 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     let sound = notification["sound"] as? String
     let attachments = notification["attachments"] as? JSArray
     let extra = notification["extra"] as? JSObject ?? [:]
+    let threadIdentifier = notification["threadIdentifier"] as? String
+    let summaryArgument = notification["summaryArgument"] as? String
     
     let content = UNMutableNotificationContent()
     content.title = NSString.localizedUserNotificationString(forKey: title, arguments: nil)
@@ -174,6 +176,14 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     content.userInfo = extra
     if actionTypeId != nil {
       content.categoryIdentifier = actionTypeId!
+    }
+
+    if let threadIdentifier = threadIdentifier {
+      content.threadIdentifier = threadIdentifier
+    }
+
+    if let summaryArgument = summaryArgument, #available(iOS 12, *) {
+      content.summaryArgument = summaryArgument
     }
     
     if sound != nil {


### PR DESCRIPTION
Similar to #2385, this PR adds options to control the grouping of local notifications.