### PR TITLE
docs(ce-plugins): Add capacitor-dark-mode plugin

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -180,3 +180,4 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | Install Referrer | `capacitor-install-referrer` | <https://github.com/eladcandroid/capacitor-install-referrer> | |
 | Request app review | `capacitor-rate-app` | <https://github.com/Nodonisko/capacitor-rate-app> | Request app review from users |
 | Change Android Navigationbar Color | `capacitor-navigationbar` | <https://github.com/nikosdouvlis/capacitor-navigationbar> | Programmatically change the navigation bar color on android devices |
+| Dark Mode | `capacitor-dark-mode` | <https://github.com/hinddeep/ionicCapacitorDarkMode> | | Listen for dark mode change events


### PR DESCRIPTION
I have written a capacitor plugin that enables the webview to listen for dark mode change events on Android, Web/PWA and electron. I'll be adding iOS support soon. Using this plugin apps can toggle its dark theme as soon as the platform's dark theme changes.