### PR TITLE
chore(cli): fix tests for newer node versions

### DIFF
--- a/cli/test/util.ts
+++ b/cli/test/util.ts
@@ -88,7 +88,10 @@ export async function makeAppDir(monoRepoLike: boolean = false) {
   await runCommand(`cd "${rootDir}" && npm install --save ${corePath} ${cliPath}`);
 
   // Make a fake cordova plugin
-  await makeCordovaPlugin(appDir);
+  const cordovaPluginPath = join(tmpDir, CORDOVA_PLUGIN_ID);
+  await makeCordovaPlugin(cordovaPluginPath);
+
+  await runCommand(`cd "${rootDir}" && npm install --save ${cordovaPluginPath}`);
 
   return {
     ...appDirObj,
@@ -180,14 +183,13 @@ Pod::Spec.new do |s|
   s.dependency 'CapacitorCordova'
 end`;
 
-async function makeCordovaPlugin(appDir: string) {
-  const cordovaPluginPath = join(appDir, 'node_modules', CORDOVA_PLUGIN_ID);
+async function makeCordovaPlugin(cordovaPluginPath: string) {
   const iosPath = join(cordovaPluginPath, 'src', 'ios');
   const androidPath = join(cordovaPluginPath, 'android/com/getcapacitor');
   await mkdirs(cordovaPluginPath);
   await writeFileAsync(join(cordovaPluginPath, 'plugin.js'), CODOVA_PLUGIN_JS);
   await writeFileAsync(join(cordovaPluginPath, 'plugin.xml'), CORDOVA_PLUGIN_XML);
-  await writeFileAsync(join(cordovaPluginPath, 'package.json'), JSON.stringify(CORDOVA_PLUGIN_PACKAGE));
+  await writeFileAsync(join(cordovaPluginPath, 'package.json'), CORDOVA_PLUGIN_PACKAGE);
   await mkdirs(iosPath);
   await mkdirs(androidPath);
   await writeFileAsync(join(iosPath, 'CoolPlugin.m'), '');


### PR DESCRIPTION
The tests create a cordova plugin right in node_modules.
In some node versions, the plugin was being removed from node_modules after adding the platform because it was not installed.

So, this PR changes the tests to create the plugin in another folder and install it with npm install.