### PR TITLE
fix(android) : App can crash on clipboard.read if empty

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
@@ -48,23 +48,35 @@ public class Clipboard extends Plugin {
     ClipboardManager clipboard = (ClipboardManager)
         c.getSystemService(Context.CLIPBOARD_SERVICE);
 
-    CharSequence value = "";
-    if(clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-      Log.d(getLogTag(), "Got plaintxt");
-      ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-      value = item.getText();
-    } else {
-      Log.d(getLogTag(), "Not plaintext!");
-      ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-      value = item.coerceToText(this.getContext()).toString();
+    CharSequence value = null;
+
+    if (clipboard.hasPrimaryClip()) {
+      if(clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+        Log.d(getLogTag(), "Got plaintxt");
+        ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+        value = item.getText();
+      } else {
+        Log.d(getLogTag(), "Not plaintext!");
+        ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+        value = item.coerceToText(this.getContext()).toString();
+      }
     }
+
     JSObject ret = new JSObject();
     String type = "text/plain";
-    ret.put("value", value != null ? value : "");
-    if (value != null && value.toString().startsWith("data:")) {
-      type = value.toString().split(";")[0].split(":")[1];
+
+    if (value != null) {
+      ret.put("value", value);
+      if (value.toString().startsWith("data:")) {
+        type = value.toString().split(";")[0].split(":")[1];
+      }
     }
+    else {
+      ret.put("value", "");
+    }
+
     ret.put("type", type);
+
     call.success(ret);
   }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
@@ -64,17 +64,10 @@ public class Clipboard extends Plugin {
 
     JSObject ret = new JSObject();
     String type = "text/plain";
-
-    if (value != null) {
-      ret.put("value", value);
-      if (value.toString().startsWith("data:")) {
-        type = value.toString().split(";")[0].split(":")[1];
-      }
+    ret.put("value", value != null ? value : "");
+    if (value != null && value.toString().startsWith("data:")) {
+      type = value.toString().split(";")[0].split(":")[1];
     }
-    else {
-      ret.put("value", "");
-    }
-
     ret.put("type", type);
 
     call.success(ret);


### PR DESCRIPTION
I encountered app crash when reading the content of the clipboard since 2.0.0+
It only occurs on Android platform and in my case on a Samsung with Android 7.
When my clipboard is empty (like after a reboot) and I attempt to read it, the plugin crashes the app because of a `NullPointerException`.
I checked the Android documentation and found the method [hasPrimaryClip()](https://developer.android.com/reference/android/content/ClipboardManager#hasPrimaryClip()).
So I implemented it in order to check if the primary clip exists. If it's the case, normal behavior happen otherwise the clipboard content will be set to an empty string.