### PR TITLE
feat(Filesystem): Remove createIntermediateDirectories from MkdirOptions

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -326,10 +326,6 @@ public class Filesystem extends Plugin {
     saveCall(call);
     String path = call.getString("path");
     String directory = getDirectoryParameter(call);
-    boolean intermediate = call.getBoolean("createIntermediateDirectories", false).booleanValue();
-    if (call.getBoolean("createIntermediateDirectories") != null) {
-      Log.w(getLogTag(),"createIntermediateDirectories is deprecated, use recursive");
-    }
     boolean recursive = call.getBoolean("recursive", false).booleanValue();
 
     File fileObject = getFileObject(path, directory);
@@ -342,7 +338,7 @@ public class Filesystem extends Plugin {
     if (!isPublicDirectory(directory)
             || isStoragePermissionGranted(PluginRequestCodes.FILESYSTEM_REQUEST_WRITE_FOLDER_PERMISSIONS, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
       boolean created = false;
-      if (intermediate || recursive) {
+      if (recursive) {
         created = fileObject.mkdirs();
       } else {
         created = fileObject.mkdir();

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -664,12 +664,6 @@ export interface MkdirOptions {
    */
   directory?: FilesystemDirectory;
   /**
-   * @deprecated - use recursive
-   * Whether to create any missing parent directories as well
-   * Defaults to false
-   */
-  createIntermediateDirectories?: boolean;
-  /**
    * Whether to create any missing parent directories as well.
    * Defaults to false
    */

--- a/core/src/web/filesystem.ts
+++ b/core/src/web/filesystem.ts
@@ -246,12 +246,7 @@ export class FilesystemPluginWeb extends WebPlugin implements FilesystemPlugin {
    */
   async mkdir(options: MkdirOptions): Promise<MkdirResult> {
     const path: string = this.getPath(options.directory, options.path);
-    const createIntermediateDirectories = options.createIntermediateDirectories;
-    if (options.createIntermediateDirectories !== undefined) {
-      console.warn('createIntermediateDirectories is deprecated, use recursive');
-    }
-    const recursive = options.recursive;
-    const doRecursive = (createIntermediateDirectories || recursive);
+    const doRecursive = options.recursive;
     const parentPath = path.substr(0, path.lastIndexOf('/'));
 
     let depth = (path.match(/\//g) || []).length;

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -113,10 +113,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      if (options.createIntermediateDirectories !== undefined) {
-        console.warn('createIntermediateDirectories is deprecated, use recursive');
-      }
-      const doRecursive = options.createIntermediateDirectories || options.recursive;
+      const doRecursive = options.recursive;
       this.NodeFS.mkdir(lookupPath, { recursive: doRecursive }, (err:any) => {
         if(err) {
           reject(err);

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -222,10 +222,6 @@ public class CAPFilesystemPlugin : CAPPlugin {
       return
     }
     
-    let createIntermediateDirectories = call.get("createIntermediateDirectories", Bool.self, false)!
-    if let _ = call.get("createIntermediateDirectories", Bool.self) {
-        CAPLog.print("createIntermediateDirectories is deprecated, use recursive")
-    }
     let recursive = call.get("recursive", Bool.self, false)!
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
     guard let fileUrl = getFileUrl(path, directoryOption) else {
@@ -234,7 +230,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     do {
-      try FileManager.default.createDirectory(at: fileUrl, withIntermediateDirectories: createIntermediateDirectories || recursive, attributes: nil)
+      try FileManager.default.createDirectory(at: fileUrl, withIntermediateDirectories: recursive, attributes: nil)
       call.success()
     } catch let error as NSError {
       handleError(call, error.localizedDescription, error)


### PR DESCRIPTION
createIntermediateDirectories was deprecated in Capacitor 1.3.0 and has been showing a warning if used

removing it for Capacitor 2.0

recursive was implemented in 1.3.0 and has the same effect

closes #2005