### PR TITLE
Fix case typo

### DIFF
--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -51,7 +51,7 @@ export class StatusBarExample {
     this.isStatusBarLight = !this.isStatusBarLight;
 
     // Display content under transparent status bar (Android only)
-    Statusbar.setOverlaysWebView({
+    StatusBar.setOverlaysWebView({
       overlay: true
     });
   }


### PR DESCRIPTION
This commit fix a typo, replacing `Statusbar` by `StatusBar`.