### PR TITLE
feat(ios): add presentVC and dismissVC methods to bridge

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -67,6 +67,7 @@ enum BridgeError: Error {
     setupCordovaCompatibility()
     bindObservers()
     self.tmpWindow.rootViewController = tmpVC
+    self.tmpWindow.makeKeyAndVisible()
     NotificationCenter.default.addObserver(forName: CAPBridge.tmpVCAppeared.name, object: .none, queue: .none) { _ in
       self.tmpWindow.isHidden = true
     }

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -9,7 +9,10 @@ enum BridgeError: Error {
 
 @objc public class CAPBridge : NSObject {
 
+  let tmpWindow = UIWindow.init(frame: UIScreen.main.bounds)
+  let tmpVC = TmpViewController.init()
   @objc public static let statusBarTappedNotification = Notification(name: Notification.Name(rawValue: "statusBarTappedNotification"))
+  @objc public static let tmpVCAppeared = Notification(name: Notification.Name(rawValue: "tmpViewControllerAppeared"))
   public static var CAP_SITE = "https://capacitor.ionicframework.com/"
   public static var CAP_FILE_START = "/_capacitor_file_"
   public static let CAP_DEFAULT_SCHEME = "capacitor"
@@ -63,6 +66,10 @@ enum BridgeError: Error {
     registerPlugins()
     setupCordovaCompatibility()
     bindObservers()
+    self.tmpWindow.rootViewController = tmpVC
+    NotificationCenter.default.addObserver(forName: CAPBridge.tmpVCAppeared.name, object: .none, queue: .none) { _ in
+      self.tmpWindow.isHidden = true
+    }
   }
   
   public func setStatusBarVisible(_ isStatusBarVisible: Bool) {
@@ -587,6 +594,15 @@ enum BridgeError: Error {
 
   public func getLocalUrl() -> String {
     return localUrl!
+  }
+
+  @objc public func presentVC(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+    self.tmpWindow.makeKeyAndVisible()
+    self.tmpVC.present(viewControllerToPresent, animated: flag, completion: completion)
+  }
+
+  @objc public func dismissVC(animated flag: Bool, completion: (() -> Void)? = nil) {
+    self.tmpVC.dismiss(animated: flag, completion: completion)
   }
 
 }

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -34,7 +34,7 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
           self.vc!.preferredBarTintColor = UIColor(fromHex: toolbarColor!)
         }
 
-        self.bridge.viewController.present(self.vc!, animated: true, completion: {
+        self.bridge.presentVC(self.vc!, animated: true, completion: {
           call.success()
         })
       }
@@ -48,7 +48,7 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
       call.success()
     }
     DispatchQueue.main.async {
-      self.bridge.viewController.dismiss(animated: true) {
+      self.bridge.dismissVC(animated: true) {
         call.success()
       }
     }

--- a/ios/Capacitor/Capacitor/TmpViewController.swift
+++ b/ios/Capacitor/Capacitor/TmpViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class TmpViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated);
+        super.viewDidAppear(animated)
         NotificationCenter.default.post(CAPBridge.tmpVCAppeared)
     }
 }

--- a/ios/Capacitor/Capacitor/TmpViewController.swift
+++ b/ios/Capacitor/Capacitor/TmpViewController.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+class TmpViewController: UIViewController {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated);
+        NotificationCenter.default.post(CAPBridge.tmpVCAppeared)
+    }
+}


### PR DESCRIPTION
Add utility `presentVC` and `dismissVC` methods in the bridge for plugins to use.
They use a temporary window and temporary view controller, so the webview javascript execution is not frozen when the view controller is presented.

Changed the Browser implementation to use this two new methods so it fixes https://github.com/ionic-team/capacitor/issues/2660

