### PR TITLE
chore(circleci): update Xcode and remove install-cocoapods job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
   run-cli-tests:
     macos:
-      xcode: "11.3.1"
+      xcode: "11.1.0"
     working_directory: /tmp/workspace
 
     steps:
@@ -29,7 +29,7 @@ jobs:
 
   build-ios:
     macos:
-      xcode: "10.0"
+      xcode: "11.1.0"
     working_directory: /tmp/workspace
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,19 +7,9 @@ jobs:
     steps:
       - checkout
 
-  install-cocoapods:
-    macos:
-      xcode: "10.0"
-    working_directory: /tmp/workspace
-    steps:
-      - run:
-          name: Install CocoaPods
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-
   run-cli-tests:
     macos:
-      xcode: "10.0"
+      xcode: "11.1.0"
     working_directory: /tmp/workspace
 
     steps:
@@ -65,12 +55,8 @@ workflows:
   node-ios-android:
     jobs:
       - get-cli
-      - install-cocoapods
       - run-cli-tests:
           requires:
             - get-cli
-            - install-cocoapods
-      - build-ios:
-          requires:
-            - install-cocoapods
+      - build-ios
       - build-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
   run-cli-tests:
     macos:
-      xcode: "11.1.0"
+      xcode: "11.3.1"
     working_directory: /tmp/workspace
 
     steps:


### PR DESCRIPTION
Since we are dropping Xcode 10 support, make circleci use Xcode 11. And as Xcode 11 image includes CocoaPods 1.8.0, we no longer need the install-cocoapods job, that should make tests much faster