### PR TITLE
fix(cli): match platform version with cli version on add command

### DIFF
--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { TaskInfoProvider, copyTemplate, installDeps, getCLIVersion, resolveNode, runCommand, runTask } from '../common';
+import { TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runCommand, runTask } from '../common';
 import { existsAsync, writeFileAsync } from '../util/fs';
 import { homedir } from 'os';
 import { join } from 'path';

--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runCommand, runTask } from '../common';
+import { TaskInfoProvider, copyTemplate, getCoreVersion, installDeps, resolveNode, runCommand, runTask } from '../common';
 import { existsAsync, writeFileAsync } from '../util/fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -11,8 +11,8 @@ export async function addAndroid(config: Config) {
       info('Skipping: already installed');
       return;
     }
-    const cliVersion = await getCLIVersion(config);
-    return installDeps(config.app.rootDir, [`@capacitor/android@${cliVersion}`], config);
+    const coreVersion = await getCoreVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/android@${coreVersion}`], config);
   });
   await runTask(`Adding native android project in: ${config.android.platformDir}`, async () => {
     return copyTemplate(config.android.assets.templateDir, config.android.platformDir);

--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { TaskInfoProvider, copyTemplate, installDeps, resolveNode, runCommand, runTask } from '../common';
+import { TaskInfoProvider, copyTemplate, installDeps, getCLIVersion, resolveNode, runCommand, runTask } from '../common';
 import { existsAsync, writeFileAsync } from '../util/fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -11,7 +11,8 @@ export async function addAndroid(config: Config) {
       info('Skipping: already installed');
       return;
     }
-    return installDeps(config.app.rootDir, ['@capacitor/android'], config);
+    const cliVersion = await getCLIVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/android@${cliVersion}`], config);
   });
   await runTask(`Adding native android project in: ${config.android.platformDir}`, async () => {
     return copyTemplate(config.android.assets.templateDir, config.android.platformDir);

--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { TaskInfoProvider, copyTemplate, getCoreVersion, installDeps, resolveNode, runCommand, runTask } from '../common';
+import { TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runCommand, runTask } from '../common';
 import { existsAsync, writeFileAsync } from '../util/fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -11,8 +11,8 @@ export async function addAndroid(config: Config) {
       info('Skipping: already installed');
       return;
     }
-    const coreVersion = await getCoreVersion(config);
-    return installDeps(config.app.rootDir, [`@capacitor/android@${coreVersion}`], config);
+    const cliVersion = await getCLIVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/android@${cliVersion}`], config);
   });
   await runTask(`Adding native android project in: ${config.android.platformDir}`, async () => {
     return copyTemplate(config.android.assets.templateDir, config.android.platformDir);

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -374,6 +374,16 @@ export async function printNextSteps(config: Config, appDir: string) {
   log(`Follow the Developer Workflow guide to get building:\n${chalk.bold(`https://capacitor.ionicframework.com/docs/basics/workflow`)}\n`);
 }
 
+export async function getCoreVersion(config: Config): Promise<string> {
+  const corePackagePath = resolveNode(config, '@capacitor/core', 'package.json');
+  if (!corePackagePath) {
+    logFatal('Unable to find node_modules/@capacitor/core/package.json. Are you sure',
+      '@capacitor/core is installed? This file is currently required for Capacitor to function.');
+  }
+
+  return (await readJSON(corePackagePath)).version;
+}
+
 export async function getCLIVersion(config: Config): Promise<string> {
   const cliPackagePath = resolveNode(config, '@capacitor/cli', 'package.json');
   if (!cliPackagePath) {

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -374,23 +374,29 @@ export async function printNextSteps(config: Config, appDir: string) {
   log(`Follow the Developer Workflow guide to get building:\n${chalk.bold(`https://capacitor.ionicframework.com/docs/basics/workflow`)}\n`);
 }
 
-export async function checkPlatformVersions(config: Config, platform: string) {
+export async function getCLIVersion(config: Config): Promise<string> {
   const cliPackagePath = resolveNode(config, '@capacitor/cli', 'package.json');
   if (!cliPackagePath) {
     logFatal('Unable to find node_modules/@capacitor/cli/package.json. Are you sure',
       '@capacitor/cli is installed? This file is currently required for Capacitor to function.');
-    return;
   }
 
+  return (await readJSON(cliPackagePath)).version;
+}
+
+export async function getPlatformVersion(config: Config, platform: string): Promise<string> {
   const platformPackagePath = resolveNode(config, `@capacitor/${platform}`, 'package.json');
   if (!platformPackagePath) {
     logFatal(`Unable to find node_modules/@capacitor/${platform}/package.json. Are you sure`,
       `@capacitor/${platform} is installed? This file is currently required for Capacitor to function.`);
-    return;
   }
 
-  const cliVersion = (await readJSON(cliPackagePath)).version;
-  const platformVersion = (await readJSON(platformPackagePath)).version;
+  return (await readJSON(platformPackagePath)).version;
+}
+
+export async function checkPlatformVersions(config: Config, platform: string) {
+  const cliVersion = await getCLIVersion(config);
+  const platformVersion = await getPlatformVersion(config, platform);
 
   if (semver.gt(cliVersion, platformVersion)) {
     log('\n');

--- a/cli/src/ios/add.ts
+++ b/cli/src/ios/add.ts
@@ -1,5 +1,5 @@
 import { checkCocoaPods } from './common';
-import { CheckFunction, TaskInfoProvider, copyTemplate, installDeps, resolveNode, runTask } from '../common';
+import { CheckFunction, TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runTask } from '../common';
 import { Config } from '../config';
 
 export const addIOSChecks: CheckFunction[] = [checkCocoaPods];
@@ -10,8 +10,8 @@ export async function addIOS(config: Config) {
       info('Skipping: already installed');
       return;
     }
-
-    return installDeps(config.app.rootDir, ['@capacitor/ios'], config);
+    const cliVersion = await getCLIVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/ios@${cliVersion}`], config);
   });
   await runTask(`Adding native xcode project in: ${config.ios.platformDir}`, () => {
     return copyTemplate(config.ios.assets.templateDir, config.ios.platformDir);

--- a/cli/src/ios/add.ts
+++ b/cli/src/ios/add.ts
@@ -1,5 +1,5 @@
 import { checkCocoaPods } from './common';
-import { CheckFunction, TaskInfoProvider, copyTemplate, getCoreVersion, installDeps, resolveNode, runTask } from '../common';
+import { CheckFunction, TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runTask } from '../common';
 import { Config } from '../config';
 
 export const addIOSChecks: CheckFunction[] = [checkCocoaPods];
@@ -10,8 +10,8 @@ export async function addIOS(config: Config) {
       info('Skipping: already installed');
       return;
     }
-    const coreVersion = await getCoreVersion(config);
-    return installDeps(config.app.rootDir, [`@capacitor/ios@${coreVersion}`], config);
+    const cliVersion = await getCLIVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/ios@${cliVersion}`], config);
   });
   await runTask(`Adding native xcode project in: ${config.ios.platformDir}`, () => {
     return copyTemplate(config.ios.assets.templateDir, config.ios.platformDir);

--- a/cli/src/ios/add.ts
+++ b/cli/src/ios/add.ts
@@ -1,5 +1,5 @@
 import { checkCocoaPods } from './common';
-import { CheckFunction, TaskInfoProvider, copyTemplate, getCLIVersion, installDeps, resolveNode, runTask } from '../common';
+import { CheckFunction, TaskInfoProvider, copyTemplate, getCoreVersion, installDeps, resolveNode, runTask } from '../common';
 import { Config } from '../config';
 
 export const addIOSChecks: CheckFunction[] = [checkCocoaPods];
@@ -10,8 +10,8 @@ export async function addIOS(config: Config) {
       info('Skipping: already installed');
       return;
     }
-    const cliVersion = await getCLIVersion(config);
-    return installDeps(config.app.rootDir, [`@capacitor/ios@${cliVersion}`], config);
+    const coreVersion = await getCoreVersion(config);
+    return installDeps(config.app.rootDir, [`@capacitor/ios@${coreVersion}`], config);
   });
   await runTask(`Adding native xcode project in: ${config.ios.platformDir}`, () => {
     return copyTemplate(config.ios.assets.templateDir, config.ios.platformDir);


### PR DESCRIPTION
Running `cap add android` should add the same version of the android platform as the rest of Capacitor. With these changes, it runs `npm install @capacitor/<platform>@<version>` so a very specific version is installed.

We could also look for the version of `@capacitor/core`, which might make more sense.