### PR TITLE
feat(Filesystem): remove FilesystemDirectory.Application

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -65,8 +65,6 @@ public class Filesystem extends Plugin {
   private File getDirectory(String directory) {
     Context c = bridge.getContext();
     switch(directory) {
-      case "APPLICATION":
-        return c.getFilesDir();
       case "DOCUMENTS":
         return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
       case "DATA":

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -567,10 +567,6 @@ export interface FilesystemPlugin extends Plugin {
 
 export enum FilesystemDirectory {
   /**
-   * The Application directory
-   */
-  Application = 'APPLICATION',
-  /**
    * The Documents directory
    */
   Documents = 'DOCUMENTS',

--- a/example/src/pages/filesystem/filesystem.ts
+++ b/example/src/pages/filesystem/filesystem.ts
@@ -109,7 +109,7 @@ export class FilesystemPage {
     try {
       let ret = await Plugins.Filesystem.getUri({
         path: 'text.txt',
-        directory: FilesystemDirectory.Application
+        directory: FilesystemDirectory.Data
       });
       alert(ret.uri);
     } catch(e) {

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -12,8 +12,6 @@ public class CAPFilesystemPlugin : CAPPlugin {
     switch directory {
     case "DOCUMENTS":
       return .documentDirectory
-    case "APPLICATION":
-      return .applicationDirectory
     case "CACHE":
       return .cachesDirectory
     default:

--- a/site/docs-md/apis/filesystem/index.md
+++ b/site/docs-md/apis/filesystem/index.md
@@ -139,20 +139,6 @@ async rename() {
 
 async copy() {
   try {
-    // This example copies a file from the app directory to the documents directory
-    let ret = await Filesystem.copy({
-      from: 'assets/icon.png',
-      to: 'icon.png',
-      directory: FilesystemDirectory.Application,
-      toDirectory: FilesystemDirectory.Documents
-    });
-  } catch(e) {
-    console.error('Unable to copy file', e);
-  }
-}
-
-async copy() {
-  try {
     // This example copies a file within the documents directory
     let ret = await Filesystem.copy({
       from: 'text.txt',


### PR DESCRIPTION
It has never worked as intended, so I'm removing it.

If using it on Android, just replace it with `FilesystemDirectory.Data` as it was pointing to the same native folder

closes #2312 

