### PR TITLE
feat(cli): use name from package.json as default name

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -301,7 +301,7 @@ export async function getName(config: Config, name: string) {
     const answers = await inquirer.prompt([{
       type: 'input',
       name: 'name',
-      default: config.app.appName ? config.app.appName : 'App',
+      default: config.app.appName ? config.app.appName : config.app.package.name ? config.app.package.name : 'App',
       message: `App name`
     }]);
     return answers.name;


### PR DESCRIPTION
If there isn't a name already set in `capacitor.config.json` and init is called without providing a name, use the package.json name field as default value.