### PR TITLE
feat(camera): make prompt strings localizable

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -103,10 +103,13 @@ public class Camera extends Plugin {
 
   private void showPrompt(final PluginCall call) {
     // We have all necessary permissions, open the camera
+    String promptLabelPhoto = call.getString("promptLabelPhoto", "From Photos");
+    String promptLabelPicture = call.getString("promptLabelPicture", "Take Picture");
+
     JSObject fromPhotos = new JSObject();
-    fromPhotos.put("title", "From Photos");
+    fromPhotos.put("title", promptLabelPhoto);
     JSObject takePicture = new JSObject();
-    takePicture.put("title", "Take Picture");
+    takePicture.put("title", promptLabelPicture);
     Object[] options = new Object[] {
       fromPhotos,
       takePicture

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -342,6 +342,19 @@ export interface CameraOptions {
    * iOS only: The presentation style of the Camera. Defaults to fullscreen.
    */
   presentationStyle?: 'fullscreen' | 'popover';
+
+  /**
+   * If use CameraSource.Prompt only, can change Prompt label.
+   * default:
+   *   promptLabelHeader  : 'Photo'       // iOS only
+   *   promptLabelCancel  : 'Cancel'      // iOS only
+   *   promptLabelPhoto   : 'From Photos'
+   *   promptLabelPicture : 'Take Picture'
+   */
+  promptLabelHeader?: string;
+  promptLabelCancel?: string;
+  promptLabelPhoto?: string;
+  promptLabelPicture?: string;
 }
 
 export enum CameraSource {

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -101,10 +101,10 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
 
   func showPrompt(_ call: CAPPluginCall) {
     // Build the action sheet
-    var promptLabelHeader = call.getString("promptLabelHeader") ?? "Photo"
-    var promptLabelPhoto = call.getString("promptLabelPhoto") ?? "From Photos"
-    var promptLabelPicture = call.getString("promptLabelPicture") ?? "Take Picture"
-    var promptLabelCancel = call.getString("promptLabelCancel") ?? "Cancel"
+    let promptLabelHeader = call.getString("promptLabelHeader") ?? "Photo"
+    let promptLabelPhoto = call.getString("promptLabelPhoto") ?? "From Photos"
+    let promptLabelPicture = call.getString("promptLabelPicture") ?? "Take Picture"
+    let promptLabelCancel = call.getString("promptLabelCancel") ?? "Cancel"
     
     let alert = UIAlertController(title: promptLabelHeader, message: nil, preferredStyle: UIAlertController.Style.actionSheet)
     alert.addAction(UIAlertAction(title: promptLabelPhoto, style: .default, handler: { (action: UIAlertAction) in

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -101,16 +101,21 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
 
   func showPrompt(_ call: CAPPluginCall) {
     // Build the action sheet
-    let alert = UIAlertController(title: "Photo", message: nil, preferredStyle: UIAlertController.Style.actionSheet)
-    alert.addAction(UIAlertAction(title: "From Photos", style: .default, handler: { (action: UIAlertAction) in
+    var promptLabelHeader = call.getString("promptLabelHeader") ?? "Photo"
+    var promptLabelPhoto = call.getString("promptLabelPhoto") ?? "From Photos"
+    var promptLabelPicture = call.getString("promptLabelPicture") ?? "Take Picture"
+    var promptLabelCancel = call.getString("promptLabelCancel") ?? "Cancel"
+    
+    let alert = UIAlertController(title: promptLabelHeader, message: nil, preferredStyle: UIAlertController.Style.actionSheet)
+    alert.addAction(UIAlertAction(title: promptLabelPhoto, style: .default, handler: { (action: UIAlertAction) in
       self.showPhotos(call)
     }))
 
-    alert.addAction(UIAlertAction(title: "Take Picture", style: .default, handler: { (action: UIAlertAction) in
+    alert.addAction(UIAlertAction(title: promptLabelPicture, style: .default, handler: { (action: UIAlertAction) in
       self.showCamera(call)
     }))
 
-    alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { (action: UIAlertAction) in
+    alert.addAction(UIAlertAction(title: promptLabelCancel, style: .cancel, handler: { (action: UIAlertAction) in
       self.call?.error("User cancelled photos app")
     }))
 


### PR DESCRIPTION
Now, Prompt message in camera plugin is hard coding.

<img width="403" alt="スクリーンショット 2020-03-25 22 21 19" src="https://user-images.githubusercontent.com/9690024/77540789-12322b80-6ee7-11ea-8c6c-9581c5076844.png">

I think this be able to change users label is better.
Thanks.