### PR TITLE
docs(updating): Provide a full path to variables.gradle file

### DIFF
--- a/site/docs-md/android/updating.md
+++ b/site/docs-md/android/updating.md
@@ -60,7 +60,7 @@ Recommended changes:
 
 * Create common variables
 
-  Create a `variables.gradle` file inside `android` folder with this content
+  Create a `android/variables.gradle` file with this content
 
   ```
   ext {


### PR DESCRIPTION
To me this is not so specific. I'd prefer to have a clear path, since the android project contains several gradle files in different directories.