### PR TITLE
PhotosPlugin - savePhoto Android implementation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -23,4 +23,5 @@ public class PluginRequestCodes {
   public static final int FILESYSTEM_REQUEST_STAT_PERMISSIONS = 9019;
   public static final int FILESYSTEM_REQUEST_RENAME_PERMISSIONS = 9020;
   public static final int FILESYSTEM_REQUEST_COPY_PERMISSIONS = 9021;
+  public static final int PHOTOS_REQUEST_WRITE_FILE_PERMISSIONS = 9022;
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Photos.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Photos.java
@@ -1,11 +1,27 @@
 package com.getcapacitor.plugin;
 
+import android.Manifest;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.MediaStore;
+import android.util.Base64;
+import android.util.Log;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
+import com.getcapacitor.PluginRequestCodes;
+import java.io.IOException;
+import java.io.OutputStream;
 
-@NativePlugin()
+@NativePlugin(
+        permissions = {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+        requestCodes = {PluginRequestCodes.PHOTOS_REQUEST_WRITE_FILE_PERMISSIONS},
+        permissionRequestCode = PluginRequestCodes.PHOTOS_REQUEST_WRITE_FILE_PERMISSIONS
+)
 public class Photos extends Plugin {
 
   @PluginMethod()
@@ -25,6 +41,90 @@ public class Photos extends Plugin {
 
   @PluginMethod()
   public void savePhoto(PluginCall call) {
-    call.unimplemented();
+    saveCall(call);
+
+    if (!hasPhotosPermissions()) {
+      return;
+    }
+
+    String data = removeBase64DataUri(call.getString("data", ""));
+
+    if (data.isEmpty()) {
+      call.error("Data field cannot be empty");
+      return;
+    }
+
+    ContentValues contentValues = new ContentValues();
+    contentValues.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
+    contentValues.put(MediaStore.Images.Media.DATE_ADDED, System.currentTimeMillis());
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      contentValues.put(MediaStore.Images.Media.DATE_TAKEN, System.currentTimeMillis());
+      contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1);
+    }
+
+    ContentResolver resolver = getActivity().getContentResolver();
+    Uri imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
+
+    try (OutputStream fos = getActivity().getContentResolver().openOutputStream(imageUri)) {
+      fos.write(Base64.decode(data, Base64.NO_WRAP));
+    } catch (IOException e) {
+      resolver.delete(imageUri, null, null);
+      call.error("Cannot create image file");
+    } finally {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0);
+      }
+    }
+
+    call.success();
+  }
+
+  @Override
+  protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
+
+    PluginCall savedCall = getSavedCall();
+
+    if (savedCall == null) {
+      savedCall.error("Unable to perform operation. Cannot retrieve saved call");
+      return;
+    }
+
+    if (someDenied(grantResults)) {
+      savedCall.error("Unable to access external storage, user denied permission request");
+      return;
+    }
+
+    if (requestCode == PluginRequestCodes.PHOTOS_REQUEST_WRITE_FILE_PERMISSIONS) {
+      savePhoto(savedCall);
+    }
+  }
+
+  private boolean hasPhotosPermissions() {
+    String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
+    if (hasPermission(permission)) {
+      Log.v(getLogTag(), String.format("Permission '%s' is granted", permission));
+      return true;
+    }
+
+    Log.v(getLogTag(), String.format("Permission '%s' denied. Asking user for it.", permission));
+    pluginRequestPermission(permission, PluginRequestCodes.PHOTOS_REQUEST_WRITE_FILE_PERMISSIONS);
+    return false;
+  }
+
+  private String removeBase64DataUri(String data) {
+    return data.startsWith("data:") ? data.substring(data.indexOf(",") + 1) : data;
+  }
+
+  private boolean someDenied(int[] list) {
+    for (int e : list) {
+      if (e == PackageManager.PERMISSION_DENIED) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1358,11 +1358,11 @@ export interface PhotosPlugin extends Plugin {
    */
   getAlbums(options?: PhotosAlbumsFetchOptions): Promise<PhotosAlbumsResult>;
   /**
-   * Save a photo the the user's photo library
+   * Save a photo to the user's photo library
    */
   savePhoto(options?: PhotosSaveOptions): Promise<PhotosSaveResult>;
   /**
-   * Create an album in the user's photo library
+   * iOS only. Create an album in the user's photo library
    */
   createAlbum(options: PhotosCreateAlbumOptions): Promise<void>;
 }
@@ -1465,17 +1465,12 @@ export interface PhotosSaveOptions {
    */
   data: string;
   /**
-   * The optional album identifier to save this photo in
+   * iOS only. The optional album identifier to save this photo in
    */
   albumIdentifier?: string;
 }
 
-export interface PhotosSaveResult {
-  /**
-   * Whether the photo was created
-   */
-  success: boolean;
-}
+export interface PhotosSaveResult {}
 
 export interface PhotosAlbumsFetchOptions {
   /**


### PR DESCRIPTION
Hi,

I was looking for a save-photo-to-gallery functionality and just found a core undocumented [Photos plugin](https://github.com/ionic-team/capacitor/blob/master/core/src/core-plugin-definitions.ts#L1351), with partial implementation on iOS and empty implementation on Android. That's what I need.

I think it could be interesting to complete this core plugin rather than creating an external one, maybe with a plugin refactoring. I've implemented and committed a functional `savePhoto` method for Android.

