### PR TITLE
fix(android): avoid camera crash on photo edit cancel

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -485,6 +485,7 @@ public class Camera extends Plugin {
       isEdited = true;
       processPickedImage(savedCall, data);
     } else if (resultCode == Activity.RESULT_CANCELED && imageFileSavePath != null) {
+      imageEditedFileSavePath = null;
       isEdited = true;
       processCameraImage(savedCall);
     }


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor/issues/2766