### PR TITLE
fix(ios): allow Browser popover presentation if supported

### DIFF
--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -34,5 +34,6 @@
 -(NSString *) getString:(CAPPluginCall *)call field:(NSString *)field defaultValue:(NSString *)defaultValue;
 -(id)getConfigValue:(NSString *) key;
 -(void)setCenteredPopover:(UIViewController *) vc;
+-(BOOL)supportsPopover;
 
 @end

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -147,5 +147,13 @@
   vc.popoverPresentationController.permittedArrowDirections = 0;
 }
 
+-(BOOL)supportsPopover {
+  if (@available(iOS 13, *)) {
+    return YES;
+  } else {
+    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
+  }
+}
+
 @end
 

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -23,7 +23,7 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
         self.vc = SFSafariViewController.init(url: url!)
         self.vc!.delegate = self
         let presentationStyle = call.getString("presentationStyle")
-        if presentationStyle != nil && presentationStyle == "popover" && UIDevice.current.userInterfaceIdiom == .pad {
+        if presentationStyle != nil && presentationStyle == "popover" && self.supportsPopover() {
           self.vc!.modalPresentationStyle = .popover
           self.setCenteredPopover(self.vc)
         } else {


### PR DESCRIPTION
iOS 13 supports popover presentation on iPhones, so allow Browser to also use popover presentation in that case