### PR TITLE
Add a note about plugin listener zoning

### DIFF
--- a/site/docs-md/plugins/android.md
+++ b/site/docs-md/plugins/android.md
@@ -213,6 +213,8 @@ Plugins.MyPlugin.addListener("myPluginEvent", (info: any) => {
 });
 ```
 
+> **Attention:** Note that the listener you provide will be run outside of the Angular zone, even if it is a lambda expression. This might have unintended side affects, like views not getting updated if they are hooked to an observable that is updated wihtin your plugin listener. Your might want to make use of `NgZone.run()`.
+
 To emit the event from the Java plugin class you can do it like this:
 
 ```java


### PR DESCRIPTION
Added a note that points out, that plugin listeners are not executed within the ngZone. This might lead to consequences that are hard to find the origin of.