### PR TITLE
feat: add requestPermission to PushNotifications and LocalNotifications

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -85,6 +85,13 @@ public class LocalNotifications extends Plugin {
   }
 
   @PluginMethod()
+  public void requestPermission(PluginCall call) {
+    JSObject result = new JSObject();
+    result.put("granted", true);
+    call.success(result);
+  }
+
+  @PluginMethod()
   public void cancel(PluginCall call) {
     manager.cancel(call);
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -104,6 +104,11 @@ public class PushNotifications extends Plugin {
         sendError(e.getLocalizedMessage());
       }
     });
+    call.success();
+  }
+
+  @PluginMethod()
+  public void requestPermission(PluginCall call) {
     JSObject result = new JSObject();
     result.put("granted", true);
     call.success(result);

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1081,12 +1081,17 @@ export interface LocalNotificationEnabledResult {
   value: boolean;
 }
 
+export interface NotificationPermissionResponse {
+  granted: boolean;
+}
+
 export interface LocalNotificationsPlugin extends Plugin {
   schedule(options: { notifications: LocalNotification[] }): Promise<LocalNotificationScheduleResult>;
   getPending(): Promise<LocalNotificationPendingList>;
   registerActionTypes(options: { types: LocalNotificationActionType[] }): Promise<void>;
   cancel(pending: LocalNotificationPendingList): Promise<void>;
   areEnabled(): Promise<LocalNotificationEnabledResult>;
+  requestPermission(): Promise<NotificationPermissionResponse>;
   addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotification) => void): PluginListenerHandle;
   addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void): PluginListenerHandle;
 }
@@ -1489,12 +1494,9 @@ export interface PushNotificationChannelList {
   channels: PushNotificationChannel[];
 }
 
-export interface PushNotificationRegistrationResponse {
-  granted: boolean;
-}
-
 export interface PushNotificationsPlugin extends Plugin {
-  register(): Promise<PushNotificationRegistrationResponse>;
+  register(): Promise<void>;
+  requestPermission(): Promise<NotificationPermissionResponse>;
   getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
   removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -6,7 +6,8 @@ import {
   LocalNotificationPendingList,
   LocalNotificationActionType,
   LocalNotification,
-  LocalNotificationScheduleResult
+  LocalNotificationScheduleResult,
+  NotificationPermissionResponse
 } from '../core-plugin-definitions';
 
 import { PermissionsRequestResult } from '../definitions';
@@ -95,6 +96,17 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
     throw new Error('Method not implemented.');
   }
 
+  requestPermission(): Promise<NotificationPermissionResponse> {
+    return new Promise((resolve) => {
+      Notification.requestPermission((result) => {
+        let granted = true;
+        if (result === 'denied' || result === 'default') {
+          granted = false;
+        }
+        resolve({granted});
+      });
+    });
+  }
 
   requestPermissions(): Promise<PermissionsRequestResult> {
     return new Promise((resolve, reject) => {

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -22,15 +22,8 @@ public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationC
    * Request permissions to send notifications
    */
   public func requestPermissions(with completion: ((Bool, Error?) -> Void)? = nil) {
-    // Override point for customization after application launch.
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options:[.badge, .alert, .sound]) { (granted, error) in
-        if granted {
-            DispatchQueue.main.async {
-              UIApplication.shared.registerForRemoteNotifications()
-            }
-        }
-
         completion?(granted, error)
     }
   }

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -84,6 +84,7 @@ CAP_PLUGIN(CAPKeyboard, "Keyboard",
 
 CAP_PLUGIN(CAPLocalNotificationsPlugin, "LocalNotifications",
   CAP_PLUGIN_METHOD(schedule, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(requestPermission, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(cancel, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getPending, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(registerActionTypes, CAPPluginReturnPromise);
@@ -107,6 +108,7 @@ CAP_PLUGIN(CAPPermissionsPlugin, "Permissions",
 
 CAP_PLUGIN(CAPPushNotificationsPlugin, "PushNotifications",
   CAP_PLUGIN_METHOD(register, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(requestPermission, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getDeliveredNotifications, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeDeliveredNotifications, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeAllDeliveredNotifications, CAPPluginReturnPromise);

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -37,9 +37,6 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       call.error("Must provide notifications array as notifications option")
       return
     }
-    
-    self.bridge.notificationsDelegate.requestPermissions()
-    
     var ids = [String]()
     
     for notification in notifications {
@@ -95,7 +92,20 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       "notifications": ret
     ])
   }
-  
+
+  /**
+   * Request notification permission
+   */
+  @objc func requestPermission(_ call: CAPPluginCall) {
+    self.bridge.notificationsDelegate.requestPermissions() { granted, error in
+        guard error == nil else {
+            call.error(error!.localizedDescription)
+            return
+        }
+        call.success(["granted": granted])
+    }
+  }
+
   /**
    * Cancel notifications by id
    */

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -23,12 +23,21 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    * Register for push notifications
    */
   @objc func register(_ call: CAPPluginCall) {
+    DispatchQueue.main.async {
+      UIApplication.shared.registerForRemoteNotifications()
+    }
+    call.success()
+  }
+
+  /**
+   * Request notification permission
+   */
+  @objc func requestPermission(_ call: CAPPluginCall) {
     self.bridge.notificationsDelegate.requestPermissions() { granted, error in
         guard error == nil else {
             call.error(error!.localizedDescription)
             return
         }
-
         call.success(["granted": granted])
     }
   }


### PR DESCRIPTION
Added a new `requestPermission` method to `PushNotifications` and `LocalNotifications`
On Android it just return `granted: true` since there are no permissions needed

Register and schedule no longer prompt for permissions, `requestPermission` have to be called first.

closes #1797
closes #2406