### PR TITLE
fix(android): allow Share plugin to provide text or url only

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Share.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Share.java
@@ -27,13 +27,18 @@ public class Share extends Plugin {
       return;
     }
     Intent intent = new Intent(Intent.ACTION_SEND);
-    // If they supplied both fields, concat em
-    if (text != null && url != null && url.startsWith("http")) {
-      text = text + " " + url;
-      intent.setTypeAndNormalize("text/plain");
+    if (text != null) {
+      // If they supplied both fields, concat em
+      if (url != null && url.startsWith("http")) {
+        text = text + " " + url;
+      }
       intent.putExtra(Intent.EXTRA_TEXT, text);
-    } else if(url != null) {
-      if (url.startsWith("file:")) {
+      intent.setTypeAndNormalize("text/plain");
+    } else if (url != null) {
+      if (url.startsWith("http")) {
+        intent.putExtra(Intent.EXTRA_TEXT, url);
+        intent.setTypeAndNormalize("text/plain");
+      } else if (url.startsWith("file:")) {
         String type = getMimeType(url);
         intent.setType(type);
         Uri fileUrl = FileProvider.getUriForFile(getActivity(), getContext().getPackageName() + ".fileprovider", new File(Uri.parse(url).getPath()));

--- a/example/src/pages/share/share.html
+++ b/example/src/pages/share/share.html
@@ -17,4 +17,10 @@
   <button (click)="showSharing()" ion-button>
     Show Sharing
   </button>
+  <button (click)="showSharingTextOnly()" ion-button>
+    Show Sharing (text only)
+  </button>
+  <button (click)="showSharingUrlOnly()" ion-button>
+    Show Sharing (url only)
+  </button>
 </ion-content>

--- a/example/src/pages/share/share.ts
+++ b/example/src/pages/share/share.ts
@@ -34,4 +34,18 @@ export class SharePage {
     console.log('Share return', shareRet);
   }
 
+  async showSharingTextOnly() {
+    let shareRet = await Share.share({
+      text: 'Really awesome thing you need to see right meow',
+    });
+    console.log('Share return', shareRet);
+  }
+
+  async showSharingUrlOnly() {
+    let shareRet = await Share.share({
+      url: 'http://ionicframework.com/',
+    });
+    console.log('Share return', shareRet);
+  }
+
 }


### PR DESCRIPTION
Currently, without this fix, either text only or url only sharing does not work.

I added two more buttons on example app to show that now it is working.