### PR TITLE
docs(site): Add target blank to external links in site header

### DIFF
--- a/site/src/components/site-header/site-header.tsx
+++ b/site/src/components/site-header/site-header.tsx
@@ -106,18 +106,18 @@ export class SiteHeader {
                 <a href="/docs/community/plugins/">Plugins</a>
               </li>
               <li class="dropdown__item">
-                <a href="https://forum.ionicframework.com/">Forum</a>
+                <a href="https://forum.ionicframework.com/" target="_blank">Forum</a>
               </li>
               <li class="dropdown__item">
-                <a href="https://getcapacitor.herokuapp.com/">Slack</a>
+                <a href="https://getcapacitor.herokuapp.com/" target="_blank">Slack</a>
               </li>
               <li class="dropdown__item">
-                <a href="https://twitter.com/getcapacitor">Twitter</a>
+                <a href="https://twitter.com/getcapacitor" target="_blank">Twitter</a>
               </li>
             </ul>
           </span>
 
-          <a class="link link--external" href="https://github.com/ionic-team/capacitor">
+          <a class="link link--external" href="https://github.com/ionic-team/capacitor" target="_blank">
             GitHub
             <app-icon name="targetblank"></app-icon>
           </a>


### PR DESCRIPTION
The GitHub link has a "targetblank" icon but the link hasn't. Same for the socials links, they have a target blank in the footer but not in the header.