### PR TITLE
fix(cli): Avoid AndroidManifest.xml not found error on add

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -414,7 +414,9 @@ ${applicationXMLEntries.join('\n')}
 ${rootXMLEntries.join('\n')}
 </manifest>`;
   content = content.replace(new RegExp(('$PACKAGE_NAME').replace('$', '\\$&'), 'g'), config.app.appId);
-  await writeFileAsync(manifestPath, content);
+  if (existsSync(manifestPath)) {
+    await writeFileAsync(manifestPath, content);
+  }
 }
 
 function getPathParts(path: string) {


### PR DESCRIPTION
On add command, copy tries to write the AndroidManifest.xml file, but it doesn't exist yet and shows an error.
This PR checks if the file exists before writing to avoid that error. 