### PR TITLE
feat(android): make JSObject.getString return null instead of 'null' string

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSObject.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSObject.java
@@ -46,7 +46,7 @@ public class JSObject extends JSONObject {
   public String getString(String key, String defaultValue) {
     try {
       String value = super.getString(key);
-      if (value != null) {
+      if (!super.isNull(key) && value != null) {
         return value;
       }
     } catch (JSONException ex) {


### PR DESCRIPTION
make JSObject.getString return null value (or default value) if a null javascript value was passed

closes #2590