### PR TITLE
feat(android): Allow plugin methods to crash

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -522,10 +522,11 @@ public class Bridge {
             if (call.isSaved()) {
               saveCall(call);
             }
-          } catch(PluginLoadException | InvalidPluginMethodException | PluginInvocationException ex) {
+          } catch(PluginLoadException | InvalidPluginMethodException ex) {
             Log.e(LOG_TAG, "Unable to execute plugin method", ex);
-          } catch(Exception ex) {
+          } catch (Exception ex) {
             Log.e(LOG_TAG, "Serious error executing plugin", ex);
+            throw new RuntimeException(ex);
           }
         }
       };

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
@@ -84,7 +84,8 @@ public class PluginHandle {
    */
   public void invoke(String methodName, PluginCall call) throws PluginLoadException,
                                                                 InvalidPluginMethodException,
-                                                                PluginInvocationException {
+                                                                InvocationTargetException,
+                                                                IllegalAccessException {
     if(this.instance == null) {
       // Can throw PluginLoadException
       this.load();
@@ -95,11 +96,8 @@ public class PluginHandle {
       throw new InvalidPluginMethodException("No method " + methodName + " found for plugin " + pluginClass.getName());
     }
 
-    try {
-      methodMeta.getMethod().invoke(this.instance, call);
-    } catch(InvocationTargetException | IllegalAccessException ex) {
-      throw new PluginInvocationException("Unable to invoke method " + methodName + " on plugin " + pluginClass.getName(), ex);
-    }
+    methodMeta.getMethod().invoke(this.instance, call);
+
   }
 
   /**


### PR DESCRIPTION
Since Capacitor uses reflection it was catching any exception the reflection could cause, but that was also hiding any possible crash a plugin might have and make it impossible for crash reporters such as Crashlytics to report those issues.

This PR changes the `invoke` exception handling to not catch `InvocationTargetException` nor `IllegalAccessException`, and throw them as a `RuntimeException`

closes #2150