### PR TITLE
fix(ios): don't use the tmpWindow on popover presentation

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -598,12 +598,20 @@ enum BridgeError: Error {
   }
 
   @objc public func presentVC(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-    self.tmpWindow.makeKeyAndVisible()
-    self.tmpVC.present(viewControllerToPresent, animated: flag, completion: completion)
+    if viewControllerToPresent.modalPresentationStyle == .popover {
+      self.viewController.present(viewControllerToPresent, animated: flag, completion: completion)
+    } else {
+      self.tmpWindow.makeKeyAndVisible()
+      self.tmpVC.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
   }
 
   @objc public func dismissVC(animated flag: Bool, completion: (() -> Void)? = nil) {
-    self.tmpVC.dismiss(animated: flag, completion: completion)
+    if self.tmpWindow.isHidden {
+      self.viewController.dismiss(animated: flag, completion: completion)
+    } else {
+      self.tmpVC.dismiss(animated: flag, completion: completion)
+    }
   }
 
 }

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -23,7 +23,7 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
         self.vc = SFSafariViewController.init(url: url!)
         self.vc!.delegate = self
         let presentationStyle = call.getString("presentationStyle")
-        if presentationStyle != nil && presentationStyle == "popover" {
+        if presentationStyle != nil && presentationStyle == "popover" && UIDevice.current.userInterfaceIdiom == .pad {
           self.vc!.modalPresentationStyle = .popover
           self.setCenteredPopover(self.vc)
         } else {


### PR DESCRIPTION
the tmpWindow doesn't work fine when using popover presentation, and since popover presentation doesn't freeze the javascript, changed the code to not use the tmpWindow when the presentation is popover

closes https://github.com/ionic-team/capacitor/issues/2711