### PR TITLE
feat(ios): change native location accuracy values

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
@@ -14,7 +14,7 @@ public struct GeolocationCoords {
 class GetLocationHandler: NSObject, CLLocationManagerDelegate {
   var locationManager = CLLocationManager()
   var call: CAPPluginCall
-  
+
   init(call: CAPPluginCall, options: [String:Any]) {
     self.call = call
     
@@ -23,19 +23,24 @@ class GetLocationHandler: NSObject, CLLocationManagerDelegate {
     // TODO: Allow user to configure accuracy, request/authorization mode
     self.locationManager.delegate = self
     self.locationManager.requestWhenInUseAuthorization()
+    let shouldWatch = options["watch"] as! Bool
     if call.getBool("enableHighAccuracy", false)! {
+      if shouldWatch {
         self.locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
-    } else {
+      } else {
         self.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      }
+    } else {
+      self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
     }
-    
-    if let shouldWatch = options["watch"], shouldWatch as? Bool == true {
+
+    if shouldWatch {
       self.locationManager.startUpdatingLocation()
     } else {
       self.locationManager.requestLocation()
     }
   }
-  
+
   public func stopUpdating() {
     self.locationManager.stopUpdatingLocation()
   }


### PR DESCRIPTION
If `enableHighAccuracy` is set, use `kCLLocationAccuracyBestForNavigation` only for `watchPosition()` and `kCLLocationAccuracyBest` for `getCurrentPosition()`

If `enableHighAccuracy` is not set, use `kCLLocationAccuracyThreeKilometers` for fastest results.

closes #1893 