### PR TITLE
fix(ios): remove applicationState check on keyboard plugin

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -110,59 +110,51 @@ NSString* UITraitsClassString;
 
 - (void)onKeyboardWillHide:(NSNotification *)notification
 {
-  if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
-    [self setKeyboardHeight:0 delay:0.01];
-    [self resetScrollView];
-    hideTimer = [NSTimer scheduledTimerWithTimeInterval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
-      [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillHide"];
-      [self notifyListeners:@"keyboardWillHide" data:nil];
-    }];
-  }
+  [self setKeyboardHeight:0 delay:0.01];
+  [self resetScrollView];
+  hideTimer = [NSTimer scheduledTimerWithTimeInterval:0 repeats:NO block:^(NSTimer * _Nonnull timer) {
+    [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillHide"];
+    [self notifyListeners:@"keyboardWillHide" data:nil];
+  }];
 }
 
 - (void)onKeyboardWillShow:(NSNotification *)notification
 {
   [self changeKeyboardStyle:self.keyboardStyle];
-  if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
-    if (hideTimer != nil) {
-      [hideTimer invalidate];
-    }
-    CGRect rect = [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-    double height = rect.size.height;
-
-    double duration = [[notification.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue]+0.2;
-    [self setKeyboardHeight:height delay:duration];
-    [self resetScrollView];
-
-    NSString * data = [NSString stringWithFormat:@"{ 'keyboardHeight': %d }", (int)height];
-    [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillShow" data:data];
-    NSDictionary * kbData = @{@"keyboardHeight": [NSNumber numberWithDouble:height]};
-    [self notifyListeners:@"keyboardWillShow" data:kbData];
+  if (hideTimer != nil) {
+    [hideTimer invalidate];
   }
+  CGRect rect = [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  double height = rect.size.height;
+
+  double duration = [[notification.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue]+0.2;
+  [self setKeyboardHeight:height delay:duration];
+  [self resetScrollView];
+
+  NSString * data = [NSString stringWithFormat:@"{ 'keyboardHeight': %d }", (int)height];
+  [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillShow" data:data];
+  NSDictionary * kbData = @{@"keyboardHeight": [NSNumber numberWithDouble:height]};
+  [self notifyListeners:@"keyboardWillShow" data:kbData];
 }
 
 - (void)onKeyboardDidShow:(NSNotification *)notification
 {
-  if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
-    CGRect rect = [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-    double height = rect.size.height;
+  CGRect rect = [[notification.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+  double height = rect.size.height;
 
-    [self resetScrollView];
+  [self resetScrollView];
 
-    NSString * data = [NSString stringWithFormat:@"{ 'keyboardHeight': %d }", (int)height];
-    [self.bridge triggerWindowJSEventWithEventName:@"keyboardDidShow" data:data];
-    NSDictionary * kbData = @{@"keyboardHeight": [NSNumber numberWithDouble:height]};
-    [self notifyListeners:@"keyboardDidShow" data:kbData];
-  }
+  NSString * data = [NSString stringWithFormat:@"{ 'keyboardHeight': %d }", (int)height];
+  [self.bridge triggerWindowJSEventWithEventName:@"keyboardDidShow" data:data];
+  NSDictionary * kbData = @{@"keyboardHeight": [NSNumber numberWithDouble:height]};
+  [self notifyListeners:@"keyboardDidShow" data:kbData];
 }
 
 - (void)onKeyboardDidHide:(NSNotification *)notification
 {
-  if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
-    [self.bridge triggerWindowJSEventWithEventName:@"keyboardDidHide"];
-    [self notifyListeners:@"keyboardDidHide" data:nil];
-    [self resetScrollView];
-  }
+  [self.bridge triggerWindowJSEventWithEventName:@"keyboardDidHide"];
+  [self notifyListeners:@"keyboardDidHide" data:nil];
+  [self resetScrollView];
 }
 
 - (void)setKeyboardHeight:(int)height delay:(NSTimeInterval)delay


### PR DESCRIPTION
The applicationState active check was there to try to solve a visual glitch when swiping apps if one of them was showing a keyboard, but was not solving it completely and causes other problems, so I'm removing the check. 

closes #2804