### PR TITLE
Add missing instructions to install plugins

### DIFF
--- a/site/docs-md/cordova/using-cordova-plugins.md
+++ b/site/docs-md/cordova/using-cordova-plugins.md
@@ -16,6 +16,7 @@ Simply install your plugin of choice, sync your project, finish any required nat
 
 ```bash
 npm install cordova-plugin-name
+ionic cordova plugin add cordova-plugin-name
 npx cap sync
 ```
 


### PR DESCRIPTION
It seems if you don't use the "ionic cordova plugin add cordova-plugin-name" plugin won't be usable, it will fail with the following warning (example with AppVersion plugin). 

Native: tried calling AppVersion.getAppName, but the AppVersion plugin is not installed.

It seem adding this line of code solves the issue, its also what is stated in the plugin doc : https://ionicframework.com/docs/native/app-version but this document seems to be colliding as it implies just adding vi anpm will be enough