### PR TITLE
fix(docs/camera): add usage descriptions for using in iOS

### DIFF
--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -23,6 +23,12 @@ iOS requires the following usage description be added and filled out for your ap
 Name: `Privacy - Camera Usage Description`  
 Key: 	`NSCameraUsageDescription`
 
+Name: `Privacy - Photo Library Additions Usage Description`  
+Key: 	`NSPhotoLibraryAddUsageDescription`
+
+Name: `Privacy - Photo Library Usage Description`  
+Key: 	`NSPhotoLibraryUsageDescription`
+
 Read about [Setting iOS Permissions](../../ios/configuration/) in the [iOS Guide](../../ios/) for more information on setting iOS permissions in Xcode
 
 ## Android Notes


### PR DESCRIPTION
Capacitor's camera plugin is require three permission: https://github.com/ionic-team/capacitor/blob/master/ios/Capacitor/Capacitor/Plugins/Camera.swift#L348-L373

But now, docs said require one permission. This pull request is fix this.
Thanks.