### PR TITLE
feat(android): Add lights and lightColor to PushNotificationChannel

### DIFF
--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1530,10 +1530,12 @@ export interface PushNotificationDeliveredList {
 export interface PushNotificationChannel {
   id: string;
   name: string;
-  description: string;
-  sound: string;
+  description?: string;
+  sound?: string;
   importance: 1 | 2 | 3 | 4 | 5;
   visibility?: -1 | 0 | 1 ;
+  lights?: boolean;
+  lightColor?: string;
 }
 
 export interface PushNotificationChannelList {


### PR DESCRIPTION
Add lights and lightColor properties to PushNotificationChannel, so can be used on `createChannel` and returned by `listChannels`.

This allows to enable led light for push notifications and configure it's color (if the device supports it)

Also make `description` and `sound` optional since the native code had default values for when they are not provided. 
 


closes #2547 