### PR TITLE
fix(cordova): Add lib prefix to .a library names

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -193,7 +193,7 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
       if (sourceFile.$.framework && sourceFile.$.framework === 'true') {
         let fileName = sourceFile.$.src.split('/').pop();
         if (!fileName.startsWith('lib')) {
-          fileName = 'lib'+fileName;
+          fileName = 'lib' + fileName;
         }
         const frameworktPath = join(sourcesFolderName, plugin.name, fileName);
         if (!sourceFrameworks.includes(frameworktPath)) {
@@ -276,7 +276,7 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
       let fileName = codeFile.$.src.split('/').pop();
       const fileExt = codeFile.$.src.split('.').pop();
       if (fileExt === 'a' && !fileName.startsWith('lib')) {
-        fileName = 'lib'+fileName;
+        fileName = 'lib' + fileName;
       }
       let destFolder = sourcesFolderName;
       if (codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -191,7 +191,10 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
     const sourceFiles = getPlatformElement(plugin, platform, 'source-file');
     sourceFiles.map((sourceFile: any) => {
       if (sourceFile.$.framework && sourceFile.$.framework === 'true') {
-        const fileName = sourceFile.$.src.split('/').pop();
+        let fileName = sourceFile.$.src.split('/').pop();
+        if (!fileName.startsWith('lib')) {
+          fileName = 'lib'+fileName;
+        }
         const frameworktPath = join(sourcesFolderName, plugin.name, fileName);
         if (!sourceFrameworks.includes(frameworktPath)) {
           sourceFrameworks.push(frameworktPath);
@@ -270,8 +273,11 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
     }
     const sourcesFolder = join(pluginsPath, sourcesFolderName, p.name);
     codeFiles.map( (codeFile: any) => {
-      const fileName = codeFile.$.src.split('/').pop();
+      let fileName = codeFile.$.src.split('/').pop();
       const fileExt = codeFile.$.src.split('.').pop();
+      if (fileExt === 'a' && !fileName.startsWith('lib')) {
+        fileName = 'lib'+fileName;
+      }
       let destFolder = sourcesFolderName;
       if (codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
         destFolder = 'noarc';


### PR DESCRIPTION
CocoaPods doesn't allow `vendored_libraries` whose name don't start with lib, patched the CLI to add lib to the .a files that don't start with lib

closes #2632