### PR TITLE
Fix ios 13 Exif data and return gps coordinate

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -217,8 +217,16 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
 
     let coordinate = (info[UIImagePickerController.InfoKey.phAsset] as? PHAsset)?.location?.coordinate
     
-    let numLat = NSNumber(value: (coordinate?.latitude)! as Double)
-    let numLong = NSNumber(value: (coordinate?.latitude)! as Double)
+    var numLat = NSNumber(value: 0 as Double)
+    var numLong = NSNumber(value: 0 as Double)
+    
+    if(coordinate?.latitude != nil){
+        numLat = NSNumber(value: (coordinate?.latitude)! as Double)
+    }
+    
+    if(coordinate?.longitude != nil){
+        numLong = NSNumber(value: (coordinate?.longitude)! as Double)
+    }
     
     let gps: [AnyHashable: Any] = [
         AnyHashable("latitude"): numLat.stringValue,


### PR DESCRIPTION
Currently, Capacitor does dont send Exif data in IOS 13.
To fix this bug, I implemented request permision to access gallery photo when open it.
Additional, I found useful get gps cordinates and send it in response if image content that info.
