### PR TITLE
fix(ios): return error if Cancel is selected from Camera.getPhoto() prompt

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -111,7 +111,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }))
 
     alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { (action: UIAlertAction) in
-      alert.dismiss(animated: true, completion: nil)
+      self.imagePickerControllerDidCancel(self.imagePicker!)
     }))
 
     self.setCenteredPopover(alert)

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -111,7 +111,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }))
 
     alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { (action: UIAlertAction) in
-      self.imagePickerControllerDidCancel(self.imagePicker!)
+      self.call?.error("User cancelled photos app")
     }))
 
     self.setCenteredPopover(alert)


### PR DESCRIPTION
First time contributor.

Noticed that nothing was being returned from `Camera.getPhoto()` on iOS  if source is `CameraSource.Prompt` and 'Cancel' is selected. 

fixes #2196 