### PR TITLE
fix(ios): writeFile failing on root folders

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -103,7 +103,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
 
     do {
-      if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent().absoluteString) {
+      if !FileManager.default.fileExists(atPath: fileUrl.deletingLastPathComponent().path) {
         if recursive {
           try FileManager.default.createDirectory(at: fileUrl.deletingLastPathComponent(), withIntermediateDirectories: recursive, attributes: nil)
         } else {


### PR DESCRIPTION
the url returned from absoluteString makes fileExists return false on the root folder, use path instead, it works with root and child folders.

closes #2667 