### PR TITLE
fix(android): don't return NO_CAMERA_ERROR if any camera is present

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -124,7 +124,7 @@ public class Camera extends Plugin {
   }
 
   private void showCamera(final PluginCall call) {
-    if (!getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
+    if (!getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
       call.error(NO_CAMERA_ERROR);
       return;
     }


### PR DESCRIPTION
`FEATURE_CAMERA` only checks if the rear camera, `FEATURE_CAMERA_ANY` allows any camera.