### PR TITLE
feat(android): avoid app restart on activity resize or uiMode change

### DIFF
--- a/android-template/app/src/main/AndroidManifest.xml
+++ b/android-template/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:name="com.getcapacitor.myapp.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"


### PR DESCRIPTION
When the app is used in multi window mode, the app gets restarted at first and on any resize, this change avoids it.
Also avoids restarts when changing the uiMode.