### PR TITLE
fix(android): maintain status bar color during splash

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -53,7 +53,9 @@ public class Splash {
       }
 
       splashImage = new ImageView(c);
-      
+
+      splashImage.setFitsSystemWindows(true);
+
       // Hide status bar during splash screen.
       Boolean splashFullScreen = Config.getBoolean(CONFIG_KEY_PREFIX + "splashFullScreen", DEFAULT_SPLASH_FULL_SCREEN);
       if(splashFullScreen){
@@ -236,7 +238,7 @@ public class Splash {
 
         WindowManager.LayoutParams params = new WindowManager.LayoutParams();
         params.gravity = Gravity.CENTER;
-        params.flags = a.getWindow().getAttributes().flags & (WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        params.flags = a.getWindow().getAttributes().flags;
 
         // Required to enable the view to actually fade
         params.format = PixelFormat.TRANSLUCENT;


### PR DESCRIPTION
This fixes #1761 so the splash screen doesn't override the status bar color when it's visible. The reason this was broken was the flags were not getting applied from the window properly. It should have been: 
```
a.getWindow().getAttributes().flags | (WindowManager.LayoutParams.FLAG_FULLSCREEN);
```
instead of
```
a.getWindow().getAttributes().flags & (WindowManager.LayoutParams.FLAG_FULLSCREEN);
```
but the fullscreen flag was replicating the behavior of the `splashFullScreen` config, so I removed it.

`splashImage.setFitsSystemWindows(true);` is required so the splash screen does not appear behind the action bar.