### PR TITLE
fix message: Cannot read property 'SplashScreen' of undefined

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -65,9 +65,15 @@ class CapacitorSplashScreen {
 
     try {
       let capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
+      let ss = {};
+      if ( capConfigJson.plugins !== undefined ) {
+        if ( capConfigJson.plugins.SplashScreen !== undefined ) {
+          ss = capConfigJson.plugins.SplashScreen;
+        }
+      }
       this.splashOptions = Object.assign(
         this.splashOptions,
-        capConfigJson.plugins.SplashScreen || {}
+        ss
       );
     } catch (e) {
       console.error(e.message);

--- a/electron/index.js
+++ b/electron/index.js
@@ -62,16 +62,7 @@ class CapacitorSplashScreen {
     };
 
     this.mainWindowRef = mainWindow;
-/*
-Change let to const
-Maybe use a ternary operator instead of multiple if's
-const capConfigJson = JSON.parse(fs.readFileSync('./capacitor.config.json', 'utf-8'));
 
-this.splashOptions = Object.assign(
-this.splashOptions,
-capConfigJson.plugins ? capConfigJson.plugins.SplashScreen || {} : {}
-);
-*/
     try {
       const capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
       this.splashOptions = Object.assign(

--- a/electron/index.js
+++ b/electron/index.js
@@ -62,18 +62,21 @@ class CapacitorSplashScreen {
     };
 
     this.mainWindowRef = mainWindow;
+/*
+Change let to const
+Maybe use a ternary operator instead of multiple if's
+const capConfigJson = JSON.parse(fs.readFileSync('./capacitor.config.json', 'utf-8'));
 
+this.splashOptions = Object.assign(
+this.splashOptions,
+capConfigJson.plugins ? capConfigJson.plugins.SplashScreen || {} : {}
+);
+*/
     try {
-      let capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
-      let ss = {};
-      if ( capConfigJson.plugins !== undefined ) {
-        if ( capConfigJson.plugins.SplashScreen !== undefined ) {
-          ss = capConfigJson.plugins.SplashScreen;
-        }
-      }
+      const capConfigJson = JSON.parse(fs.readFileSync(`./capacitor.config.json`, 'utf-8'));
       this.splashOptions = Object.assign(
         this.splashOptions,
-        ss
+        capConfigJson.plugins ? capConfigJson.plugins.SplashScreen || {} : {}
       );
     } catch (e) {
       console.error(e.message);


### PR DESCRIPTION
If `capacitor.config.json` does not have any plugins defined, then the code throws an error message about a `SplashScreen` property, like this:
```
$ electron ./

(electron) The default value of app.allowRendererProcessReuse is deprecated, it is currently "false".  It will change to be "true" in Electron 9.  For more information please check https://github.com/electron/electron/issues/18397
Cannot read property 'SplashScreen' of undefined
Done in 12.30s.
$
```
The little change in this PR verifies that a plugin is defined before trying to read the property of it.