### PR TITLE
fix(cordova): handle source-file with framework attribute (#2507)

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -279,19 +279,21 @@ function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
       const filePath = getFilePath(config, p, codeFile.$.src);
       const fileDest = join(pluginsPath, destFolder, p.name, fileName);
       copySync(filePath, fileDest);
-      let fileContent = readFileSync(fileDest, 'utf8');
-      if (fileExt === 'swift') {
-        fileContent = 'import Cordova\n' + fileContent;
-        writeFileSync(fileDest, fileContent, 'utf8');
-      } else {
-        if (fileContent.includes('@import Firebase;')) {
-          fileContent = fileContent.replace('@import Firebase;', '#import <Firebase/Firebase.h>');
+      if (!codeFile.$.framework) {
+        let fileContent = readFileSync(fileDest, 'utf8');
+        if (fileExt === 'swift') {
+          fileContent = 'import Cordova\n' + fileContent;
           writeFileSync(fileDest, fileContent, 'utf8');
-        }
-        if (fileContent.includes('[NSBundle bundleForClass:[self class]]') || fileContent.includes('[NSBundle bundleForClass:[CDVCapture class]]')) {
-          fileContent = fileContent.replace('[NSBundle bundleForClass:[self class]]', '[NSBundle mainBundle]');
-          fileContent = fileContent.replace('[NSBundle bundleForClass:[CDVCapture class]]', '[NSBundle mainBundle]');
-          writeFileSync(fileDest, fileContent, 'utf8');
+        } else {
+          if (fileContent.includes('@import Firebase;')) {
+            fileContent = fileContent.replace('@import Firebase;', '#import <Firebase/Firebase.h>');
+            writeFileSync(fileDest, fileContent, 'utf8');
+          }
+          if (fileContent.includes('[NSBundle bundleForClass:[self class]]') || fileContent.includes('[NSBundle bundleForClass:[CDVCapture class]]')) {
+            fileContent = fileContent.replace('[NSBundle bundleForClass:[self class]]', '[NSBundle mainBundle]');
+            fileContent = fileContent.replace('[NSBundle bundleForClass:[CDVCapture class]]', '[NSBundle mainBundle]');
+            writeFileSync(fileDest, fileContent, 'utf8');
+          }
         }
       }
     });


### PR DESCRIPTION
cherry-picking this commit because I would like a fix for the mentioned bug in a project using Capacitor 1.5.1