### PR TITLE
feat(android): added configurable icon color for local notifications

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -31,6 +31,7 @@ public class LocalNotification {
   private Integer id;
   private String sound;
   private String smallIcon;
+  private String iconColor;
   private String actionTypeId;
   private String group;
   private boolean groupSummary;
@@ -74,6 +75,24 @@ public class LocalNotification {
   }
 
   public void setSmallIcon(String smallIcon) { this.smallIcon = getResourceBaseName(smallIcon); }
+
+  public String getIconColor() { 
+    // use the one defined local before trying for a globally defined color
+    if (iconColor != null) {
+      return iconColor;
+    } 
+    
+    String globalColor = Config.getString(CONFIG_KEY_PREFIX + "iconColor");
+    if (globalColor != null) {
+      return globalColor;
+    }
+
+    return null;
+  }
+
+  public void setIconColor(String iconColor) {
+    this.iconColor = iconColor;
+  }
 
   public List<LocalNotificationAttachment> getAttachments() {
     return attachments;
@@ -158,6 +177,7 @@ public class LocalNotification {
       activeLocalNotification.setSound(notification.getString("sound"));
       activeLocalNotification.setTitle(notification.getString("title"));
       activeLocalNotification.setSmallIcon(notification.getString("smallIcon"));
+      activeLocalNotification.setIconColor(notification.getString("iconColor"));
       activeLocalNotification.setAttachments(LocalNotificationAttachment.getAttachments(notification));
       activeLocalNotification.setGroupSummary(notification.getBoolean("groupSummary", false));
       try {
@@ -253,6 +273,7 @@ public class LocalNotification {
             ", id=" + id +
             ", sound='" + sound + '\'' +
             ", smallIcon='" + smallIcon + '\'' +
+            ", iconColor='" + iconColor + '\'' +
             ", actionTypeId='" + actionTypeId + '\'' +
             ", group='" + group + '\'' +
             ", extra=" + extra +
@@ -274,6 +295,7 @@ public class LocalNotification {
     if (id != null ? !id.equals(that.id) : that.id != null) return false;
     if (sound != null ? !sound.equals(that.sound) : that.sound != null) return false;
     if (smallIcon != null ? !smallIcon.equals(that.smallIcon) : that.smallIcon != null) return false;
+    if (iconColor != null ? !iconColor.equals(that.iconColor) : that.iconColor != null) return false;
     if (actionTypeId != null ? !actionTypeId.equals(that.actionTypeId) : that.actionTypeId != null)
       return false;
     if (group != null ? !group.equals(that.group) : that.group != null) return false;
@@ -291,6 +313,7 @@ public class LocalNotification {
     result = 31 * result + (id != null ? id.hashCode() : 0);
     result = 31 * result + (sound != null ? sound.hashCode() : 0);
     result = 31 * result + (smallIcon != null ? smallIcon.hashCode() : 0);
+    result = 31 * result + (iconColor != null ? iconColor.hashCode() : 0);
     result = 31 * result + (actionTypeId != null ? actionTypeId.hashCode() : 0);
     result = 31 * result + (group != null ? group.hashCode() : 0);
     result = 31 * result + Boolean.hashCode(groupSummary);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -178,7 +178,12 @@ public class LocalNotificationManager {
 
     String iconColor = localNotification.getIconColor();
     if (iconColor != null) {
-      mBuilder.setColor(Color.parseColor(iconColor));
+      try {
+        mBuilder.setColor(Color.parseColor(iconColor));
+      } catch (Exception ex) {
+        call.error("The iconColor string was not able to be parsed.  Please provide a valid string hexidecimal color code.", ex);
+        return;
+      }
     }
 
     createActionIntents(localNotification, mBuilder);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -7,6 +7,7 @@ import android.app.NotificationChannel;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -174,6 +175,12 @@ public class LocalNotificationManager {
     mBuilder.setOnlyAlertOnce(true);
 
     mBuilder.setSmallIcon(localNotification.getSmallIcon(context));
+
+    String iconColor = localNotification.getIconColor();
+    if (iconColor != null) {
+      mBuilder.setColor(Color.parseColor(iconColor));
+    }
+
     createActionIntents(localNotification, mBuilder);
     // notificationId is a unique int for each localNotification that you must define
     Notification buildNotification = mBuilder.build();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -180,8 +180,8 @@ public class LocalNotificationManager {
     if (iconColor != null) {
       try {
         mBuilder.setColor(Color.parseColor(iconColor));
-      } catch (Exception ex) {
-        call.error("The iconColor string was not able to be parsed.  Please provide a valid string hexidecimal color code.", ex);
+      } catch (IllegalArgumentException ex) {
+        call.error("Invalid color provided. Must be a hex string (ex: #ff0000");
         return;
       }
     }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1033,7 +1033,7 @@ export interface LocalNotification {
    * If set, it overrides default icon from capacitor.config.json
    */
   smallIcon?: string;
-      /**
+  /**
    * Android only: set the color of the notification icon
    */
   iconColor?: string

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1033,6 +1033,10 @@ export interface LocalNotification {
    * If set, it overrides default icon from capacitor.config.json
    */
   smallIcon?: string;
+      /**
+   * Android only: set the color of the notification icon
+   */
+  iconColor?: string
   attachments?: LocalNotificationAttachment[];
   actionTypeId?: string;
   extra?: any;

--- a/example/android/app/src/main/assets/capacitor.config.json
+++ b/example/android/app/src/main/assets/capacitor.config.json
@@ -6,6 +6,10 @@
   "plugins": {
     "SplashScreen": {
       "launchShowDuration": 12345
+    },
+    "LocalNotifications": {
+      "smallIcon": "ic_stat_icon_config_sample",
+      "iconColor": "#CE0B7C"
     }
   }
 }

--- a/example/capacitor.config.json
+++ b/example/capacitor.config.json
@@ -8,7 +8,8 @@
       "launchShowDuration": 12345
     },
     "LocalNotifications": {
-      "smallIcon": "ic_stat_icon_config_sample"
+      "smallIcon": "ic_stat_icon_config_sample",
+      "iconColor": "#CE0B7C"
     }
   }
 }

--- a/example/ios/IonicRunner/IonicRunner/capacitor.config.json
+++ b/example/ios/IonicRunner/IonicRunner/capacitor.config.json
@@ -8,7 +8,8 @@
       "launchShowDuration": 12345
     },
     "LocalNotifications": {
-      "smallIcon": "ic_stat_icon_config_sample"
+      "smallIcon": "ic_stat_icon_config_sample",
+      "iconColor": "#CE0B7C"
     }
   }
 }

--- a/example/src/pages/local-notifications/local-notifications.html
+++ b/example/src/pages/local-notifications/local-notifications.html
@@ -24,6 +24,9 @@
   <button (click)="scheduleNowWithIcon()" ion-button>
     Schedule Now - Icon parameter
   </button>
+  <button (click)="scheduleNowWithColor()" ion-button>
+    Schedule Now - Custom color
+  </button>
   <br/><br/>
   <button (click)="scheduleOnce()" ion-button>
     Schedule in 10 seconds

--- a/example/src/pages/local-notifications/local-notifications.ts
+++ b/example/src/pages/local-notifications/local-notifications.ts
@@ -86,6 +86,26 @@ export class LocalNotificationsPage {
     });
   }
 
+  async scheduleNowWithColor() {
+    this.notifs = await Plugins.LocalNotifications.schedule({
+      notifications: [{
+        title: 'Get 10% off!',
+        body: 'Swipe now to learn more',
+        // Get random id to test cancel
+        id: Math.floor(Math.random()*10),
+        sound: 'beep.aiff',
+        attachments: [
+          { id: 'face', url: 'res://public/assets/ionitron.png' }
+        ],
+        actionTypeId: 'OPEN_PRODUCT',
+        extra: {
+          productId: 'PRODUCT-1'
+        },
+        iconColor: '#00ff00'
+      }]
+    });
+  }
+
   async scheduleNowWithIcon() {
     this.notifs = await Plugins.LocalNotifications.schedule({
       notifications: [{

--- a/site/docs-md/apis/local-notifications/index.md
+++ b/site/docs-md/apis/local-notifications/index.md
@@ -33,7 +33,9 @@ LocalNotifications.schedule({
       sound: null,
       attachments: null,
       actionTypeId: "",
-      extra: null
+      extra: null,
+      smallIcon: null,
+      iconColor: null
     }
   ]
 });

--- a/site/docs-md/apis/local-notifications/index.md
+++ b/site/docs-md/apis/local-notifications/index.md
@@ -33,9 +33,7 @@ LocalNotifications.schedule({
       sound: null,
       attachments: null,
       actionTypeId: "",
-      extra: null,
-      smallIcon: null,
-      iconColor: null
+      extra: null
     }
   ]
 });


### PR DESCRIPTION
Good day,
I was finding that I needed to customize quite a few things with android local notifications so I decided to put my first PR in to see how it goes.  

This PR adds the ability to set an icon color in android.  You can do it with the plugin definition or globally in the config.

If this is something the community is interested in... i have already done something similar to make the notification expandable and can put that PR in at some point in the future as well.