### PR TITLE
fix(web): Gracefully degrade Proxy usage to fix IE11

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -59,8 +59,7 @@
     },
     "testMatch": [
       "**/__test__/*.(ts|tsx|js)"
-    ],
-    "testURL": "http://localhost/"
+    ]
   },
   "dependencies": {
     "tslib": "^1.9.0"

--- a/core/package.json
+++ b/core/package.json
@@ -59,7 +59,8 @@
     },
     "testMatch": [
       "**/__test__/*.(ts|tsx|js)"
-    ]
+    ],
+    "testURL": "http://localhost/"
   },
   "dependencies": {
     "tslib": "^1.9.0"


### PR DESCRIPTION
Fixes https://github.com/ionic-team/capacitor/issues/456. This guards the `Proxy` usage is order to ensures that loading Capacitor does not throw a Syntax Error in IE11 and other older browser engines.