### PR TITLE
chore: make deploy script publish Android before iOS

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,5 +26,5 @@ git push --follow-tags origin master
 #rm -rf capacitor-ios
 
 # Do the actual native deploys second, because they require tags/releases in github
-bash scripts/deploy/pods.sh
 bash scripts/deploy/android.sh
+bash scripts/deploy/pods.sh


### PR DESCRIPTION
iOS script sometimes fails on Capacitor as it depends on CapcitorCordova, and if it fails, Android is not published.
Publish Android first to avoid forgetting to manually publish it if it failed.