### PR TITLE
fix(android): Use NotificationCompat constant for setting visibility

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -180,7 +180,7 @@ public class LocalNotificationManager {
         .setShowWhen(true);
     }
 
-    mBuilder.setVisibility(Notification.VISIBILITY_PRIVATE);
+    mBuilder.setVisibility(NotificationCompat.VISIBILITY_PRIVATE);
     mBuilder.setOnlyAlertOnce(true);
 
     mBuilder.setSmallIcon(localNotification.getSmallIcon(context));


### PR DESCRIPTION
It's using `Notification` instead of `NotificationCompat`, which might cause problems in Android versions. 