### PR TITLE
feat(android): Make Bridge.restoreInstanceState() public

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -662,7 +662,7 @@ public class Bridge {
    * Restore any saved bundle state data
    * @param savedInstanceState
    */
-  protected void restoreInstanceState(Bundle savedInstanceState) {
+  public void restoreInstanceState(Bundle savedInstanceState) {
     String lastPluginId = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_ID_KEY);
     String lastPluginCallMethod = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_CALL_METHOD_NAME_KEY);
     String lastOptionsJson = savedInstanceState.getString(BUNDLE_PLUGIN_CALL_OPTIONS_SAVED_KEY);


### PR DESCRIPTION
Currently, Capacitor does not yet support Android fragments.
To overcome this limitation, I implemented my own `BridgeFragment`, which is similar to `BridgeActivity`. To do so, I found it useful to make `Bridge.restoreInstanceState()` a public method.

More generally, I suggest to treat `Bridge.java` as a pseudo-public API that can be used by any developer. The reason is that the existing Bridge implementations might not cover every case that is necessary for integrations in complex native codebases.
