### PR TITLE
feat(ios): set status bar animation style when showing and hiding

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1595,11 +1595,11 @@ export interface StatusBarPlugin extends Plugin {
   /**
    * Show the status bar
    */
-  show(): Promise<void>;
+  show(options?: StatusBarAnimationOptions): Promise<void>;
   /**
    *  Hide the status bar
    */
-  hide(): Promise<void>;
+  hide(options?: StatusBarAnimationOptions): Promise<void>;
   /**
    *  Get info about the current state of the status bar
    */
@@ -1619,6 +1619,28 @@ export enum StatusBarStyle {
    * Dark text for light backgrounds.
    */
   Light = 'LIGHT'
+}
+
+export interface StatusBarAnimationOptions {
+  /**
+   * iOS only. The type of status bar animation used when showing or hiding.
+   */
+  animation: StatusBarAnimation;
+}
+
+export enum StatusBarAnimation {
+  /**
+   * No animation during show/hide.
+   */
+  None = 'NONE',
+  /**
+   * Slide animation during show/hide.
+   */
+  Slide = 'SLIDE',
+  /**
+   * Fade animation during show/hide.
+   */
+  Fade = 'FADE'
 }
 
 export interface StatusBarBackgroundColorOptions {

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -83,6 +83,15 @@ enum BridgeError: Error {
     }
   }
 
+  public func setStatusBarAnimation(_ statusBarAnimation: UIStatusBarAnimation) {
+    guard let bridgeVC = self.viewController as? CAPBridgeViewController else {
+      return
+    }
+    DispatchQueue.main.async {
+      bridgeVC.setStatusBarAnimation(statusBarAnimation)
+    }
+  }
+
   public func getStatusBarVisible() -> Bool {
     guard let bridgeVC = self.viewController as? CAPBridgeViewController else {
       return false

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -26,6 +26,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   
   private var isStatusBarVisible = true
   private var statusBarStyle: UIStatusBarStyle = .default
+  private var statusBarAnimation: UIStatusBarAnimation = .slide
   @objc public var supportedOrientations: Array<Int> = []
   
   @objc public var startDir = ""
@@ -405,7 +406,7 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
 
   override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
     get {
-      return .slide
+      return statusBarAnimation
     }
   }
 
@@ -421,6 +422,10 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     UIView.animate(withDuration: 0.2, animations: {
       self.setNeedsStatusBarAppearanceUpdate()
     })
+  }
+
+  public func setStatusBarAnimation(_ statusBarAnimation: UIStatusBarAnimation) {
+    self.statusBarAnimation = statusBarAnimation
   }
 
   public func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {

--- a/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
+++ b/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
@@ -35,12 +35,25 @@ public class CAPStatusBarPlugin: CAPPlugin {
     call.unimplemented()
   }
   
+  func setAnimation(_ call: CAPPluginCall) {
+    let animation = call.getString("animation", "SLIDE")
+    if animation == "FADE" {
+      bridge.setStatusBarAnimation(.fade)
+    } else if animation == "NONE" {
+      bridge.setStatusBarAnimation(.none)
+    } else {
+      bridge.setStatusBarAnimation(.slide)
+    }
+  }
+  
   @objc func hide(_ call: CAPPluginCall) {
+    setAnimation(call)
     bridge.setStatusBarVisible(false)
     call.success()
   }
   
   @objc func show(_ call: CAPPluginCall) {
+    setAnimation(call)
     bridge.setStatusBarVisible(true)
     call.success()
   }


### PR DESCRIPTION
This adds an option to the status bar `show` and `hide` methods to change the animation style. The style will always default to `.slide` if not specified in the options (other options are `.fade` and `.none`. This is iOS only. I considered adding this as a plugin config that could be configured in `capacitor.config.json` but there could be use cases to change this on each show and hide.