### PR TITLE
fix(android): make camera work on Android 10

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
@@ -16,22 +16,15 @@ import java.util.Date;
 
 public class CameraUtils {
     public static Uri createImageFileUri(Activity activity, String appId) throws IOException{
-        File photoFile = CameraUtils.createImageFile(activity, false);
+        File photoFile = CameraUtils.createImageFile(activity);
         return FileProvider.getUriForFile(activity, appId + ".fileprovider", photoFile);
     }
 
-    public static File createImageFile(Activity activity, boolean saveToGallery) throws IOException {
+    public static File createImageFile(Activity activity) throws IOException {
         // Create an image file name
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";
-        File storageDir;
-        if(saveToGallery) {
-            Log.d(getLogTag(), "Trying to save image to public external directory");
-            storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-            storageDir.mkdirs();
-        }  else {
-            storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-        }
+        File storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
 
         File image = File.createTempFile(
                 imageFileName,  /* prefix */


### PR DESCRIPTION
If `saveToGallery` was used, the camera plugin tried to write on `getExternalStoragePublicDirectory`, which is deprecated on Android 10.
`Intent.ACTION_MEDIA_SCANNER_SCAN_FILE` is also deprecated, so changing the save to gallery code to use `MediaStore.Images.Media.insertImage` instead. 


closes #2555 