### PR TITLE
docs(keyboard): Add missing import in example

### DIFF
--- a/site/docs-md/apis/keyboard/index.md
+++ b/site/docs-md/apis/keyboard/index.md
@@ -26,7 +26,7 @@ The Keyboard API provides keyboard display and visibility control, along with ev
 ## Example
 
 ```typescript
-import { Plugins } from '@capacitor/core';
+import { Plugins, KeyboardInfo } from '@capacitor/core';
 
 const { Keyboard } = Plugins;
 


### PR DESCRIPTION
add import for KeyboardInfo