### PR TITLE
fix(electron): correct implementation of Filesystem.appendFile

### DIFF
--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -89,7 +89,12 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.appendFile(lookupPath, options.data, options.encoding, (err:any) => {
+      let data: (Buffer | string) = options.data;
+      if (!options.encoding) {
+        const base64Data = options.data.indexOf(',') >= 0 ? options.data.split(',')[1] : options.data;
+        data = Buffer.from(base64Data, 'base64');
+      }
+      this.NodeFS.appendFile(lookupPath, data, options.encoding || 'binary', (err:any) => {
         if(err) {
           reject(err);
           return;

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -89,7 +89,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.appendFile(lookupPath, options.data, options.encoding (err:any) => {
+      this.NodeFS.appendFile(lookupPath, options.data, options.encoding, (err:any) => {
         if(err) {
           reject(err);
           return;

--- a/electron/src/electron/filesystem.ts
+++ b/electron/src/electron/filesystem.ts
@@ -89,7 +89,7 @@ export class FilesystemPluginElectron extends WebPlugin implements FilesystemPlu
       if(Object.keys(this.fileLocations).indexOf(options.directory) === -1)
         reject(`${options.directory} is currently not supported in the Electron implementation.`);
       let lookupPath = this.fileLocations[options.directory] + options.path;
-      this.NodeFS.appendFile(lookupPath, options.encoding, options.data, (err:any) => {
+      this.NodeFS.appendFile(lookupPath, options.data, options.encoding (err:any) => {
         if(err) {
           reject(err);
           return;


### PR DESCRIPTION
Currently `appendFile` on electron is broken because the parameters are in the wrong order.

Also if data was `binary` the append would not work correctly because the string did not get converted to a `buffer`