### PR TITLE
feat(LocalNotifications): add createChannel, deleteChannel and listChannels methods

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -1,5 +1,7 @@
 package com.getcapacitor.plugin;
 
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 
 import com.getcapacitor.JSArray;
@@ -12,6 +14,7 @@ import com.getcapacitor.PluginRequestCodes;
 import com.getcapacitor.plugin.notification.LocalNotification;
 import com.getcapacitor.plugin.notification.LocalNotificationManager;
 import com.getcapacitor.plugin.notification.NotificationAction;
+import com.getcapacitor.plugin.notification.NotificationChannelManager;
 import com.getcapacitor.plugin.notification.NotificationStorage;
 
 import org.json.JSONArray;
@@ -29,6 +32,7 @@ import java.util.Map;
 public class LocalNotifications extends Plugin {
   private LocalNotificationManager manager;
   private NotificationStorage notificationStorage;
+  public NotificationManager notificationManager;
 
   public LocalNotifications() {
   }
@@ -39,6 +43,8 @@ public class LocalNotifications extends Plugin {
     notificationStorage = new NotificationStorage(getContext());
     manager = new LocalNotificationManager(notificationStorage, getActivity());
     manager.createNotificationChannel();
+    notificationManager = (NotificationManager) getActivity()
+            .getSystemService(Context.NOTIFICATION_SERVICE);
   }
 
   @Override
@@ -116,6 +122,21 @@ public class LocalNotifications extends Plugin {
     JSObject data = new JSObject();
     data.put("value", manager.areNotificationsEnabled());
     call.success(data);
+  }
+
+  @PluginMethod()
+  public void createChannel(PluginCall call) {
+    NotificationChannelManager.createChannel(call, getActivity(), notificationManager);
+  }
+
+  @PluginMethod()
+  public void deleteChannel(PluginCall call) {
+    NotificationChannelManager.deleteChannel(call, notificationManager);
+  }
+
+  @PluginMethod()
+  public void listChannels(PluginCall call) {
+    NotificationChannelManager.listChannel(call, notificationManager);
   }
 
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -1,7 +1,5 @@
 package com.getcapacitor.plugin;
 
-import android.app.NotificationManager;
-import android.content.Context;
 import android.content.Intent;
 
 import com.getcapacitor.JSArray;
@@ -32,7 +30,7 @@ import java.util.Map;
 public class LocalNotifications extends Plugin {
   private LocalNotificationManager manager;
   private NotificationStorage notificationStorage;
-  public NotificationManager notificationManager;
+  private NotificationChannelManager notificationChannelManager;
 
   public LocalNotifications() {
   }
@@ -43,8 +41,7 @@ public class LocalNotifications extends Plugin {
     notificationStorage = new NotificationStorage(getContext());
     manager = new LocalNotificationManager(notificationStorage, getActivity());
     manager.createNotificationChannel();
-    notificationManager = (NotificationManager) getActivity()
-            .getSystemService(Context.NOTIFICATION_SERVICE);
+    notificationChannelManager = new NotificationChannelManager(getActivity());
   }
 
   @Override
@@ -126,17 +123,17 @@ public class LocalNotifications extends Plugin {
 
   @PluginMethod()
   public void createChannel(PluginCall call) {
-    NotificationChannelManager.createChannel(call, getActivity(), notificationManager);
+    notificationChannelManager.createChannel(call);
   }
 
   @PluginMethod()
   public void deleteChannel(PluginCall call) {
-    NotificationChannelManager.deleteChannel(call, notificationManager);
+    notificationChannelManager.deleteChannel(call);
   }
 
   @PluginMethod()
   public void listChannels(PluginCall call) {
-    NotificationChannelManager.listChannels(call, notificationManager);
+    notificationChannelManager.listChannels(call);
   }
 
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -42,6 +42,7 @@ public class LocalNotifications extends Plugin {
     super.load();
     notificationStorage = new NotificationStorage(getContext());
     manager = new LocalNotificationManager(notificationStorage, getActivity());
+    manager.createNotificationChannel();
     notificationManager = (NotificationManager) getActivity()
             .getSystemService(Context.NOTIFICATION_SERVICE);
   }
@@ -135,7 +136,7 @@ public class LocalNotifications extends Plugin {
 
   @PluginMethod()
   public void listChannels(PluginCall call) {
-    NotificationChannelManager.listChannel(call, notificationManager);
+    NotificationChannelManager.listChannels(call, notificationManager);
   }
 
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -42,7 +42,6 @@ public class LocalNotifications extends Plugin {
     super.load();
     notificationStorage = new NotificationStorage(getContext());
     manager = new LocalNotificationManager(notificationStorage, getActivity());
-    manager.createNotificationChannel();
     notificationManager = (NotificationManager) getActivity()
             .getSystemService(Context.NOTIFICATION_SERVICE);
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -1,20 +1,13 @@
 package com.getcapacitor.plugin;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
-import android.media.AudioAttributes;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
-import androidx.core.app.NotificationCompat;
 import android.net.Uri;
-
-import android.util.Log;
 
 import com.getcapacitor.Bridge;
 import com.getcapacitor.JSArray;
@@ -24,6 +17,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginHandle;
 import com.getcapacitor.PluginMethod;
+import com.getcapacitor.plugin.notification.NotificationChannelManager;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.iid.FirebaseInstanceId;
@@ -35,21 +29,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @NativePlugin()
 public class PushNotifications extends Plugin {
-
-  public static String CHANNEL_ID = "id";
-  public static String CHANNEL_NAME = "name";
-  public static String CHANNEL_DESCRIPTION = "description";
-  public static String CHANNEL_IMPORTANCE = "importance";
-  public static String CHANNEL_VISIBILITY = "visibility";
-  public static String CHANNEL_SOUND = "sound";
-  public static String CHANNEL_USE_LIGHTS = "lights";
-  public static String CHANNEL_LIGHT_COLOR = "lightColor";
 
   public static Bridge staticBridge = null;
   public static RemoteMessage lastMessage = null;
@@ -187,85 +170,17 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void createChannel(PluginCall call) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-      JSObject channel = new JSObject();
-      channel.put(CHANNEL_ID, call.getString(CHANNEL_ID));
-      channel.put(CHANNEL_NAME, call.getString(CHANNEL_NAME));
-      channel.put(CHANNEL_DESCRIPTION, call.getString(CHANNEL_DESCRIPTION, ""));
-      channel.put(CHANNEL_VISIBILITY, call.getInt(CHANNEL_VISIBILITY, NotificationCompat.VISIBILITY_PUBLIC));
-      channel.put(CHANNEL_IMPORTANCE, call.getInt(CHANNEL_IMPORTANCE));
-      channel.put(CHANNEL_SOUND, call.getString(CHANNEL_SOUND, null));
-      channel.put(CHANNEL_USE_LIGHTS, call.getBoolean(CHANNEL_USE_LIGHTS, false));
-      channel.put(CHANNEL_LIGHT_COLOR, call.getString(CHANNEL_LIGHT_COLOR, null));
-      createChannel(channel);
-      call.success();
-    } else {
-      call.unavailable();
-    }
+    NotificationChannelManager.createChannel(call,getContext(), notificationManager);
   }
 
   @PluginMethod()
   public void deleteChannel(PluginCall call) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-      String channelId = call.getString("id");
-      notificationManager.deleteNotificationChannel(channelId);
-      call.success();
-    } else {
-      call.unavailable();
-    }
+    NotificationChannelManager.deleteChannel(call, notificationManager);
   }
 
   @PluginMethod()
   public void listChannels(PluginCall call) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-      List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
-      JSArray channels = new JSArray();
-      for (NotificationChannel notificationChannel : notificationChannels) {
-        JSObject channel = new JSObject();
-        channel.put(CHANNEL_ID, notificationChannel.getId());
-        channel.put(CHANNEL_NAME, notificationChannel.getName());
-        channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
-        channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
-        channel.put(CHANNEL_VISIBILITY, notificationChannel.getLockscreenVisibility());
-        channel.put(CHANNEL_SOUND, notificationChannel.getSound());
-        channel.put(CHANNEL_USE_LIGHTS, notificationChannel.shouldShowLights());
-        channel.put(CHANNEL_LIGHT_COLOR, String.format("#%06X", (0xFFFFFF & notificationChannel.getLightColor())));
-        Log.d(getLogTag(), "visibility " + notificationChannel.getLockscreenVisibility());
-        Log.d(getLogTag(), "importance " + notificationChannel.getImportance());
-        channels.put(channel);
-      }
-      JSObject result = new JSObject();
-      result.put("channels", channels);
-      call.success(result);
-    } else {
-      call.unavailable();
-    }
-  }
-
-  private void createChannel(JSObject channel) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-      NotificationChannel notificationChannelChannel = new NotificationChannel(channel.getString(CHANNEL_ID), channel.getString(CHANNEL_NAME), channel.getInteger(CHANNEL_IMPORTANCE));
-      notificationChannelChannel.setDescription(channel.getString(CHANNEL_DESCRIPTION));
-      notificationChannelChannel.setLockscreenVisibility(channel.getInteger(CHANNEL_VISIBILITY));
-      notificationChannelChannel.enableLights(channel.getBool(CHANNEL_USE_LIGHTS));
-      String lightColor = channel.getString(CHANNEL_LIGHT_COLOR);
-      if (lightColor != null) {
-        try {
-          notificationChannelChannel.setLightColor(Color.parseColor(lightColor));
-        } catch (IllegalArgumentException ex) {
-          Log.e(getLogTag(), "Invalid color provided for light color.");
-        }
-      }
-      String sound = channel.getString(CHANNEL_SOUND, null);
-      if (sound != null && !sound.isEmpty()) {
-        AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .setUsage(AudioAttributes.USAGE_ALARM).build();
-        Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + getContext().getPackageName() + "/raw/" + sound);
-        notificationChannelChannel.setSound(soundUri, audioAttributes);
-      }
-      notificationManager.createNotificationChannel(notificationChannelChannel);
-    }
+    NotificationChannelManager.listChannel(call, notificationManager);
   }
 
   public void sendToken(String token) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -37,7 +37,7 @@ public class PushNotifications extends Plugin {
   public static Bridge staticBridge = null;
   public static RemoteMessage lastMessage = null;
   public NotificationManager notificationManager;
-
+  private NotificationChannelManager notificationChannelManager;
 
   private static final String EVENT_TOKEN_CHANGE = "registration";
   private static final String EVENT_TOKEN_ERROR = "registrationError";
@@ -50,6 +50,7 @@ public class PushNotifications extends Plugin {
       fireNotification(lastMessage);
       lastMessage = null;
     }
+    notificationChannelManager = new NotificationChannelManager(getActivity(), notificationManager);
   }
 
   @Override
@@ -170,17 +171,17 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void createChannel(PluginCall call) {
-    NotificationChannelManager.createChannel(call,getContext(), notificationManager);
+    notificationChannelManager.createChannel(call);
   }
 
   @PluginMethod()
   public void deleteChannel(PluginCall call) {
-    NotificationChannelManager.deleteChannel(call, notificationManager);
+    notificationChannelManager.deleteChannel(call);
   }
 
   @PluginMethod()
   public void listChannels(PluginCall call) {
-    NotificationChannelManager.listChannels(call, notificationManager);
+    notificationChannelManager.listChannels(call);
   }
 
   public void sendToken(String token) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -180,7 +180,7 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void listChannels(PluginCall call) {
-    NotificationChannelManager.listChannel(call, notificationManager);
+    NotificationChannelManager.listChannels(call, notificationManager);
   }
 
   public void sendToken(String token) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -38,6 +38,7 @@ public class LocalNotification {
   private JSObject extra;
   private List<LocalNotificationAttachment> attachments;
   private LocalNotificationSchedule schedule;
+  private String channelId;
 
   private String source;
 
@@ -142,6 +143,14 @@ public class LocalNotification {
     this.groupSummary = groupSummary;
   }
 
+  public String getChannelId() {
+    return channelId;
+  }
+
+  public void setChannelId(String channelId) {
+    this.channelId = channelId;
+  }
+
   /**
    * Build list of the notifications from remote plugin call
    */
@@ -180,6 +189,7 @@ public class LocalNotification {
       activeLocalNotification.setIconColor(notification.getString("iconColor"));
       activeLocalNotification.setAttachments(LocalNotificationAttachment.getAttachments(notification));
       activeLocalNotification.setGroupSummary(notification.getBoolean("groupSummary", false));
+      activeLocalNotification.setChannelId(notification.getString("channelId"));
       try {
         activeLocalNotification.setSchedule(new LocalNotificationSchedule(notification));
       } catch (ParseException e) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -147,7 +147,7 @@ public class LocalNotificationManager {
   // TODO media style notification support NotificationCompat.MediaStyle
   // TODO custom small/large icons
   private void buildNotification(NotificationManagerCompat notificationManager, LocalNotification localNotification, PluginCall call) {
-    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this.context, DEFAULT_NOTIFICATION_CHANNEL_ID)
+    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this.context, localNotification.getChannelId())
             .setContentTitle(localNotification.getTitle())
             .setContentText(localNotification.getBody())
             .setAutoCancel(true)

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -3,11 +3,13 @@ package com.getcapacitor.plugin.notification;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -41,6 +43,7 @@ public class LocalNotificationManager {
   public static final String NOTIFICATION_IS_REMOVABLE_KEY = "LocalNotificationRepeating";
   public static final String REMOTE_INPUT_KEY = "LocalNotificationRemoteInput";
 
+  public static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "default";
   private static final String DEFAULT_PRESS_ACTION = "tap";
 
   private Context context;
@@ -91,6 +94,25 @@ public class LocalNotificationManager {
     return dataJson;
   }
 
+  /**
+   * Create notification channel
+   */
+  public void createNotificationChannel() {
+    // Create the NotificationChannel, but only on API 26+ because
+    // the NotificationChannel class is new and not in the support library
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      CharSequence name = "Default";
+      String description = "Default";
+      int importance = android.app.NotificationManager.IMPORTANCE_DEFAULT;
+      NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID, name, importance);
+      channel.setDescription(description);
+      // Register the channel with the system; you can't change the importance
+      // or other notification behaviors after this
+      android.app.NotificationManager notificationManager = context.getSystemService(android.app.NotificationManager.class);
+      notificationManager.createNotificationChannel(channel);
+    }
+  }
+
   @Nullable
   public JSONArray schedule(PluginCall call, List<LocalNotification> localNotifications) {
     JSONArray ids = new JSONArray();
@@ -124,7 +146,10 @@ public class LocalNotificationManager {
   // TODO media style notification support NotificationCompat.MediaStyle
   // TODO custom small/large icons
   private void buildNotification(NotificationManagerCompat notificationManager, LocalNotification localNotification, PluginCall call) {
-    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this.context, localNotification.getChannelId())
+    String channelId = DEFAULT_NOTIFICATION_CHANNEL_ID;
+    if (localNotification.getChannelId() != null)
+      channelId = localNotification.getChannelId();
+    NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this.context, channelId)
             .setContentTitle(localNotification.getTitle())
             .setContentText(localNotification.getBody())
             .setAutoCancel(true)

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -3,13 +3,11 @@ package com.getcapacitor.plugin.notification;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.Notification;
-import android.app.NotificationChannel;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -43,7 +41,6 @@ public class LocalNotificationManager {
   public static final String NOTIFICATION_IS_REMOVABLE_KEY = "LocalNotificationRepeating";
   public static final String REMOTE_INPUT_KEY = "LocalNotificationRemoteInput";
 
-  public static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "default";
   private static final String DEFAULT_PRESS_ACTION = "tap";
 
   private Context context;
@@ -92,26 +89,6 @@ public class LocalNotificationManager {
     }
     dataJson.put("notification", request);
     return dataJson;
-  }
-
-  /**
-   * Create notification channel
-   */
-  public void createNotificationChannel() {
-    // TODO allow to create multiple channels
-    // Create the NotificationChannel, but only on API 26+ because
-    // the NotificationChannel class is new and not in the support library
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      CharSequence name = "Default";
-      String description = "Default";
-      int importance = android.app.NotificationManager.IMPORTANCE_DEFAULT;
-      NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID, name, importance);
-      channel.setDescription(description);
-      // Register the channel with the system; you can't change the importance
-      // or other notification behaviors after this
-      android.app.NotificationManager notificationManager = context.getSystemService(android.app.NotificationManager.class);
-      notificationManager.createNotificationChannel(channel);
-    }
   }
 
   @Nullable

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -147,8 +147,9 @@ public class LocalNotificationManager {
   // TODO custom small/large icons
   private void buildNotification(NotificationManagerCompat notificationManager, LocalNotification localNotification, PluginCall call) {
     String channelId = DEFAULT_NOTIFICATION_CHANNEL_ID;
-    if (localNotification.getChannelId() != null)
+    if (localNotification.getChannelId() != null) {
       channelId = localNotification.getChannelId();
+    }
     NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this.context, channelId)
             .setContentTitle(localNotification.getTitle())
             .setContentText(localNotification.getBody())

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
@@ -1,0 +1,95 @@
+package com.getcapacitor.plugin.notification;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.graphics.Color;
+import android.media.AudioAttributes;
+import android.net.Uri;
+import android.util.Log;
+
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+
+import java.util.List;
+
+public class NotificationChannelManager {
+
+    private static final String TAG = "NotificationChannel: ";
+
+
+    private static String CHANNEL_ID = "id";
+    private static String CHANNEL_NAME = "name";
+    private static String CHANNEL_DESCRIPTION = "description";
+    private static String CHANNEL_IMPORTANCE = "importance";
+    private static String CHANNEL_VISIBILITY = "visibility";
+    private static String CHANNEL_SOUND = "sound";
+    private static String CHANNEL_USE_LIGHTS = "lights";
+    private static String CHANNEL_LIGHT_COLOR = "lightColor";
+
+
+    public static void createChannel(PluginCall call, Context context, NotificationManager notificationManager) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            android.app.NotificationChannel notificationChannelChannel = new android.app.NotificationChannel(call.getString(CHANNEL_ID), call.getString(CHANNEL_NAME), call.getInt(CHANNEL_IMPORTANCE));
+            notificationChannelChannel.setDescription(call.getString(CHANNEL_DESCRIPTION));
+            notificationChannelChannel.setLockscreenVisibility(call.getInt(CHANNEL_VISIBILITY));
+            notificationChannelChannel.enableLights(call.getBoolean(CHANNEL_USE_LIGHTS));
+            String lightColor = call.getString(CHANNEL_LIGHT_COLOR);
+            if (lightColor != null) {
+                try {
+                    notificationChannelChannel.setLightColor(Color.parseColor(lightColor));
+                } catch (IllegalArgumentException ex) {
+                    call.error("Invalid color provided for light color.", ex);
+                }
+            }
+            String sound = call.getString(CHANNEL_SOUND, null);
+            if (sound != null && !sound.isEmpty()) {
+                AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .setUsage(AudioAttributes.USAGE_ALARM).build();
+                Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
+                notificationChannelChannel.setSound(soundUri, audioAttributes);
+            }
+            notificationManager.createNotificationChannel(notificationChannelChannel);
+        }
+    }
+
+    public static void deleteChannel(PluginCall call, NotificationManager notificationManager) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            String channelId = call.getString("id");
+            notificationManager.deleteNotificationChannel(channelId);
+            call.success();
+        } else {
+            call.unavailable();
+        }
+    }
+
+    public static void listChannel(PluginCall call, NotificationManager notificationManager) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
+            JSArray channels = new JSArray();
+            for (NotificationChannel notificationChannel : notificationChannels) {
+                JSObject channel = new JSObject();
+                channel.put(CHANNEL_ID, notificationChannel.getId());
+                channel.put(CHANNEL_NAME, notificationChannel.getName());
+                channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
+                channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
+                channel.put(CHANNEL_VISIBILITY, notificationChannel.getLockscreenVisibility());
+                channel.put(CHANNEL_SOUND, notificationChannel.getSound());
+                channel.put(CHANNEL_USE_LIGHTS, notificationChannel.shouldShowLights());
+                channel.put(CHANNEL_LIGHT_COLOR, String.format("#%06X", (0xFFFFFF & notificationChannel.getLightColor())));
+                Log.d(TAG, "visibility " + notificationChannel.getLockscreenVisibility());
+                Log.d(TAG, "importance " + notificationChannel.getImportance());
+                channels.put(channel);
+            }
+            JSObject result = new JSObject();
+            result.put("channels", channels);
+            call.success(result);
+        } else {
+            call.unavailable();
+        }
+    }
+}

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
@@ -20,6 +20,19 @@ import java.util.List;
 
 public class NotificationChannelManager {
 
+    private Context context;
+    private NotificationManager notificationManager;
+
+    public NotificationChannelManager(Context context) {
+        this.context = context;
+        this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    public NotificationChannelManager(Context context, NotificationManager manager) {
+        this.context = context;
+        this.notificationManager = manager;
+    }
+
     private static final String TAG = "NotificationChannel: ";
 
 
@@ -32,7 +45,7 @@ public class NotificationChannelManager {
     private static String CHANNEL_USE_LIGHTS = "lights";
     private static String CHANNEL_LIGHT_COLOR = "lightColor";
 
-    public static void createChannel(PluginCall call, Context context, NotificationManager notificationManager) {
+    public void createChannel(PluginCall call) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             JSObject channel = new JSObject();
             channel.put(CHANNEL_ID, call.getString(CHANNEL_ID));
@@ -43,13 +56,13 @@ public class NotificationChannelManager {
             channel.put(CHANNEL_SOUND, call.getString(CHANNEL_SOUND, null));
             channel.put(CHANNEL_USE_LIGHTS, call.getBoolean(CHANNEL_USE_LIGHTS, false));
             channel.put(CHANNEL_LIGHT_COLOR, call.getString(CHANNEL_LIGHT_COLOR, null));
-            createChannel(channel, context, notificationManager);
+            createChannel(channel);
             call.success();
         } else {
             call.unavailable();
         }
     }
-    public static void createChannel(JSObject channel, Context context, NotificationManager notificationManager) {
+    public void createChannel(JSObject channel) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             NotificationChannel notificationChannel = new NotificationChannel(channel.getString(CHANNEL_ID), channel.getString(CHANNEL_NAME), channel.getInteger(CHANNEL_IMPORTANCE));
             notificationChannel.setDescription(channel.getString(CHANNEL_DESCRIPTION));
@@ -78,7 +91,7 @@ public class NotificationChannelManager {
         }
     }
 
-    public static void deleteChannel(PluginCall call, NotificationManager notificationManager) {
+    public void deleteChannel(PluginCall call) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             String channelId = call.getString("id");
             notificationManager.deleteNotificationChannel(channelId);
@@ -88,7 +101,7 @@ public class NotificationChannelManager {
         }
     }
 
-    public static void listChannels(PluginCall call, NotificationManager notificationManager) {
+    public void listChannels(PluginCall call) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
             JSArray channels = new JSArray();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
@@ -33,14 +33,17 @@ public class NotificationChannelManager {
 
     public static void createChannel(PluginCall call, Context context, NotificationManager notificationManager) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            android.app.NotificationChannel notificationChannelChannel = new android.app.NotificationChannel(call.getString(CHANNEL_ID), call.getString(CHANNEL_NAME), call.getInt(CHANNEL_IMPORTANCE));
-            notificationChannelChannel.setDescription(call.getString(CHANNEL_DESCRIPTION));
-            notificationChannelChannel.setLockscreenVisibility(call.getInt(CHANNEL_VISIBILITY));
-            notificationChannelChannel.enableLights(call.getBoolean(CHANNEL_USE_LIGHTS));
+            NotificationChannel notificationChannel = new NotificationChannel(call.getString(CHANNEL_ID), call.getString(CHANNEL_NAME), call.getInt(CHANNEL_IMPORTANCE));
+            if (call.getString(CHANNEL_DESCRIPTION) != null)
+                notificationChannel.setDescription(call.getString(CHANNEL_DESCRIPTION));
+            if (call.getInt(CHANNEL_VISIBILITY) != null)
+                notificationChannel.setLockscreenVisibility(call.getInt(CHANNEL_VISIBILITY));
+            if (call.getBoolean(CHANNEL_USE_LIGHTS) != null)
+                notificationChannel.enableLights(call.getBoolean(CHANNEL_USE_LIGHTS));
             String lightColor = call.getString(CHANNEL_LIGHT_COLOR);
             if (lightColor != null) {
                 try {
-                    notificationChannelChannel.setLightColor(Color.parseColor(lightColor));
+                    notificationChannel.setLightColor(Color.parseColor(lightColor));
                 } catch (IllegalArgumentException ex) {
                     call.error("Invalid color provided for light color.", ex);
                 }
@@ -51,9 +54,9 @@ public class NotificationChannelManager {
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_ALARM).build();
                 Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + sound);
-                notificationChannelChannel.setSound(soundUri, audioAttributes);
+                notificationChannel.setSound(soundUri, audioAttributes);
             }
-            notificationManager.createNotificationChannel(notificationChannelChannel);
+            notificationManager.createNotificationChannel(notificationChannel);
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
@@ -70,7 +70,7 @@ public class NotificationChannelManager {
         }
     }
 
-    public static void listChannel(PluginCall call, NotificationManager notificationManager) {
+    public static void listChannels(PluginCall call, NotificationManager notificationManager) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
             JSArray channels = new JSArray();

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1106,7 +1106,7 @@ export interface LocalNotification {
    * will generate. If channel with the given name does not exist then the 
    * notification will not fire.
    */
-  channelId: string;
+  channelId?: string;
 }
 
 export interface LocalNotificationSchedule {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1101,6 +1101,12 @@ export interface LocalNotification {
    * (should be used with the `group` property).
    */
   groupSummary?: boolean;
+  /**
+   * Android only: set the notification channel on which local notification 
+   * will generate. If channel with the given name does not exist then the 
+   * notification will not fire.
+   */
+  channelId: string;
 }
 
 export interface LocalNotificationSchedule {
@@ -1148,6 +1154,10 @@ export interface LocalNotificationsPlugin extends Plugin {
    * Remove all native listeners for this plugin
    */
   removeAllListeners(): void;
+  
+  createChannel(channel: PushNotificationChannel): Promise<void>;
+  deleteChannel(channel: PushNotificationChannel): Promise<void>;
+  listChannels(): Promise<PushNotificationChannelList>;
 }
 
 

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1104,7 +1104,7 @@ export interface LocalNotification {
   /**
    * Android only: set the notification channel on which local notification 
    * will generate. If channel with the given name does not exist then the 
-   * notification will not fire.
+   * notification will not fire. If not provided, it will use the default channel.
    */
   channelId?: string;
 }
@@ -1146,6 +1146,9 @@ export interface LocalNotificationsPlugin extends Plugin {
   registerActionTypes(options: { types: LocalNotificationActionType[] }): Promise<void>;
   cancel(pending: LocalNotificationPendingList): Promise<void>;
   areEnabled(): Promise<LocalNotificationEnabledResult>;
+  createChannel(channel: NotificationChannel): Promise<void>;
+  deleteChannel(channel: NotificationChannel): Promise<void>;
+  listChannels(): Promise<NotificationChannelList>;
   requestPermission(): Promise<NotificationPermissionResponse>;
   addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotification) => void): PluginListenerHandle;
   addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void): PluginListenerHandle;
@@ -1154,10 +1157,6 @@ export interface LocalNotificationsPlugin extends Plugin {
    * Remove all native listeners for this plugin
    */
   removeAllListeners(): void;
-  
-  createChannel(channel: PushNotificationChannel): Promise<void>;
-  deleteChannel(channel: PushNotificationChannel): Promise<void>;
-  listChannels(): Promise<PushNotificationChannelList>;
 }
 
 
@@ -1555,7 +1554,7 @@ export interface PushNotificationDeliveredList {
   notifications: PushNotification[];
 }
 
-export interface PushNotificationChannel {
+export interface NotificationChannel {
   id: string;
   name: string;
   description?: string;
@@ -1566,8 +1565,8 @@ export interface PushNotificationChannel {
   lightColor?: string;
 }
 
-export interface PushNotificationChannelList {
-  channels: PushNotificationChannel[];
+export interface NotificationChannelList {
+  channels: NotificationChannel[];
 }
 
 export interface PushNotificationsPlugin extends Plugin {
@@ -1576,9 +1575,9 @@ export interface PushNotificationsPlugin extends Plugin {
   getDeliveredNotifications(): Promise<PushNotificationDeliveredList>;
   removeDeliveredNotifications(delivered: PushNotificationDeliveredList): Promise<void>;
   removeAllDeliveredNotifications(): Promise<void>;
-  createChannel(channel: PushNotificationChannel): Promise<void>;
-  deleteChannel(channel: PushNotificationChannel): Promise<void>;
-  listChannels(): Promise<PushNotificationChannelList>;
+  createChannel(channel: NotificationChannel): Promise<void>;
+  deleteChannel(channel: NotificationChannel): Promise<void>;
+  listChannels(): Promise<NotificationChannelList>;
   addListener(eventName: 'registration', listenerFunc: (token: PushNotificationToken) => void): PluginListenerHandle;
   addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -7,7 +7,9 @@ import {
   LocalNotificationActionType,
   LocalNotification,
   LocalNotificationScheduleResult,
-  NotificationPermissionResponse
+  NotificationPermissionResponse,
+  PushNotificationChannel,
+  PushNotificationChannelList
 } from '../core-plugin-definitions';
 
 import { PermissionsRequestResult } from '../definitions';
@@ -21,15 +23,16 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
       platforms: ['web']
     });
   }
-  createChannel(channel: import("../core-plugin-definitions").PushNotificationChannel): Promise<void> {
+  
+  createChannel(channel: PushNotificationChannel): Promise<void> {
     throw new Error('Feature not available in the browser. ' + channel.id);
   }
 
-  deleteChannel(channel: import("../core-plugin-definitions").PushNotificationChannel): Promise<void> {
+  deleteChannel(channel: PushNotificationChannel): Promise<void> {
     throw new Error('Feature not available in the browser. ' + channel.id);
   }
   
-  listChannels(): Promise<import("../core-plugin-definitions").PushNotificationChannelList> {
+  listChannels(): Promise<PushNotificationChannelList> {
     throw new Error('Feature not available in the browser');
   }
 

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -8,8 +8,8 @@ import {
   LocalNotification,
   LocalNotificationScheduleResult,
   NotificationPermissionResponse,
-  PushNotificationChannel,
-  PushNotificationChannelList
+  NotificationChannel,
+  NotificationChannelList
 } from '../core-plugin-definitions';
 
 import { PermissionsRequestResult } from '../definitions';
@@ -24,15 +24,15 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
     });
   }
   
-  createChannel(channel: PushNotificationChannel): Promise<void> {
+  createChannel(channel: NotificationChannel): Promise<void> {
     throw new Error('Feature not available in the browser. ' + channel.id);
   }
 
-  deleteChannel(channel: PushNotificationChannel): Promise<void> {
+  deleteChannel(channel: NotificationChannel): Promise<void> {
     throw new Error('Feature not available in the browser. ' + channel.id);
   }
   
-  listChannels(): Promise<PushNotificationChannelList> {
+  listChannels(): Promise<NotificationChannelList> {
     throw new Error('Feature not available in the browser');
   }
 

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -21,6 +21,17 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
       platforms: ['web']
     });
   }
+  createChannel(channel: import("../core-plugin-definitions").PushNotificationChannel): Promise<void> {
+    throw new Error('Feature not available in the browser. ' + channel.id);
+  }
+
+  deleteChannel(channel: import("../core-plugin-definitions").PushNotificationChannel): Promise<void> {
+    throw new Error('Feature not available in the browser. ' + channel.id);
+  }
+  
+  listChannels(): Promise<import("../core-plugin-definitions").PushNotificationChannelList> {
+    throw new Error('Feature not available in the browser');
+  }
 
   sendPending() {
     const toRemove: LocalNotification[] = [];
@@ -103,7 +114,7 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
         if (result === 'denied' || result === 'default') {
           granted = false;
         }
-        resolve({granted});
+        resolve({ granted });
       });
     });
   }
@@ -116,7 +127,7 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
           return;
         }
         resolve({
-          results: [ result ]
+          results: [result]
         });
       });
     });

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -94,6 +94,9 @@ CAP_PLUGIN(CAPLocalNotificationsPlugin, "LocalNotifications",
   CAP_PLUGIN_METHOD(getPending, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(registerActionTypes, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(areEnabled, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(createChannel, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(deleteChannel, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(listChannels, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnNone);
 )
 

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -511,5 +511,17 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     }
     return opts
   }
+  
+  @objc func createChannel(_ call: CAPPluginCall) {
+    call.unimplemented()
+  }
+
+  @objc func deleteChannel(_ call: CAPPluginCall) {
+    call.unimplemented()
+  }
+
+  @objc func listChannels(_ call: CAPPluginCall) {
+    call.unimplemented()
+  }
 }
 


### PR DESCRIPTION
Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel. For each channel, you can set the visual and auditory behaviour that is applied to all notifications in that channel. Then, users can change these settings and decide which notification channels from your app should be intrusive or visible at all.

This PR is for allowing channel feature to LocalNotification. The first user needs to create a Notification channel with `createChannel` method and then assign `channelId` at the time of scheduling notification. If no `channelId` is provided will use the default channel and if provided `channelId` does not exist, the notification will not be generated.
Fixes #2675