### PR TITLE
feat(android): Allow to configure a default LocalNotification sound

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -1,6 +1,8 @@
 package com.getcapacitor.plugin.notification;
 
+import android.content.ContentResolver;
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 
 import com.getcapacitor.Config;
@@ -25,6 +27,7 @@ public class LocalNotification {
   private static final String CONFIG_KEY_PREFIX = "plugins.LocalNotifications.";
   private static final int RESOURCE_ID_ZERO_VALUE = 0;
   private static int defaultSmallIconID = RESOURCE_ID_ZERO_VALUE;
+  private static int defaultSoundID = RESOURCE_ID_ZERO_VALUE;
 
   private String title;
   private String body;
@@ -66,8 +69,20 @@ public class LocalNotification {
     this.schedule = schedule;
   }
 
-  public String getSound() {
-    return sound;
+  public String getSound(Context context) {
+    String soundPath = null;
+    int resId = RESOURCE_ID_ZERO_VALUE;
+    String name = getResourceBaseName(sound);
+    if (name != null) {
+      resId = getResourceID(context, name, "raw");
+    }
+    if (resId == RESOURCE_ID_ZERO_VALUE) {
+      resId = getDefaultSound(context);
+    }
+    if(resId != RESOURCE_ID_ZERO_VALUE){
+      soundPath = ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/" + resId;
+    }
+    return soundPath;
   }
 
   public void setSound(String sound) {
@@ -256,6 +271,29 @@ public class LocalNotification {
 
     defaultSmallIconID = resId;
     return resId;
+  }
+
+  private static int getDefaultSound(Context context){
+    if(defaultSoundID != RESOURCE_ID_ZERO_VALUE) return defaultSoundID;
+
+    int resId = RESOURCE_ID_ZERO_VALUE;
+    String soundConfigResourceName = Config.getString(CONFIG_KEY_PREFIX + "sound");
+    soundConfigResourceName = getResourceBaseName(soundConfigResourceName);
+
+    if(soundConfigResourceName != null){
+      resId = getResourceID(context, soundConfigResourceName, "raw");
+    }
+
+    defaultSoundID = resId;
+    return resId;
+  }
+
+  public static Uri getDefaultSoundUrl(Context context){
+    int soundId = LocalNotification.getDefaultSound(context);
+    if (soundId != RESOURCE_ID_ZERO_VALUE) {
+      return Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/" + soundId);
+    }
+    return null;
   }
 
   public boolean isScheduled() {

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1071,6 +1071,13 @@ export interface LocalNotification {
   body: string;
   id: number;
   schedule?: LocalNotificationSchedule;
+  /**
+   * Name of the audio file with extension.
+   * On iOS the file should be in the app bundle.
+   * On Android the file should be on res/raw folder.
+   * Doesn't work on Android version 26+ (Android O and newer), for
+   * Recommended format is .wav because is supported by both platforms.
+   */
   sound?: string;
   /**
    * Android-only: set a custom statusbar icon.

--- a/site/docs-md/apis/local-notifications/index.md
+++ b/site/docs-md/apis/local-notifications/index.md
@@ -46,12 +46,14 @@ The local notification plugin allows the following configuration values to be ad
 
 - `smallIcon`: It allows you to set the default icon for the local notification.
 - `iconColor`: It allows you to set the default color for the local notification icon.
+- `sound`: It allows you to set the default notification sound. On Android 26+ it sets the default channel sound and can't be changed unless the app is uninstalled.
 
 ```json
  "plugins": {
     "LocalNotifications": {
       "smallIcon": "ic_stat_icon_config_sample",
-      "iconColor": "#488AFF"
+      "iconColor": "#488AFF",
+      "sound": "beep.wav"
     }
   }
 ```


### PR DESCRIPTION
Allow to configure a default notification sound from capacitor.config.json file.

Also fixes and documents the regular LocalNotification sound

closes https://github.com/ionic-team/capacitor/issues/2657
