### PR TITLE
chore: remove electron from lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,8 +5,7 @@
     "./android/",
     "./capacitor-ios/",
     "./cli/",
-    "./core/",
-    "./electron/"
+    "./core/"
   ],
   "version": "1.5.0"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,6 @@ git add Capacitor.podspec
 git add CapacitorCordova.podspec
 git add cli/package.json
 git add core/package.json
-git add electron/package.json
 git add android/package.json
 git commit -m "Release v$LERNA_VERSION"
 git tag $LERNA_VERSION -m $LERNA_VERSION


### PR DESCRIPTION
remove capacitor electron from lerna so it's not released with the other capacitor packages, but uses it's own versioning. 

