### PR TITLE
docs(dependencies): update to latest Capacitor

### DIFF
--- a/site/docs-md/getting-started/dependencies.md
+++ b/site/docs-md/getting-started/dependencies.md
@@ -25,15 +25,13 @@ For building iOS apps, Capacitor requires a **Mac with Xcode 11 or above**. Soon
 
 Additionally, you'll need to install **[CocoaPods](https://cocoapods.org/)** (`sudo gem install cocoapods`), and install the **Xcode Command Line tools** (either from Xcode, or running `xcode-select --install`).
 
-Once you have CocoaPods installed, update your local repo by running `pod repo update`. You should run this command periodically to ensure you have the latest versions of CocoaPods dependencies.
+As a rule, the latest version of Capacitor always supports at least the last two iOS versions.
 
-As a rule, the latest version of Capacitor always supports the last two iOS versions. For example, iOS 11 and iOS 12. For support for older versions of iOS, use an older version of Capacitor (if available).
+Capacitor 2.0 supports iOS 11+.
 
 Capacitor uses the WKWebView.
 
 ## Android Development
-
-First, the **Java 8 JDK** must be installed and [set to the default](https://stackoverflow.com/a/24657630/32140) if you have other versions of the JDK installed. Java 9 does _not_ work at the moment.
 
 Android development requires the **Android SDK** installed with **[Android Studio](https://developer.android.com/studio/index.html)**. Technically, Android Studio isn't required as you can build and run apps using only the Android CLI tools, but it will make building and running your app much easier so we strongly recommend using it.
 


### PR DESCRIPTION
Capacitor 2.0 supports iOS 11+ (same as 1.x), so remove the example text where it says  11 & 12 as 13 is also supported and might be confusing.

pod repo update is not needed if using CocoaPods 1.7.2 or newer, so removing the note.

java is not required as Android studio ships with its own JDK.
