### PR TITLE
fix(android): Make Modals.showActions non cancelable

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Modals.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Modals.java
@@ -125,6 +125,7 @@ public class Modals extends Plugin {
 
     final ModalsBottomSheetDialogFragment fragment = new ModalsBottomSheetDialogFragment();
     fragment.setOptions(options);
+    fragment.setCancelable(false);
     fragment.setOnSelectedListener(new ModalsBottomSheetDialogFragment.OnSelectedListener() {
       @Override
       public void onSelected(int index) {


### PR DESCRIPTION
showActions is non cancelable on iOS and web, make it non cancelable on Android too to avoid apps hanging on the await 