### PR TITLE
fix(LocalNotifications): return proper LocalNotificationScheduleResult on schedule

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -71,7 +71,17 @@ public class LocalNotifications extends Plugin {
     }
     JSONArray ids = manager.schedule(call, localNotifications);
     notificationStorage.appendNotificationIds(localNotifications);
-    call.success(new JSObject().put("ids", ids));
+    JSObject result = new JSObject();
+    JSArray jsArray = new JSArray();
+    for (int i=0; i < ids.length(); i++) {
+      try {
+        JSObject notification = new JSObject().put("id", ids.getString(i));
+        jsArray.put(notification);
+      } catch (Exception ex) {
+      }
+    }
+    result.put("notifications", jsArray);
+    call.success(result);
   }
 
   @PluginMethod()

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -66,7 +66,7 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
     });
 
     return Promise.resolve({
-      notifications: notifications.map(_ => { return { id: '' }; })
+      notifications: options.notifications.map(notification => { return { id: '' + notification.id }; })
     });
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -86,8 +86,13 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       ids.append(request.identifier)
     }
 
+    let ret = ids.map({ (id) -> [String:String] in
+      return [
+        "id": id,
+      ]
+    })
     call.success([
-      "ids": ids
+      "notifications": ret
     ])
   }
   


### PR DESCRIPTION
iOS and Android weren't returning a proper LocalNotificationScheduleResult (according to the types)
On web it was returning a proper LocalNotificationScheduleResult, but didn't include the id.



closes #2152