### PR TITLE
fix(android): Avoid Accessibility.speak() crash

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
@@ -61,9 +61,6 @@ public class Accessibility extends Plugin {
         tts.speak(value, TextToSpeech.QUEUE_FLUSH, null, "capacitoraccessibility" + System.currentTimeMillis());
       }
     });
-
-    // Not yet implemented
-    throw new UnsupportedOperationException();
   }
 
 }


### PR DESCRIPTION
Don't throw the `UnsupportedOperationException` since it was implemented.

