### PR TITLE
fix(cli): avoid error on create command

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -301,7 +301,7 @@ export async function getName(config: Config, name: string) {
     const answers = await inquirer.prompt([{
       type: 'input',
       name: 'name',
-      default: config.app.appName ? config.app.appName : config.app.package.name ? config.app.package.name : 'App',
+      default: config.app.appName ? config.app.appName : config.app.package && config.app.package.name ? config.app.package.name : 'App',
       message: `App name`
     }]);
     return answers.name;


### PR DESCRIPTION
The CLI tries to default to the package.json name, but on create there is no package.json yet. 

closes #2721 