### PR TITLE
fix(cli): Warn if core version doesn't match platform version

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -405,13 +405,12 @@ export async function getPlatformVersion(config: Config, platform: string): Prom
 }
 
 export async function checkPlatformVersions(config: Config, platform: string) {
-  const cliVersion = await getCLIVersion(config);
+  const coreVersion = await getCoreVersion(config);
   const platformVersion = await getPlatformVersion(config, platform);
-
-  if (semver.gt(cliVersion, platformVersion)) {
+  if (semver.diff(coreVersion, platformVersion) === 'minor' || semver.diff(coreVersion, platformVersion) === 'major') {
     log('\n');
-    logInfo(`Your @capacitor/cli version is greater than @capacitor/${platform} version`);
-    log(`Consider updating to matching version ${chalk`{bold npm install @capacitor/${platform}@${cliVersion}}`}`);
+    logWarn(`Your @capacitor/core version doesn't match your @capacitor/${platform} version`);
+    log(`Consider updating to matching version ${chalk`{bold npm install @capacitor/core@${platformVersion}}`}`);
   }
 }
 


### PR DESCRIPTION
We were showing an info message if the CLI version was newer than the platform versions, but makes more sense to warn (because it's serious and can cause issues) if the core version doesn't match the platform version.
Only do it at minor or major level, since at patch level the types shouldn't have changed.