### PR TITLE
subscribe to & unsubscribe from a topic in Firebase Push Notification #1682

### DIFF
--- a/Capacitor.podspec
+++ b/Capacitor.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
   s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => s.version.to_s }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
-  s.static_framework = true
   s.dependency 'CapacitorCordova', '2.0.0'
   s.dependency 'FirebaseMessaging'
   s.swift_version = '5.0'
+  s.static_framework = true
 end

--- a/Capacitor.podspec
+++ b/Capacitor.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => s.version.to_s }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.dependency 'CapacitorCordova', '2.0.0'
-  s.dependency 'Firebase'
+  s.dependency 'FirebaseMessaging'
   s.swift_version = '5.0'
 end

--- a/Capacitor.podspec
+++ b/Capacitor.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
   s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => s.version.to_s }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
+  s.static_framework = true
   s.dependency 'CapacitorCordova', '2.0.0'
   s.dependency 'FirebaseMessaging'
   s.swift_version = '5.0'

--- a/Capacitor.podspec
+++ b/Capacitor.podspec
@@ -10,5 +10,6 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => s.version.to_s }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.dependency 'CapacitorCordova', '2.0.0'
+  s.dependency 'Firebase'
   s.swift_version = '5.0'
 end

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -218,7 +218,7 @@ public class PushNotifications extends Plugin {
       .addOnFailureListener(new OnFailureListener() {
           @Override
           public void onFailure(@NonNull Exception e) {
-              call.error("error : unable to unsubscribe from topic " + topic, e)
+              call.error("error : unable to unsubscribe from topic " + topic, e);
           }
       });
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -197,8 +197,7 @@ public class PushNotifications extends Plugin {
       })
       .addOnFailureListener(new OnFailureListener() {
           @Override
-          public void onFailure(@NonNull Exception e) {
-              error(e.getLocalizedMessage());
+          public void onFailure(Exception e) {
               call.error("error : unable to subscribe to topic " + topic, e);
           }
       });
@@ -217,7 +216,7 @@ public class PushNotifications extends Plugin {
       })
       .addOnFailureListener(new OnFailureListener() {
           @Override
-          public void onFailure(@NonNull Exception e) {
+          public void onFailure(Exception e) {
               call.error("error : unable to unsubscribe from topic " + topic, e);
           }
       });

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -186,7 +186,7 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void subscribeToTopic(PluginCall call) {
-    String topic = call.getString("topic");
+    String topic = call.getString("name");
     
     FirebaseMessaging.getInstance().subscribeToTopic(topic)
       .addOnSuccessListener(new OnSuccessListener<Void>() {
@@ -206,7 +206,7 @@ public class PushNotifications extends Plugin {
 
   @PluginMethod()
   public void unsubscribeFromTopic(PluginCall call) {
-    String topic = call.getString("topic");
+    String topic = call.getString("name");
     
     FirebaseMessaging.getInstance().unsubscribeFromTopic(topic)
       .addOnSuccessListener(new OnSuccessListener<Void>() {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/PushNotifications.java
@@ -184,6 +184,45 @@ public class PushNotifications extends Plugin {
     notificationChannelManager.listChannels(call);
   }
 
+  @PluginMethod()
+  public void subscribeToTopic(PluginCall call) {
+    String topic = call.getString("topic");
+    
+    FirebaseMessaging.getInstance().subscribeToTopic(topic)
+      .addOnSuccessListener(new OnSuccessListener<Void>() {
+        @Override
+        public void onSuccess(Void aVoid) {
+            call.success();
+        }
+      })
+      .addOnFailureListener(new OnFailureListener() {
+          @Override
+          public void onFailure(@NonNull Exception e) {
+              error(e.getLocalizedMessage());
+              call.error("error : unable to subscribe to topic " + topic, e);
+          }
+      });
+  }
+
+  @PluginMethod()
+  public void unsubscribeFromTopic(PluginCall call) {
+    String topic = call.getString("topic");
+    
+    FirebaseMessaging.getInstance().unsubscribeFromTopic(topic)
+      .addOnSuccessListener(new OnSuccessListener<Void>() {
+          @Override
+          public void onSuccess(Void aVoid) {
+              call.success();
+          }
+      })
+      .addOnFailureListener(new OnFailureListener() {
+          @Override
+          public void onFailure(@NonNull Exception e) {
+              call.error("error : unable to unsubscribe from topic " + topic, e)
+          }
+      });
+  }
+
   public void sendToken(String token) {
     JSObject data = new JSObject();
     data.put("value", token);

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1577,6 +1577,10 @@ export interface NotificationChannelList {
   channels: NotificationChannel[];
 }
 
+export interface NotificationTopic {
+  name: string;
+}
+
 export interface PushNotificationsPlugin extends Plugin {
   register(): Promise<void>;
   requestPermission(): Promise<NotificationPermissionResponse>;
@@ -1586,6 +1590,8 @@ export interface PushNotificationsPlugin extends Plugin {
   createChannel(channel: NotificationChannel): Promise<void>;
   deleteChannel(channel: NotificationChannel): Promise<void>;
   listChannels(): Promise<NotificationChannelList>;
+  subscribeToTopic(topic: NotificationTopic): Promise<void>;
+  unsubscribeFromTopic(topic: NotificationTopic): Promise<void>;
   addListener(eventName: 'registration', listenerFunc: (token: PushNotificationToken) => void): PluginListenerHandle;
   addListener(eventName: 'registrationError', listenerFunc: (error: any) => void): PluginListenerHandle;
   addListener(eventName: 'pushNotificationReceived', listenerFunc: (notification: PushNotification) => void): PluginListenerHandle;

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -125,6 +125,8 @@ CAP_PLUGIN(CAPPushNotificationsPlugin, "PushNotifications",
   CAP_PLUGIN_METHOD(createChannel, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(deleteChannel, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(listChannels, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(subscribeToTopic, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(unsubscribeFromTopic, CAPPluginReturnPromise);
   CAP_PLUGIN_METHOD(removeAllListeners, CAPPluginReturnNone);
 )
 

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -94,6 +94,34 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
     call.unimplemented()
   }
 
+  /**
+   * Subscribe to a specific Push Notification Topic
+   */
+  @objc func subscribeToTopic(_ call: CAPPluginCall) {
+    let topic = call.getString("name")
+    Messaging.messaging().subscribe(toTopic: topic) {error in
+      guard error == nil else {
+        call.error(error!.localizedDescription)
+        return
+      }
+      call.success()
+    }
+  }
+
+  /**
+   * Unsubscribe from a specific Push Notification Topic
+   */
+  @objc func unsubscribeFromTopic(_ call: CAPPluginCall) {
+    let topic = call.getString("name")
+    Messaging.messaging().unsubscribe(fromTopic: topic) {error in
+      guard error == nil else {
+        call.error(error!.localizedDescription)
+        return
+      }
+      call.success()
+    }
+  }
+
   @objc public func didRegisterForRemoteNotificationsWithDeviceToken(notification: NSNotification){
     if let deviceToken = notification.object as? Data {
       let deviceTokenString = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UserNotifications
 
-import Firebase
+import FirebaseMessaging
 
 enum PushNotificationError: Error {
   case tokenParsingFailed

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UserNotifications
 
-import FirebaseMessaging
+import Firebase
 
 enum PushNotificationError: Error {
   case tokenParsingFailed

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -100,7 +100,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    * Subscribe to a specific Push Notification Topic
    */
   @objc func subscribeToTopic(_ call: CAPPluginCall) {
-    let topic = call.getString("name")
+    let topic = call.getString("name") ?? ""
     Messaging.messaging().subscribe(toTopic: topic) {error in
       guard error == nil else {
         call.error(error!.localizedDescription)
@@ -114,7 +114,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    * Unsubscribe from a specific Push Notification Topic
    */
   @objc func unsubscribeFromTopic(_ call: CAPPluginCall) {
-    let topic = call.getString("name")
+    let topic = call.getString("name") ?? ""
     Messaging.messaging().unsubscribe(fromTopic: topic) {error in
       guard error == nil else {
         call.error(error!.localizedDescription)

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -1,6 +1,8 @@
 import Foundation
 import UserNotifications
 
+import FirebaseMessaging
+
 enum PushNotificationError: Error {
   case tokenParsingFailed
 }


### PR DESCRIPTION
Please review my code, and if possible allow to merge it to the base.
Subscribing and Unsubscribing from topic is now becoming an essential part of FCM, as with new API Endpoint if we need to send messages to multiple devices they are asking to create a topic as one of the options. So thought if we can have this directly in capacitor instead of using fcm-capacitor plugin from @stewwan 
Please let me know if there is any scope for improvement. @stewwan @dwlrathod 