### PR TITLE
Docs - State plugin import required for web implementation to be registereds

### DIFF
--- a/site/docs-md/plugins/index.md
+++ b/site/docs-md/plugins/index.md
@@ -85,6 +85,12 @@ This will build the JS portion of your plugin and publish the rest of your plugi
 
 Your package can now be installed using `npm install your-plugin` in any Capacitor app.
 
+You may need to import your plugin for the web implementation to be registered within the `Plugins`:
+
+```js
+import 'your-plugin';
+```
+
 ## Next steps
 
 Now it's up to you to make your plugin do something truly awesome!


### PR DESCRIPTION
It's a piece of data that evaded me until I found an answer in this issue:
ionic-team#749

It was stated that the docs would be updated, I couldn't find it so in case they haven't been I've written this small update.

It is to state that an import is required for the plugin web implementation to be registered to the Plugins accesible from @capacitor/core.