### PR TITLE
feat(android): Add Statusbar.setOverlaysWebView method

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -119,7 +119,7 @@ public class StatusBar extends Plugin {
 
   @PluginMethod()
   public void setOverlaysWebView(final PluginCall call) {
-    final Boolean overlays = call.getBoolean("enabled", true);
+    final Boolean overlays = call.getBoolean("overlay", true);
     getBridge().executeOnMainThread(new Runnable() {
       @Override
       public void run() {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -116,4 +116,32 @@ public class StatusBar extends Plugin {
     data.put("color", String.format("#%06X", (0xFFFFFF & window.getStatusBarColor())));
     call.resolve(data);
   }
+
+  @PluginMethod()
+  public void setOverlaysWebView(final PluginCall call) {
+    final Boolean overlays = call.getBoolean("enabled", true);
+    getBridge().executeOnMainThread(new Runnable() {
+      @Override
+      public void run() {
+        if (overlays) {
+          // Sets the layout to a fullscreen one that does not hide the actual status bar, so the webview is displayed behind it.
+          View decorView = getActivity().getWindow().getDecorView();
+          int uiOptions = decorView.getSystemUiVisibility();
+          uiOptions = uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+          decorView.setSystemUiVisibility(uiOptions);
+          getActivity().getWindow().setStatusBarColor(Color.TRANSPARENT);
+
+          call.success();
+        } else {
+          // Sets the layout to a normal one that displays the webview below the status bar.
+          View decorView = getActivity().getWindow().getDecorView();
+          int uiOptions = decorView.getSystemUiVisibility();
+          uiOptions = uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+          decorView.setSystemUiVisibility(uiOptions);
+          call.success();
+        }
+
+      }
+    });
+  }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -124,7 +124,7 @@ public class StatusBar extends Plugin {
     data.put("visible", (decorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_FULLSCREEN) != View.SYSTEM_UI_FLAG_FULLSCREEN);
     data.put("style", style);
     data.put("color", String.format("#%06X", (0xFFFFFF & window.getStatusBarColor())));
-    data.put("overlaysWebview", (decorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) == View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+    data.put("overlays", (decorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) == View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     call.resolve(data);
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -114,6 +114,7 @@ public class StatusBar extends Plugin {
     data.put("visible", (decorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_FULLSCREEN) != View.SYSTEM_UI_FLAG_FULLSCREEN);
     data.put("style", style);
     data.put("color", String.format("#%06X", (0xFFFFFF & window.getStatusBarColor())));
+    data.put("overlaysWebview", (decorView.getSystemUiVisibility() & View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) == View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     call.resolve(data);
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -1,7 +1,6 @@
 package com.getcapacitor.plugin;
 
 import android.graphics.Color;
-import android.support.annotation.ColorInt;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
@@ -17,7 +16,6 @@ import com.getcapacitor.PluginMethod;
 @NativePlugin()
 public class StatusBar extends Plugin {
 
-  @ColorInt
   private int currentStatusbarColor;
 
   public void load() {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1638,6 +1638,7 @@ export interface StatusBarInfoResult {
   visible: boolean;
   style: StatusBarStyle;
   color?: string;
+  overlaysWebview: boolean;
 }
 
 export interface StatusBarOverlaysWebviewOptions {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1641,7 +1641,7 @@ export interface StatusBarInfoResult {
 }
 
 export interface StatusBarOverlaysWebviewOptions {
-  enabled: boolean;
+  overlay: boolean;
 }
 
 export interface StoragePlugin extends Plugin {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1608,6 +1608,11 @@ export interface StatusBarPlugin extends Plugin {
    *  Get info about the current state of the status bar
    */
   getInfo(): Promise<StatusBarInfoResult>;
+  /**
+   *  Set whether or not the status bar should overlay the webview to allow usage of the space
+   *  around a device "notch"
+   */
+  setOverlaysWebView(options: StatusBarOverlaysWebviewOptions): Promise<void>;
 }
 
 export interface StatusBarStyleOptions {
@@ -1633,6 +1638,10 @@ export interface StatusBarInfoResult {
   visible: boolean;
   style: StatusBarStyle;
   color?: string;
+}
+
+export interface StatusBarOverlaysWebviewOptions {
+  enabled: boolean;
 }
 
 export interface StoragePlugin extends Plugin {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1638,7 +1638,7 @@ export interface StatusBarInfoResult {
   visible: boolean;
   style: StatusBarStyle;
   color?: string;
-  overlaysWebview: boolean;
+  overlays?: boolean;
 }
 
 export interface StatusBarOverlaysWebviewOptions {

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -139,6 +139,7 @@ CAP_PLUGIN(CAPStatusBarPlugin, "StatusBar",
   CAP_PLUGIN_METHOD(show, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(hide, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(getInfo, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(setOverlaysWebView, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPStoragePlugin, "Storage",

--- a/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
+++ b/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
@@ -75,5 +75,9 @@ public class CAPStatusBarPlugin: CAPPlugin {
       ])
     }
   }
+
+  @objc func setOverlaysWebView(_ call: CAPPluginCall) {
+    call.unimplemented()
+  }
 }
 

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -50,7 +50,7 @@ export class StatusBarExample {
     });
     this.isStatusBarLight = !this.isStatusBarLight;
 
-    // Display content unter transparent status bar (Android only)
+    // Display content under transparent status bar (Android only)
     Statusbar.setOverlaysWebView({
       enabled: true
     })

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -52,8 +52,8 @@ export class StatusBarExample {
 
     // Display content under transparent status bar (Android only)
     Statusbar.setOverlaysWebView({
-      enabled: true
-    })
+      overlay: true
+    });
   }
 
   hideStatusBar() {

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -49,6 +49,11 @@ export class StatusBarExample {
       style: this.isStatusBarLight ? StatusBarStyle.Dark : StatusBarStyle.Light
     });
     this.isStatusBarLight = !this.isStatusBarLight;
+
+    // Display content unter transparent status bar (Android only)
+    Statusbar.setOverlaysWebView({
+      enabled: true
+    })
   }
 
   hideStatusBar() {


### PR DESCRIPTION
Addition of a new method in the core Statusbar plugin, similar to the `overlaysWebView` method/preference of the cordova statusbar plugin. Updated example in the docs for the Statusbar plugin.

Works only for android (as discussed in [#1876](https://github.com/ionic-team/capacitor/issues/1876)) since on iOS it already handles it correctly on devices with notches.

I'm not confident in my android knowledge these days, so I might have overlooked something. But in my tests everything worked as expected, similar to the cordova plugin.

What I'm not sure about is the correct way to handle that the iOS version of the plugin doesn't implement this feature. I added it with a `"not implemented"` response in the `Statusbar.swift` file but I'm not sure if that is all that's needed here.
