### PR TITLE
docs(permissions): Display permissions page on side menu

### DIFF
--- a/site/docs-md/README.md
+++ b/site/docs-md/README.md
@@ -69,6 +69,7 @@
   * [Modals](apis/modals/index.md)
   * [Motion](apis/motion/index.md)
   * [Network](apis/network/index.md)
+  * [Permissions](apis/permissions/index.md)
   * [Push Notifications](apis/push-notifications/index.md)
   * [Share](apis/share/index.md)
   * [Splash Screen](apis/splash-screen/index.md)


### PR DESCRIPTION
it was documented, but never added to the side menu