### PR TITLE
Update CLI Electron Add

### DIFF
--- a/cli/src/electron/add.ts
+++ b/cli/src/electron/add.ts
@@ -1,11 +1,18 @@
 import { exec } from 'child_process';
 import { Config } from '../config';
 import { copyTemplate, hasYarn, installDeps, runTask } from '../common';
+import { readFileSync, writeFileSync } from '../util/fs';
+import * as path from 'path';
 
 export async function addElectron(config: Config) {
 
   await runTask(`Adding Electron project in: ${config.electron.platformDir}`, async () => {
-    return copyTemplate(config.electron.assets.templateDir, config.electron.platformDir);
+    const copyReturn = await copyTemplate(config.electron.assets.templateDir, config.electron.platformDir);
+    const capConfigName = JSON.parse(readFileSync(path.join(config.electron.platformDir, '../capacitor.config.json')) + '')['appName'];
+    const packageJSONParse = JSON.parse(readFileSync(path.join(config.electron.platformDir, './package.json')) + '');
+    packageJSONParse.name = capConfigName;
+    writeFileSync(path.join(config.electron.platformDir, './package.json'), JSON.stringify(packageJSONParse));
+    return copyReturn;
   });
 
   await runTask(`Installing NPM Dependencies`, async () => {


### PR DESCRIPTION
Update to address issue #2604 around the copying of the appName from capacitor.config.json to package.json in Electron projects.