### PR TITLE
Add New plugin for capacitor : capacitor-snackbar-gfc

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -45,6 +45,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | Name                    | NPM package | GitHub | Notes |
 | ----------------------- | ----------- | ------ | ------ |
 | Keep Screen On |`capacitor-keep-screen-on` | <https://github.com/go-u/capacitor-keep-screen-on> | |
+| Snackbar | [`capacitor-snackbar-gfc`](https://www.npmjs.com/package/capacitor-snackbar-gfc)  | <https://github.com/SASGeniusFlashConception/capacitor-snackbar-gfc> | Currently on Android, soon on Ios
 
 ## Storage
 


### PR DESCRIPTION
We would like to make available to the community our new plugin which displays the native snackBar component