### PR TITLE
fix(android): make LocalNotification not crash on showing when

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -176,9 +176,9 @@ public class LocalNotificationManager {
     }
 
     // make sure scheduled time is shown instead of display time
-    if (localNotification.isScheduled()) {
+    if (localNotification.isScheduled() && localNotification.getSchedule().getAt() != null) {
       mBuilder.setWhen(localNotification.getSchedule().getAt().getTime())
-        .setShowWhen(true);
+              .setShowWhen(true);
     }
 
     mBuilder.setVisibility(NotificationCompat.VISIBILITY_PRIVATE);


### PR DESCRIPTION
If the notification was scheduled with every or on options, it will crash when trying to set the `when` time.
So set it only if at is not null to prevent the crash.

closes #2639 