### PR TITLE
feat: Allow plugins to reject with a string code

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -84,6 +84,10 @@ public class PluginCall {
   }
 
   public void error(String msg, Exception ex) {
+    error(msg, null, ex);
+  }
+
+  public void error(String msg, String code, Exception ex) {
     PluginResult errorResult = new PluginResult();
 
     if(ex != null) {
@@ -92,6 +96,7 @@ public class PluginCall {
 
     try {
       errorResult.put("message", msg);
+      errorResult.put("code", code);
     } catch (Exception jsonEx) {
       Log.e(LogUtils.getPluginTag(), jsonEx.getMessage());
     }
@@ -105,6 +110,10 @@ public class PluginCall {
 
   public void reject(String msg, Exception ex) {
     error(msg, ex);
+  }
+
+  public void reject(String msg, String code) {
+    error(msg, code, null);
   }
 
   public void reject(String msg) {

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -418,7 +418,7 @@ enum BridgeError: Error {
         }
       }, error: {(error: CAPPluginCallError?) -> Void in
         let description = error?.error?.localizedDescription ?? ""
-        self.toJsError(error: JSResultError(call: call, message: error!.message, errorMessage: description, error: error!.data))
+        self.toJsError(error: JSResultError(call: call, message: error!.message, errorMessage: description, error: error!.data, code: error!.code))
       })!
       
       plugin.perform(selector, with: pluginCall)

--- a/ios/Capacitor/Capacitor/CAPPluginCall.h
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.h
@@ -10,10 +10,11 @@
 @interface CAPPluginCallError : NSObject
 
 @property (nonatomic, strong) NSString *message;
+@property (nonatomic, strong) NSString *code;
 @property (nonatomic, strong) NSError *error;
 @property (nonatomic, strong) NSDictionary<NSString *, id> *data;
 
-- (instancetype)initWithMessage:(NSString *)message error:(NSError *)error data:(NSDictionary<NSString *, id>*)data;
+- (instancetype)initWithMessage:(NSString *)message code:(NSString *)code error:(NSError *)error data:(NSDictionary<NSString *, id>*)data;
 
 @end
 

--- a/ios/Capacitor/Capacitor/CAPPluginCall.m
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.m
@@ -11,8 +11,9 @@
 
 @implementation CAPPluginCallError
 
-- (instancetype)initWithMessage:(NSString *)message error:(NSError *)error data:(NSDictionary<NSString *,id> *)data {
+- (instancetype)initWithMessage:(NSString *)message code:(NSString *) code error:(NSError *)error data:(NSDictionary<NSString *,id> *)data {
   self.message = message;
+  self.code = code;
   self.error = error;
   self.data = data;
   return self;

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -79,15 +79,15 @@ public typealias PluginEventListener = CAPPluginCall
   }
   
   func error(_ message: String, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
-    errorHandler(CAPPluginCallError(message: message, error: error, data: data))
+    errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
   }
-  
-  func reject(_ message: String, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
-    errorHandler(CAPPluginCallError(message: message, error: error, data: data))
+
+  func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
+    errorHandler(CAPPluginCallError(message: message, code: code, error: error, data: data))
   }
 
   func unimplemented() {
-    errorHandler(CAPPluginCallError(message: CAPPluginCall.UNIMPLEMENTED, error: nil, data: [:]))
+    errorHandler(CAPPluginCallError(message: CAPPluginCall.UNIMPLEMENTED, code: nil, error: nil, data: [:]))
   }
 }
 

--- a/ios/Capacitor/Capacitor/JS.swift
+++ b/ios/Capacitor/Capacitor/JS.swift
@@ -78,15 +78,17 @@ public class JSResultError {
   var call: JSCall
   var error: JSResultBody
   var message: String
+  var code: String?
   var errorMessage: String
-  
-  public init(call: JSCall, message: String, errorMessage: String, error: JSResultBody) {
+
+  public init(call: JSCall, message: String, errorMessage: String, error: JSResultBody, code: String? = nil) {
     self.call = call
     self.message = message
     self.errorMessage = errorMessage
     self.error = error
+    self.code = code
   }
-  
+
   /**
    * Return a linkable error that we can use to help users find help for common exceptions,
    * much like AngularJS back in the day.
@@ -103,6 +105,7 @@ public class JSResultError {
     var jsonResponse = "{}"
     
     error["message"] = self.message
+    error["code"] = self.code
     error["errorMessage"] = self.errorMessage
     //error["_exlink"] = getLinkableError(self.message)
     


### PR DESCRIPTION
This allows plugin calls to reject with a node like code (string) 
`call.reject("Error message", "ERROR_CODE");`