### PR TITLE
feat(clipboard): remove Clipboard.read() options

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
@@ -29,7 +29,7 @@ public class Clipboard extends Plugin {
     if(strVal != null) {
       data = ClipData.newPlainText(label, strVal);
     } else if(imageVal != null) {
-      // Does nothing
+      data = ClipData.newPlainText(label, imageVal);
     } else if(urlVal != null) {
       data = ClipData.newPlainText(label, urlVal);
     }
@@ -45,24 +45,26 @@ public class Clipboard extends Plugin {
   public void read(PluginCall call) {
     Context c = this.getContext();
 
-    String type = call.getString("type");
     ClipboardManager clipboard = (ClipboardManager)
         c.getSystemService(Context.CLIPBOARD_SERVICE);
 
+    CharSequence value = "";
     if(clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
       Log.d(getLogTag(), "Got plaintxt");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-
-      JSObject ret = new JSObject();
-      ret.put("value", item.getText());
-      call.success(ret);
+      value = item.getText();
     } else {
       Log.d(getLogTag(), "Not plaintext!");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-      String value = item.coerceToText(this.getContext()).toString();
-      JSObject ret = new JSObject();
-      ret.put("value", value);
-      call.success(ret);
+      value = item.coerceToText(this.getContext()).toString();
     }
+    JSObject ret = new JSObject();
+    String type = "text/plain";
+    ret.put("value", value != null ? value : "");
+    if (value != null && value.toString().startsWith("data:")) {
+      type = value.toString().split(";")[0].split(":")[1];
+    }
+    ret.put("type", type);
+    call.success(ret);
   }
 }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -380,7 +380,7 @@ export interface ClipboardPlugin extends Plugin {
   /**
    * Read a value from the clipboard (the "paste" action)
    */
-  read(options: ClipboardRead): Promise<ClipboardReadResult>;
+  read(): Promise<ClipboardReadResult>;
 }
 
 export interface ClipboardWrite {
@@ -390,12 +390,9 @@ export interface ClipboardWrite {
   label?: string; // Android only
 }
 
-export interface ClipboardRead {
-  type: 'string' | 'url' | 'image';
-}
-
 export interface ClipboardReadResult {
   value: string;
+  type: string;
 }
 
 //


### PR DESCRIPTION
removed the Clipboard.read() options (type)

Now the keyboard will always return what it has, and instead of the user passing a type, it returns a type with the mime type of the data the clipboard has.

also writes image data as plain text

closes #2365
closes https://github.com/ionic-team/capacitor/issues/375