### PR TITLE
feat(ios): Allow to configure WebView's ScrollView's content inset

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -73,9 +73,14 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
 
     webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
     webView?.scrollView.bounces = false
-    
-    webView?.scrollView.contentInsetAdjustmentBehavior = .never
-    
+    let availableInsets = ["automatic", "scrollableAxes", "never", "always"]
+    if let contentInset = (capConfig.getValue("ios.contentInset") as? String),
+      let index = availableInsets.firstIndex(of: contentInset) {
+      webView?.scrollView.contentInsetAdjustmentBehavior = UIScrollView.ContentInsetAdjustmentBehavior.init(rawValue: index)!
+    } else {
+      webView?.scrollView.contentInsetAdjustmentBehavior = .never
+    }
+
     webView?.uiDelegate = self
     webView?.navigationDelegate = self
     if let allowsLinkPreview = (capConfig.getValue("ios.allowsLinkPreview") as? Bool) {

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -110,6 +110,11 @@ The current ones you might configure are:
     "appendUserAgent": "string to append for iOS",
     // Background color of Capacitor WebView for iOS only
     "backgroundColor": "#ffffffff",
+    // Configure the WebView's UIScrollView's content inset behavior
+    // Default is never
+    // Possible values are "automatic", "scrollableAxes", "never" and "always"
+    // https://developer.apple.com/documentation/uikit/uiscrollview/contentinsetadjustmentbehavior
+    "contentInset": "always",
     // Configure the Swift version to be used for Cordova plugins.
     // Default is 4.0
     "cordovaSwiftVersion": "3.0",


### PR DESCRIPTION
We are setting the WebView's ScrollView's content inset to never, but some users might not want that.
This PR makes possible to configure the value from `capacitor.config.json` file

Closes #1947 