### PR TITLE
feat(cli): make init use values from capacitor.config.json as defaults

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -301,7 +301,7 @@ export async function getName(config: Config, name: string) {
     const answers = await inquirer.prompt([{
       type: 'input',
       name: 'name',
-      default: 'App',
+      default: config.app.appName ? config.app.appName : 'App',
       message: `App name`
     }]);
     return answers.name;
@@ -314,7 +314,7 @@ export async function getAppId(config: Config, id: string) {
     const answers = await inquirer.prompt([{
       type: 'input',
       name: 'id',
-      default: 'com.example.app',
+      default: config.app.appId ? config.app.appId : 'com.example.app',
       message: 'App Package ID (in Java package format, no dashes)'
     }]);
     return answers.id;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,7 +37,7 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
   program
     .command('init [appName] [appId]')
     .description('Initializes a new Capacitor project in the current directory')
-    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets', config.app.webDir ? config.app.webDir: 'www')
+    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets', config.app.webDir ? config.app.webDir : 'www')
     .option('--npm-client [npmClient]', 'Optional: npm client to use for dependency installation')
     .action((appName, appId, { webDir, npmClient }) => {
       return initCommand(config, appName, appId, webDir, npmClient);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,7 +37,7 @@ export function run(process: NodeJS.Process, cliBinDir: string) {
   program
     .command('init [appName] [appId]')
     .description('Initializes a new Capacitor project in the current directory')
-    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets', 'www')
+    .option('--web-dir [value]', 'Optional: Directory of your projects built web assets', config.app.webDir ? config.app.webDir: 'www')
     .option('--npm-client [npmClient]', 'Optional: npm client to use for dependency installation')
     .action((appName, appId, { webDir, npmClient }) => {
       return initCommand(config, appName, appId, webDir, npmClient);


### PR DESCRIPTION
If `npx cap init` is called but a `capacitor.config.json` already exists, use the values there as defaults.

This is specially important for react apps as some guides tell users to run `npx cap init` after ionic integration, and that sets the webDir value to www instead of build.