### PR TITLE
feat(android): hideLogs feature

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/AndroidProtocolHandler.java
@@ -7,7 +7,6 @@ package com.getcapacitor;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
-import android.util.Log;
 import android.util.TypedValue;
 
 import java.io.File;
@@ -51,10 +50,10 @@ public class AndroidProtocolHandler {
       if (valueType == TypedValue.TYPE_STRING) {
         return context.getResources().openRawResource(fieldId);
       } else {
-        Log.e(LogUtils.getCoreTag(), "Asset not of type string: " + uri);
+        Logger.error("Asset not of type string: " + uri);
       }
     } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
-      Log.e(LogUtils.getCoreTag(), "Unable to open resource URL: " + uri, e);
+      Logger.error("Unable to open resource URL: " + uri, e);
     }
     return null;
   }
@@ -86,7 +85,7 @@ public class AndroidProtocolHandler {
     try {
       stream = context.getContentResolver().openInputStream(Uri.parse(realPath));
     } catch (SecurityException e) {
-      Log.e(LogUtils.getCoreTag(), "Unable to open content URL: " + uri, e);
+      Logger.error("Unable to open content URL: " + uri, e);
     }
     return stream;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -11,7 +11,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.util.Log;
 import android.webkit.ValueCallback;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -75,7 +74,6 @@ import java.util.ArrayList;
  */
 public class Bridge {
 
-  private static final String LOG_TAG = LogUtils.getCoreTag();
   private static final String PREFS_NAME = "CapacitorSettings";
   private static final String BUNDLE_LAST_PLUGIN_ID_KEY = "capacitorLastActivityPluginId";
   private static final String BUNDLE_LAST_PLUGIN_CALL_METHOD_NAME_KEY = "capacitorLastActivityPluginMethod";
@@ -209,7 +207,7 @@ public class Bridge {
     localServer = new WebViewLocalServer(context, this, getJSInjector(), authorities, html5mode);
     localServer.hostAssets(DEFAULT_WEB_ASSET_DIR);
 
-    Log.d(LOG_TAG, "Loading app at " + appUrl);
+    Logger.debug("Loading app at " + appUrl);
 
     webView.setWebChromeClient(new BridgeWebChromeClient(this));
     webView.setWebViewClient(this.webViewClient);
@@ -251,7 +249,7 @@ public class Bridge {
       versionCode = Integer.toString(pInfo.versionCode);
       versionName = pInfo.versionName;
     } catch(Exception ex) {
-      Log.e(LOG_TAG, "Unable to get package info", ex);
+      Logger.error("Unable to get package info", ex);
     }
 
     if (!versionCode.equals(lastVersionCode) || !versionName.equals(lastVersionName)) {
@@ -275,7 +273,7 @@ public class Bridge {
       if (BuildConfig.DEBUG) {
         Toast.show(getContext(), "Unable to load app. Are you sure the server is running at " + appUrl + "?");
       }
-      Log.e(LOG_TAG, "Unable to load app. Ensure the server is running at " + appUrl + ", or modify the " +
+      Logger.error("Unable to load app. Ensure the server is running at " + appUrl + ", or modify the " +
           "appUrl setting in capacitor.config.json (make sure to npx cap copy after to commit changes).", ex);
     }
   }
@@ -323,22 +321,6 @@ public class Bridge {
       return Config.getString("server.androidScheme", CAPACITOR_HTTP_SCHEME);
   }
 
-  /*
-  public void registerPlugins() {
-    Log.d(LOG_TAG, "Finding plugins");
-    try {
-      Enumeration<URL> roots = getClass().getClassLoader().getResources("");
-      while (roots.hasMoreElements()) {
-        URL url = roots.nextElement();
-        Log.d(LOG_TAG, "CLASSAPTH ROOT: " + url.getPath());
-        //File root = new File(url.getPath());
-      }
-    } catch(Exception ex) {
-      Log.e(LOG_TAG, "Unable to query for plugin classes", ex);
-    }
-  }
-  */
-
   public void reset() {
     savedCalls = new HashMap<>();
   }
@@ -376,7 +358,7 @@ public class Bridge {
         webView.setBackgroundColor(Color.parseColor(backgroundColor));
       }
     } catch (IllegalArgumentException ex) {
-      Log.d(LogUtils.getCoreTag(), "WebView background color not applied");
+      Logger.debug("WebView background color not applied");
     }
     boolean defaultDebuggable = false;
     if (isDevMode()) {
@@ -437,7 +419,7 @@ public class Bridge {
     NativePlugin pluginAnnotation = pluginClass.getAnnotation(NativePlugin.class);
 
     if (pluginAnnotation == null) {
-      Log.e(LOG_TAG, "NativePlugin doesn't have the @NativePlugin annotation. Please add it");
+      Logger.error("NativePlugin doesn't have the @NativePlugin annotation. Please add it");
       return;
     }
 
@@ -448,16 +430,16 @@ public class Bridge {
       pluginId = pluginAnnotation.name();
     }
 
-    Log.d(LOG_TAG, "Registering plugin: " + pluginId);
+    Logger.debug("Registering plugin: " + pluginId);
 
     try {
       this.plugins.put(pluginId, new PluginHandle(this, pluginClass));
     } catch (InvalidPluginException ex) {
-      Log.e(LOG_TAG, "NativePlugin " + pluginClass.getName() +
+      Logger.error("NativePlugin " + pluginClass.getName() +
           " is invalid. Ensure the @NativePlugin annotation exists on the plugin class and" +
           " the class extends Plugin");
     } catch (PluginLoadException ex) {
-      Log.e(LOG_TAG, "NativePlugin " + pluginClass.getName() + " failed to load", ex);
+      Logger.error("NativePlugin " + pluginClass.getName() + " failed to load", ex);
     }
   }
 
@@ -504,12 +486,12 @@ public class Bridge {
       final PluginHandle plugin = this.getPlugin(pluginId);
 
       if (plugin == null) {
-        Log.e(LOG_TAG, "unable to find plugin : " + pluginId);
+        Logger.error("unable to find plugin : " + pluginId);
         call.errorCallback("unable to find plugin : " + pluginId);
         return;
       }
 
-      Log.v(LOG_TAG, "callback: " + call.getCallbackId() +
+      Logger.verbose("callback: " + call.getCallbackId() +
           ", pluginId: " + plugin.getId() +
           ", methodName: " + methodName + ", methodData: " + call.getData().toString());
 
@@ -523,9 +505,9 @@ public class Bridge {
               saveCall(call);
             }
           } catch(PluginLoadException | InvalidPluginMethodException ex) {
-            Log.e(LOG_TAG, "Unable to execute plugin method", ex);
+            Logger.error("Unable to execute plugin method", ex);
           } catch (Exception ex) {
-            Log.e(LOG_TAG, "Serious error executing plugin", ex);
+            Logger.error("Serious error executing plugin", ex);
             throw new RuntimeException(ex);
           }
         }
@@ -534,7 +516,7 @@ public class Bridge {
       taskHandler.post(currentThreadTask);
 
     } catch (Exception ex) {
-      Log.e("callPluginMethod", "error : " + ex);
+      Logger.error(Logger.tags("callPluginMethod"), "error : " + ex, null);
       call.errorCallback(ex.toString());
     }
   }
@@ -647,7 +629,7 @@ public class Bridge {
 
       return new JSInjector(globalJS, coreJS, pluginJS, cordovaJS, cordovaPluginsJS, cordovaPluginsFileJS, localUrlJS);
     } catch(JSExportException ex) {
-      Log.e(LOG_TAG, "Unable to export Capacitor JS. App will not function!", ex);
+      Logger.error("Unable to export Capacitor JS. App will not function!", ex);
     }
     return null;
   }
@@ -678,7 +660,7 @@ public class Bridge {
               lastPluginId, PluginCall.CALLBACK_ID_DANGLING, lastPluginCallMethod, options);
 
         } catch (JSONException ex) {
-          Log.e(LOG_TAG, "Unable to restore plugin call, unable to parse persisted JSON object", ex);
+          Logger.error("Unable to restore plugin call, unable to parse persisted JSON object", ex);
         }
       }
 
@@ -692,7 +674,7 @@ public class Bridge {
   }
 
   public void saveInstanceState(Bundle outState) {
-    Log.d(LOG_TAG, "Saving instance state!");
+    Logger.debug("Saving instance state!");
 
     // If there was a last PluginCall for a started activity, we need to
     // persist it so we can load it again in case our app gets terminated
@@ -710,7 +692,7 @@ public class Bridge {
   }
 
   public void startActivityForPluginWithResult(PluginCall call, Intent intent, int requestCode) {
-    Log.d(LOG_TAG, "Starting activity for result");
+    Logger.debug("Starting activity for result");
 
     pluginCallForLastActivity = call;
 
@@ -729,11 +711,11 @@ public class Bridge {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
     if (plugin == null) {
-      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle permission requestCode, trying Cordova plugins " + requestCode);
+      Logger.debug("Unable to find a Capacitor plugin to handle permission requestCode, trying Cordova plugins " + requestCode);
       try {
         cordovaInterface.onRequestPermissionResult(requestCode, permissions, grantResults);
       } catch (JSONException e) {
-        Log.d(LOG_TAG, "Error on Cordova plugin permissions request " + e.getMessage());
+        Logger.debug("Error on Cordova plugin permissions request " + e.getMessage());
       }
       return;
     }
@@ -752,7 +734,7 @@ public class Bridge {
     PluginHandle plugin = getPluginWithRequestCode(requestCode);
 
     if (plugin == null || plugin.getInstance() == null) {
-      Log.d(LOG_TAG, "Unable to find a Capacitor plugin to handle requestCode, trying Cordova plugins " + requestCode);
+      Logger.debug("Unable to find a Capacitor plugin to handle requestCode, trying Cordova plugins " + requestCode);
       cordovaInterface.onActivityResult(requestCode, resultCode, data);
       return;
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.webkit.WebView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -62,7 +61,7 @@ public class BridgeActivity extends AppCompatActivity {
    * Load the WebView and create the Bridge
    */
   protected void load(Bundle savedInstanceState) {
-    Log.d(LogUtils.getCoreTag(), "Starting BridgeActivity");
+    Logger.debug("Starting BridgeActivity");
 
     webView = findViewById(R.id.webview);
 
@@ -122,14 +121,14 @@ public class BridgeActivity extends AppCompatActivity {
     this.bridge.onStart();
     mockWebView.handleStart();
 
-    Log.d(LogUtils.getCoreTag(), "App started");
+    Logger.debug("App started");
   }
 
   @Override
   public void onRestart() {
     super.onRestart();
     this.bridge.onRestart();
-    Log.d(LogUtils.getCoreTag(), "App restarted");
+    Logger.debug("App restarted");
   }
 
   @Override
@@ -142,7 +141,7 @@ public class BridgeActivity extends AppCompatActivity {
 
     mockWebView.handleResume(this.keepRunning);
 
-    Log.d(LogUtils.getCoreTag(), "App resumed");
+    Logger.debug("App resumed");
   }
 
   @Override
@@ -155,7 +154,7 @@ public class BridgeActivity extends AppCompatActivity {
       this.mockWebView.handlePause(keepRunning);
     }
 
-    Log.d(LogUtils.getCoreTag(), "App paused");
+    Logger.debug("App paused");
   }
 
   @Override
@@ -173,7 +172,7 @@ public class BridgeActivity extends AppCompatActivity {
       mockWebView.handleStop();
     }
 
-    Log.d(LogUtils.getCoreTag(), "App stopped");
+    Logger.debug("App stopped");
   }
 
   @Override
@@ -183,7 +182,7 @@ public class BridgeActivity extends AppCompatActivity {
     if (this.mockWebView != null) {
       mockWebView.handleDestroy();
     }
-    Log.d(LogUtils.getCoreTag(), "App destroyed");
+    Logger.debug("App destroyed");
   }
 
   @Override

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
@@ -6,7 +6,6 @@ import android.content.res.TypedArray;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -84,7 +83,7 @@ public class BridgeFragment extends Fragment {
    * Load the WebView and create the Bridge
    */
   protected void load(Bundle savedInstanceState) {
-    Log.d(LogUtils.getCoreTag(), "Starting BridgeActivity");
+    Logger.debug("Starting BridgeActivity");
 
     Bundle args = getArguments();
     String startDir = null;

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.provider.MediaStore;
-import android.util.Log;
 import android.webkit.ConsoleMessage;
 import android.webkit.GeolocationPermissions;
 import android.webkit.JsPromptResult;
@@ -181,7 +180,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
   @Override
   public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
     super.onGeolocationPermissionsShowPrompt(origin, callback);
-    Log.d(LogUtils.getCoreTag(), "onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
+    Logger.debug("onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
 
     // Set that we want geolocation perms for this origin
     callback.invoke(origin, true, false);
@@ -190,7 +189,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     if (!geo.hasRequiredPermissions()) {
       geo.pluginRequestAllPermissions();
     } else {
-      Log.d(LogUtils.getCoreTag(), "onGeolocationPermissionsShowPrompt: has required permis");
+      Logger.debug("onGeolocationPermissionsShowPrompt: has required permis");
     }
   }
 
@@ -211,7 +210,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
               if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 showMediaCaptureOrFilePicker(filePathCallback, fileChooserParams, captureVideo);
               } else {
-                Log.w(LogUtils.getCoreTag("FileChooser"), "Camera permission not granted");
+                Logger.warn(Logger.tags("FileChooser"), "Camera permission not granted");
                 filePathCallback.onReceiveValue(null);
               }
             }
@@ -244,7 +243,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
       shown = showImageCapturePicker(filePathCallback);
     }
     if (!shown) {
-      Log.w(LogUtils.getCoreTag("FileChooser"), "Media capture intent could not be launched. Falling back to default file picker.");
+      Logger.warn(Logger.tags("FileChooser"), "Media capture intent could not be launched. Falling back to default file picker.");
       showFilePicker(filePathCallback, fileChooserParams);
     }
   }
@@ -259,7 +258,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     try {
       imageFileUri = CameraUtils.createImageFileUri(bridge.getActivity(), bridge.getContext().getPackageName());
     } catch (Exception ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to create temporary media capture file: " + ex.getMessage());
+      Logger.error("Unable to create temporary media capture file: " + ex.getMessage());
       return false;
     }
     takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageFileUri);
@@ -350,18 +349,18 @@ public class BridgeWebChromeClient extends WebChromeClient {
 
   @Override
   public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
-    String tag = "Capacitor/Console";
+    String tag = Logger.tags("Console");
     if (consoleMessage.message() != null && isValidMsg(consoleMessage.message())) {
       String msg = String.format("File: %s - Line %d - Msg: %s" , consoleMessage.sourceId() , consoleMessage.lineNumber(), consoleMessage.message());
       String level = consoleMessage.messageLevel().name();
       if ("ERROR".equalsIgnoreCase(level)) {
-        Log.e(tag, msg);
+        Logger.error(tag, msg, null);
       } else if ("WARNING".equalsIgnoreCase(level)) {
-        Log.w(tag, msg);
+        Logger.warn(tag, msg);
       } else if ("TIP".equalsIgnoreCase(level)) {
-        Log.d(tag, msg);
+        Logger.debug(tag, msg);
       } else {
-        Log.i(tag, msg);
+        Logger.info(tag, msg);
       }
     }
     return true;

--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -2,14 +2,11 @@ package com.getcapacitor;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.webkit.WebView;
-
-import java.util.Date;
 
 public class CapacitorWebView extends WebView {
   private BaseInputConnection capInputConnection;

--- a/android/capacitor/src/main/java/com/getcapacitor/Config.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Config.java
@@ -1,7 +1,6 @@
 package com.getcapacitor;
 
 import android.app.Activity;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -48,9 +47,9 @@ public class Config {
       String jsonString = b.toString();
       this.config = new JSONObject(jsonString);
     } catch (IOException ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to load capacitor.config.json. Run npx cap copy first", ex);
+      Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);
     } catch (JSONException ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to parse capacitor.config.json. Make sure it's valid json", ex);
+      Logger.error("Unable to parse capacitor.config.json. Make sure it's valid json", ex);
     } finally {
       if (reader != null) {
         try {

--- a/android/capacitor/src/main/java/com/getcapacitor/Dialogs.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Dialogs.java
@@ -1,6 +1,5 @@
 package com.getcapacitor;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -33,7 +33,6 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.provider.OpenableColumns;
-import android.util.Log;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -2,7 +2,6 @@ package com.getcapacitor;
 
 import android.content.Context;
 import android.text.TextUtils;
-import android.util.Log;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -48,7 +47,7 @@ public class JSExport {
     try {
       fileContent = getJS(context, "public/cordova.js");
     } catch(IOException ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to read public/cordova.js file, Cordova plugins will not work");
+      Logger.error("Unable to read public/cordova.js file, Cordova plugins will not work");
     }
     return fileContent;
   }
@@ -58,7 +57,7 @@ public class JSExport {
     try {
       fileContent = getJS(context, "public/cordova_plugins.js");
     } catch(IOException ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
+      Logger.error("Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
     }
     return fileContent;
   }
@@ -109,7 +108,7 @@ public class JSExport {
         return getJS(context, path);
       }
     } catch(IOException ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to read file at path " + path);
+      Logger.error("Unable to read file at path " + path);
     }
     return builder.toString();
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -1,7 +1,5 @@
 package com.getcapacitor;
 
-import android.util.Log;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -62,7 +60,7 @@ class JSInjector {
     } else if (html.contains("</head>")) {
       html = html.replace("</head>", js + "\n" + "</head>");
     } else {
-      Log.e(LogUtils.getCoreTag(), "Unable to inject Capacitor, Plugins won't work");
+      Logger.error("Unable to inject Capacitor, Plugins won't work");
     }
     return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
   }
@@ -81,7 +79,7 @@ class JSInjector {
       }
       return out.toString();
     } catch (Exception e) {
-      Log.e(LogUtils.getCoreTag(), "Unable to process HTML asset file. This is a fatal error", e);
+      Logger.error("Unable to process HTML asset file. This is a fatal error", e);
     }
 
     return "";

--- a/android/capacitor/src/main/java/com/getcapacitor/LogUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/LogUtils.java
@@ -3,15 +3,24 @@ package com.getcapacitor;
 import android.text.TextUtils;
 
 /**
- *
+ * @deprecated
  */
 public abstract class LogUtils {
 
+  /**
+   * @deprecated
+   */
   public static final String LOG_TAG_CORE = "Capacitor";
+
+  /**
+   * @deprecated
+   */
   public static final String LOG_TAG_PLUGIN = LOG_TAG_CORE + "/Plugin";
 
   /**
    * Creates a core log TAG
+   *
+   * @deprecated
    * @param subTags sub log tags joined by a slash
    */
   public static String getCoreTag(String... subTags) {
@@ -20,6 +29,8 @@ public abstract class LogUtils {
 
   /**
    * Creates a plugin log TAG
+   *
+   * @deprecated
    * @param subTags sub log tags joined by a slash
    */
   public static String getPluginTag(String... subTags) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Logger.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Logger.java
@@ -1,0 +1,84 @@
+package com.getcapacitor;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+public class Logger {
+  public static final String LOG_TAG_CORE = "Capacitor";
+
+  public static String tags(String... subtags) {
+    if (subtags != null && subtags.length > 0) {
+      return LOG_TAG_CORE + "/" + TextUtils.join("/", subtags);
+    }
+
+    return LOG_TAG_CORE;
+  }
+
+  public static void verbose(String message) {
+    verbose(LOG_TAG_CORE, message);
+  }
+
+  public static void verbose(String tag, String message) {
+    if (!shouldLog()) {
+      return;
+    }
+
+    Log.v(tag, message);
+  }
+
+  public static void debug(String message) {
+    debug(LOG_TAG_CORE, message);
+  }
+
+  public static void debug(String tag, String message) {
+    if (!shouldLog()) {
+      return;
+    }
+
+    Log.d(tag, message);
+  }
+
+  public static void info(String message) {
+    info(LOG_TAG_CORE, message);
+  }
+
+  public static void info(String tag, String message) {
+    if (!shouldLog()) {
+      return;
+    }
+
+    Log.i(tag, message);
+  }
+
+  public static void warn(String message) {
+    warn(LOG_TAG_CORE, message);
+  }
+
+  public static void warn(String tag, String message) {
+    if (!shouldLog()) {
+      return;
+    }
+
+    Log.w(tag, message);
+  }
+
+  public static void error(String message) {
+    error(LOG_TAG_CORE, message, null);
+  }
+
+  public static void error(String message, Throwable e) {
+    error(LOG_TAG_CORE, message, e);
+  }
+
+  public static void error(String tag, String message, Throwable e) {
+    if (!shouldLog()) {
+      return;
+    }
+
+    Log.e(tag, message, e);
+  }
+
+  protected static boolean shouldLog() {
+    return !Config.getBoolean("android.hideLogs", false);
+  }
+}

--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -1,6 +1,5 @@
 package com.getcapacitor;
 
-import android.util.Log;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
@@ -41,22 +40,22 @@ public class MessageHandler {
         String service = postData.getString("service");
         String action = postData.getString("action");
         String actionArgs = postData.getString("actionArgs");
-        Log.v(LogUtils.getPluginTag(), "To native (Cordova plugin): callbackId: " + callbackId + ", service: " + service +
+        Logger.verbose(Logger.tags("Plugin"), "To native (Cordova plugin): callbackId: " + callbackId + ", service: " + service +
           ", action: " + action + ", actionArgs: " + actionArgs);
         this.callCordovaPluginMethod(callbackId, service, action, actionArgs);
       } else if (type != null && type.equals("js.error")) {
-        Log.e(LogUtils.getCoreTag(), "JavaScript Error: " + jsonStr);
+        Logger.error("JavaScript Error: " + jsonStr);
       } else {
         String callbackId = postData.getString("callbackId");
         String pluginId = postData.getString("pluginId");
         String methodName = postData.getString("methodName");
         JSObject methodData = postData.getJSObject("options", new JSObject());
-        Log.v(LogUtils.getPluginTag(), "To native (Capacitor plugin): callbackId: " + callbackId + ", pluginId: " + pluginId + ", methodName: " + methodName);
+        Logger.verbose(Logger.tags("Plugin"), "To native (Capacitor plugin): callbackId: " + callbackId + ", pluginId: " + pluginId + ", methodName: " + methodName);
         this.callPluginMethod(callbackId, pluginId, methodName, methodData);
       }
 
     } catch (Exception ex) {
-      Log.e(LogUtils.getCoreTag(), "Post message error:", ex);
+      Logger.error("Post message error:", ex);
     }
   }
 
@@ -81,7 +80,7 @@ public class MessageHandler {
       if (errorResult != null) {
         data.put("success", false);
         data.put("error", errorResult);
-        Log.d(LogUtils.getCoreTag(), "Sending plugin error: " + data.toString());
+        Logger.debug("Sending plugin error: " + data.toString());
       } else {
         data.put("success", true);
         data.put("data", successResult);
@@ -103,7 +102,7 @@ public class MessageHandler {
       }
 
     } catch (Exception ex) {
-      Log.e(LogUtils.getCoreTag(), "sendResponseMessage: error: " + ex);
+      Logger.error("sendResponseMessage: error: " + ex);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -335,10 +334,10 @@ public class Plugin {
    * @param data
    */
   protected void notifyListeners(String eventName, JSObject data, boolean retainUntilConsumed) {
-    Log.v(getLogTag(), "Notifying listeners for event " + eventName);
+    Logger.verbose(getLogTag(), "Notifying listeners for event " + eventName);
     List<PluginCall> listeners = eventListeners.get(eventName);
     if (listeners == null || listeners.isEmpty()) {
-      Log.d(getLogTag(), "No listeners found for event " + eventName);
+      Logger.debug(getLogTag(), "No listeners found for event " + eventName);
       if (retainUntilConsumed) {
         retainedEventArguments.put(eventName, data);
       }
@@ -576,13 +575,13 @@ public class Plugin {
    * @param subTags
    */
   protected String getLogTag(String... subTags) {
-    return LogUtils.getPluginTag(subTags);
+    return Logger.tags(subTags);
   }
 
   /**
    * Gets a plugin log tag with the child's class name as subTag.
    */
   protected String getLogTag() {
-    return LogUtils.getPluginTag(this.getClass().getSimpleName());
+    return Logger.tags(this.getClass().getSimpleName());
   }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -1,7 +1,5 @@
 package com.getcapacitor;
 
-import android.util.Log;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -77,7 +75,7 @@ public class PluginCall {
     try {
       errorResult.put("message", msg);
     } catch (Exception jsonEx) {
-      Log.e(LogUtils.getPluginTag(), jsonEx.toString());
+      Logger.error(Logger.tags("Plugin"), jsonEx.toString(), null);
     }
 
     this.msgHandler.sendResponseMessage(this, null, errorResult);
@@ -91,14 +89,14 @@ public class PluginCall {
     PluginResult errorResult = new PluginResult();
 
     if(ex != null) {
-      Log.e(LogUtils.getPluginTag(), msg, ex);
+      Logger.error(Logger.tags("Plugin"), msg, ex);
     }
 
     try {
       errorResult.put("message", msg);
       errorResult.put("code", code);
     } catch (Exception jsonEx) {
-      Log.e(LogUtils.getPluginTag(), jsonEx.getMessage());
+      Logger.error(Logger.tags("Plugin"), jsonEx.getMessage(), null);
     }
 
     this.msgHandler.sendResponseMessage(this, null, errorResult);

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginResult.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginResult.java
@@ -1,9 +1,5 @@
 package com.getcapacitor;
 
-import android.util.Log;
-
-import org.json.JSONException;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -62,7 +58,7 @@ public class PluginResult {
     try {
       this.json.put(name, value);
     } catch (Exception ex) {
-      Log.e(LogUtils.getPluginTag(), "", ex);
+      Logger.error(Logger.tags("Plugin"), "", ex);
     }
     return this;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -10,7 +10,6 @@ import android.graphics.PixelFormat;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
@@ -53,7 +52,7 @@ public class Splash {
       try {
         splash = c.getResources().getDrawable(splashId, c.getTheme());
       } catch (Resources.NotFoundException ex) {
-        Log.w(LogUtils.getCoreTag(), "No splash screen found, not displaying");
+        Logger.warn("No splash screen found, not displaying");
         return;
       }
 
@@ -90,7 +89,7 @@ public class Splash {
           splashImage.setBackgroundColor(Color.parseColor(backgroundColor));
         }
       } catch (IllegalArgumentException ex) {
-        Log.d(LogUtils.getCoreTag(), "Background color not applied");
+        Logger.debug("Background color not applied");
       }
 
       String scaleTypeName = Config.getString(CONFIG_KEY_PREFIX + "androidScaleType", "FIT_XY");
@@ -157,7 +156,7 @@ public class Splash {
           spinnerBar.setIndeterminateTintList(colorStateList);
         }
       } catch (IllegalArgumentException ex) {
-        Log.d(LogUtils.getCoreTag(), "Spinner color not applied");
+        Logger.debug("Spinner color not applied");
       }
     }
   }
@@ -194,6 +193,7 @@ public class Splash {
 
   /**
    * Show the Splash Screen
+   *
    * @param a
    * @param showDuration how long to show the splash for if autoHide is enabled
    * @param fadeInDuration how long to fade the splash screen in
@@ -263,7 +263,7 @@ public class Splash {
         try {
           wm.addView(splashImage, params);
         } catch (IllegalStateException | IllegalArgumentException ex) {
-          Log.d(LogUtils.getCoreTag(), "Could not add splash view");
+          Logger.debug("Could not add splash view");
           return;
         }
 
@@ -317,7 +317,7 @@ public class Splash {
     // Warn the user if the splash was hidden automatically, which means they could be experiencing an app
     // that feels slower than it actually is.
     if(isLaunchSplash && isVisible) {
-      Log.d(LogUtils.getCoreTag(), "SplashScreen was automatically hidden after the launch timeout. " +
+      Logger.debug("SplashScreen was automatically hidden after the launch timeout. " +
               "You should call `SplashScreen.hide()` as soon as your web app is loaded (or increase the timeout)." +
               "Read more at https://capacitor.ionicframework.com/docs/apis/splash-screen/#hiding-the-splash-screen");
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -17,7 +17,6 @@ package com.getcapacitor;
 
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -143,12 +142,12 @@ public class WebViewLocalServer {
     }
     Uri uri = Uri.parse(url);
     if (uri == null) {
-      Log.e(LogUtils.getCoreTag(), "Malformed URL: " + url);
+      Logger.error("Malformed URL: " + url);
       return null;
     }
     String path = uri.getPath();
     if (path == null || path.length() == 0) {
-      Log.e(LogUtils.getCoreTag(), "URL does not have a path: " + url);
+      Logger.error("URL does not have a path: " + url);
       return null;
     }
     return uri;
@@ -174,7 +173,7 @@ public class WebViewLocalServer {
     }
 
     if (isLocalFile(loadingUrl) || (Config.getString("server.url") == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
-      Log.d(LogUtils.getCoreTag(), "Handling local request: " + request.getUrl().toString());
+      Logger.debug("Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {
       return handleProxyRequest(request, handler);
@@ -239,7 +238,7 @@ public class WebViewLocalServer {
           responseStream = protocolHandler.openFile(startPath);
         }
       } catch (IOException e) {
-        Log.e(LogUtils.getCoreTag(), "Unable to open index.html", e);
+        Logger.error("Unable to open index.html", e);
         return null;
       }
 
@@ -255,7 +254,7 @@ public class WebViewLocalServer {
       try {
         return new WebResourceResponse("image/png", null, null);
       } catch (Exception e) {
-        Log.e(LogUtils.getCoreTag(), "favicon handling failed", e);
+        Logger.error("favicon handling failed", e);
       }
     }
 
@@ -325,7 +324,7 @@ public class WebViewLocalServer {
     try {
       mimeType = URLConnection.guessContentTypeFromName(path); // Does not recognize *.js
       if (mimeType != null && path.endsWith(".js") && mimeType.equals("image/x-icon")) {
-        Log.d(LogUtils.getCoreTag(), "We shouldn't be here");
+        Logger.debug("We shouldn't be here");
       }
       if (mimeType == null) {
         if (path.endsWith(".js") || path.endsWith(".mjs")) {
@@ -338,7 +337,7 @@ public class WebViewLocalServer {
         }
       }
     } catch (Exception ex) {
-      Log.e(LogUtils.getCoreTag(), "Unable to get mime type" + path, ex);
+      Logger.error("Unable to get mime type" + path, ex);
     }
     return mimeType;
   }
@@ -427,7 +426,7 @@ public class WebViewLocalServer {
             stream = protocolHandler.openAsset(assetPath + path);
           }
         } catch (IOException e) {
-          Log.e(LogUtils.getCoreTag(), "Unable to open asset URL: " + url);
+          Logger.error("Unable to open asset URL: " + url);
           return null;
         }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Accessibility.java
@@ -1,9 +1,9 @@
 package com.getcapacitor.plugin;
 
 import android.speech.tts.TextToSpeech;
-import android.util.Log;
 import android.view.accessibility.AccessibilityManager;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -35,8 +35,8 @@ public class Accessibility extends Plugin {
 
   @PluginMethod()
   public void isScreenReaderEnabled(PluginCall call) {
-    Log.d(getLogTag(), "Checking for screen reader");
-    Log.d(getLogTag(), "Is it enabled? " + am.isTouchExplorationEnabled());
+    Logger.debug(getLogTag(), "Checking for screen reader");
+    Logger.debug(getLogTag(), "Is it enabled? " + am.isTouchExplorationEnabled());
 
     JSObject ret = new JSObject();
     ret.put("value", am.isTouchExplorationEnabled());

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.util.Log;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -22,7 +22,7 @@ public class App extends Plugin {
   private boolean isActive = false;
 
   public void fireChange(boolean isActive) {
-    Log.d(getLogTag(), "Firing change: " + isActive);
+    Logger.debug(getLogTag(), "Firing change: " + isActive);
     JSObject data = new JSObject();
     data.put("isActive", isActive);
     this.isActive = isActive;
@@ -30,7 +30,7 @@ public class App extends Plugin {
   }
 
   public void fireRestoredResult(PluginResult result) {
-    Log.d(getLogTag(), "Firing restored result");
+    Logger.debug(getLogTag(), "Firing restored result");
     notifyListeners(EVENT_RESTORED_RESULT, result.getWrappedResult(), true);
   }
 
@@ -87,7 +87,7 @@ public class App extends Plugin {
       call.success(ret);
       return;
     } catch(PackageManager.NameNotFoundException e) {
-      Log.e(getLogTag(), "Package name '"+url+"' not found!");
+      Logger.error(getLogTag(), "Package name '"+url+"' not found!", null);
     }
 
     ret.put("value", false);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Browser.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsClient;
@@ -15,6 +14,7 @@ import androidx.browser.customtabs.CustomTabsSession;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -58,7 +58,7 @@ public class Browser extends Plugin {
       try {
         builder.setToolbarColor(Color.parseColor(toolbarColor));
       } catch (IllegalArgumentException ex) {
-        Log.e(getLogTag(), "Invalid color provided for toolbarColor. Using default");
+        Logger.error(getLogTag(), "Invalid color provided for toolbarColor. Using default", null);
       }
     }
 
@@ -125,7 +125,7 @@ public class Browser extends Plugin {
     }
     boolean ok = CustomTabsClient.bindCustomTabsService(getContext(), CUSTOM_TAB_PACKAGE_NAME, connection);
     if (!ok) {
-      Log.e(getLogTag(), "Error binding to custom tabs service");
+      Logger.error(getLogTag(), "Error binding to custom tabs service", null);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -8,16 +8,15 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Base64;
-import android.util.Log;
 
 import androidx.core.content.FileProvider;
 
 import com.getcapacitor.Dialogs;
 import com.getcapacitor.FileUtils;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -186,7 +185,7 @@ public class Camera extends Plugin {
     try {
       return CameraResultType.valueOf(resultType.toUpperCase());
     } catch (IllegalArgumentException ex) {
-      Log.d(getLogTag(), "Invalid result type \"" + resultType + "\", defaulting to base64");
+      Logger.debug(getLogTag(), "Invalid result type \"" + resultType + "\", defaulting to base64");
       return CameraResultType.BASE64;
     }
   }
@@ -271,7 +270,7 @@ public class Camera extends Plugin {
         try {
           imageStream.close();
         } catch (IOException e) {
-          Log.e(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
+          Logger.error(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
         }
       }
     }
@@ -334,7 +333,7 @@ public class Camera extends Plugin {
         String fileToSave = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
         MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSave, "", "");
       } catch (FileNotFoundException e) {
-        Log.e(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
+        Logger.error(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
       }
     }
 
@@ -380,7 +379,7 @@ public class Camera extends Plugin {
         try {
           bis.close();
         } catch (IOException e) {
-          Log.e(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
+          Logger.error(getLogTag(), UNABLE_TO_PROCESS_IMAGE, e);
         }
       }
     }
@@ -441,10 +440,10 @@ public class Camera extends Plugin {
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
 
-    Log.d(getLogTag(),"handling request perms result");
+    Logger.debug(getLogTag(),"handling request perms result");
 
     if (getSavedCall() == null) {
-      Log.d(getLogTag(),"No stored plugin call for permissions request result");
+      Logger.debug(getLogTag(),"No stored plugin call for permissions request result");
       return;
     }
 
@@ -454,7 +453,7 @@ public class Camera extends Plugin {
       int result = grantResults[i];
       String perm = permissions[i];
       if(result == PackageManager.PERMISSION_DENIED) {
-        Log.d(getLogTag(), "User denied camera permission: " + perm);
+        Logger.debug(getLogTag(), "User denied camera permission: " + perm);
         savedCall.error(PERMISSION_DENIED_ERROR);
         return;
       }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Clipboard.java
@@ -4,8 +4,8 @@ import android.content.ClipData;
 import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.util.Log;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -50,11 +50,11 @@ public class Clipboard extends Plugin {
 
     CharSequence value = "";
     if(clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-      Log.d(getLogTag(), "Got plaintxt");
+      Logger.debug(getLogTag(), "Got plaintxt");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
       value = item.getText();
     } else {
-      Log.d(getLogTag(), "Not plaintext!");
+      Logger.debug(getLogTag(), "Not plaintext!");
       ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
       value = item.coerceToText(this.getContext()).toString();
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -7,9 +7,9 @@ import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
 import android.util.Base64;
-import android.util.Log;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -193,13 +193,13 @@ public class Filesystem extends Plugin {
     Boolean recursive = call.getBoolean("recursive", false);
 
     if (path == null) {
-      Log.e(getLogTag(), "No path or filename retrieved from call");
+      Logger.error(getLogTag(), "No path or filename retrieved from call", null);
       call.error("NO_PATH");
       return;
     }
 
     if (data == null) {
-      Log.e(getLogTag(), "No data retrieved from call");
+      Logger.error(getLogTag(), "No data retrieved from call", null);
       call.error("NO_DATA");
       return;
     }
@@ -220,11 +220,11 @@ public class Filesystem extends Plugin {
               call.error("Parent folder doesn't exist");
             }
           } else {
-            Log.e(getLogTag(), "Not able to create '" + directory + "'!");
+            Logger.error(getLogTag(), "Not able to create '" + directory + "'!", null);
             call.error("NOT_CREATED_DIR");
           }
         } else {
-          Log.e(getLogTag(), "Directory ID '" + directory + "' is not supported by plugin");
+          Logger.error(getLogTag(), "Directory ID '" + directory + "' is not supported by plugin", null);
           call.error("INVALID_DIR");
         }
       }
@@ -264,7 +264,7 @@ public class Filesystem extends Plugin {
         writer.write(data);
         success = true;
       } catch (IOException e) {
-        Log.e(getLogTag(), "Creating text file '" + file.getPath() + "' with charset '" + charset + "' failed. Error: " + e.getMessage(), e);
+        Logger.error(getLogTag(), "Creating text file '" + file.getPath() + "' with charset '" + charset + "' failed. Error: " + e.getMessage(), e);
       }
     } else {
       //remove header from dataURL
@@ -275,7 +275,7 @@ public class Filesystem extends Plugin {
         fos.write(Base64.decode(data, Base64.NO_WRAP));
         success = true;
       } catch (IOException e) {
-        Log.e(getLogTag(), "Creating binary file '" + file.getPath() + "' failed. Error: " + e.getMessage(), e);
+        Logger.error(getLogTag(), "Creating binary file '" + file.getPath() + "' failed. Error: " + e.getMessage(), e);
       }
     }
 
@@ -284,7 +284,7 @@ public class Filesystem extends Plugin {
       if (isPublicDirectory(getDirectoryParameter(call))) {
         MediaScannerConnection.scanFile(getContext(), new String[] {file.getAbsolutePath()}, null, null);
       }
-      Log.d(getLogTag(), "File '" + file.getAbsolutePath() + "' saved!");
+      Logger.debug(getLogTag(), "File '" + file.getAbsolutePath() + "' saved!");
       JSObject result = new JSObject();
       result.put("uri", Uri.fromFile(file).toString());
       call.success(result);
@@ -607,10 +607,10 @@ public class Filesystem extends Plugin {
    */
   private boolean isStoragePermissionGranted(int permissionRequestCode, String permission) {
     if (hasPermission(permission)) {
-      Log.v(getLogTag(),"Permission '" + permission + "' is granted");
+      Logger.verbose(getLogTag(),"Permission '" + permission + "' is granted");
       return true;
     } else {
-      Log.v(getLogTag(),"Permission '" + permission + "' denied. Asking user for it.");
+      Logger.verbose(getLogTag(),"Permission '" + permission + "' denied. Asking user for it.");
       pluginRequestPermissions(new String[] {permission}, permissionRequestCode);
       return false;
     }
@@ -636,10 +636,10 @@ public class Filesystem extends Plugin {
   protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
 
-    Log.d(getLogTag(),"handling request perms result");
+    Logger.debug(getLogTag(),"handling request perms result");
 
     if (getSavedCall() == null) {
-      Log.d(getLogTag(),"No stored plugin call for permissions request result");
+      Logger.debug(getLogTag(),"No stored plugin call for permissions request result");
       return;
     }
 
@@ -649,7 +649,7 @@ public class Filesystem extends Plugin {
       int result = grantResults[i];
       String perm = permissions[i];
       if(result == PackageManager.PERMISSION_DENIED) {
-        Log.d(getLogTag(), "User denied storage permission: " + perm);
+        Logger.debug(getLogTag(), "User denied storage permission: " + perm);
         savedCall.error(PERMISSION_DENIED_ERROR);
         this.freeSavedCall();
         return;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Network.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Network.java
@@ -7,8 +7,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.util.Log;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -45,7 +45,7 @@ public class Network extends Plugin {
         if (hasRequiredPermissions()) {
           notifyListeners(NETWORK_CHANGE_EVENT, getStatusJSObject(cm.getActiveNetworkInfo()));
         } else {
-          Log.e(getLogTag(), PERMISSION_NOT_SET);
+          Logger.error(getLogTag(), PERMISSION_NOT_SET, null);
         }
       }
     };

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/StatusBar.java
@@ -1,12 +1,10 @@
 package com.getcapacitor.plugin;
 
 import android.graphics.Color;
-import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 
-import com.getcapacitor.Bridge;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/background/BackgroundTaskService.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/background/BackgroundTaskService.java
@@ -2,11 +2,10 @@ package com.getcapacitor.plugin.background;
 
 import android.app.IntentService;
 import android.content.Intent;
-import android.util.Log;
 
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 public class BackgroundTaskService extends IntentService {
   public BackgroundTaskService() {
@@ -17,7 +16,7 @@ public class BackgroundTaskService extends IntentService {
   protected void onHandleIntent(Intent intent) {
     // Gets data from the incoming Intent
     String taskId = intent.getStringExtra("taskId");
-    Log.d(LogUtils.getCoreTag(), "Doing background task: " + taskId);
+    Logger.debug("Doing background task: " + taskId);
 
     Intent localIntent = new Intent(BackgroundTask.TASK_BROADCAST_ACTION)
         .putExtra("taskId", taskId);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraUtils.java
@@ -3,11 +3,10 @@ package com.getcapacitor.plugin.camera;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Environment;
-import android.util.Log;
 
 import androidx.core.content.FileProvider;
 
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,6 +35,6 @@ public class CameraUtils {
     }
 
     protected static String getLogTag() {
-        return LogUtils.getCoreTag("CameraUtils");
+        return Logger.tags("CameraUtils");
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -8,10 +8,9 @@ import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
-import android.util.Log;
 
 import com.getcapacitor.FileUtils;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -125,7 +124,7 @@ public class ImageUtils {
 
       return new ExifWrapper(exifInterface);
     } catch (IOException ex) {
-      Log.e(LogUtils.getCoreTag(), "Error loading exif data from image", ex);
+      Logger.error("Error loading exif data from image", ex);
     } finally {
     }
     return new ExifWrapper(null);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotification.java
@@ -3,12 +3,11 @@ package com.getcapacitor.plugin.notification;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 
 import com.getcapacitor.Config;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 import com.getcapacitor.PluginCall;
 
 import org.json.JSONException;
@@ -377,7 +376,7 @@ public class LocalNotification {
       JSONObject jsonObject = new JSONObject(extraFromString);
       this.extra = JSObject.fromJSONObject(jsonObject);
     } catch (JSONException e) {
-      Log.e(LogUtils.getPluginTag("LN"), "Cannot rebuild extra data", e);
+      Logger.error(Logger.tags("LN"), "Cannot rebuild extra data", e);
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -12,7 +12,6 @@ import android.media.AudioAttributes;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -21,7 +20,7 @@ import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.RemoteInput;
 
 import com.getcapacitor.JSObject;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.android.R;
 import org.json.JSONArray;
@@ -61,10 +60,10 @@ public class LocalNotificationManager {
    * Method extecuted when notification is launched by user from the notification bar.
    */
   public JSObject handleNotificationActionPerformed(Intent data, NotificationStorage notificationStorage) {
-    Log.d(LogUtils.getPluginTag("LN"), "LocalNotification received: " + data.getDataString());
+    Logger.debug(Logger.tags("LN"), "LocalNotification received: " + data.getDataString());
     int notificationId = data.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (notificationId == Integer.MIN_VALUE) {
-      Log.d(LogUtils.getPluginTag("LN"), "Activity started without notification attached");
+      Logger.debug(Logger.tags("LN"), "Activity started without notification attached");
       return null;
     }
     boolean isRemovable = data.getBooleanExtra(LocalNotificationManager.NOTIFICATION_IS_REMOVABLE_KEY, true);
@@ -298,7 +297,7 @@ public class LocalNotificationManager {
     Date at = schedule.getAt();
     if (at != null) {
       if (at.getTime() < new Date().getTime()) {
-        Log.e(LogUtils.getPluginTag("LN"), "Scheduled time must be *after* current time");
+        Logger.error(Logger.tags("LN"), "Scheduled time must be *after* current time", null);
         return;
       }
       if (schedule.isRepeating()) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationAction.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationAction.java
@@ -1,11 +1,10 @@
 package com.getcapacitor.plugin.notification;
 
-import android.util.Log;
-
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -58,7 +57,7 @@ public class NotificationAction {
         }
       }
     } catch (Exception e) {
-      Log.e(LogUtils.getPluginTag("LN"), "Error when building action types", e);
+      Logger.error(Logger.tags("LN"), "Error when building action types", e);
     }
     return actionTypeMap;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationChannelManager.java
@@ -7,13 +7,12 @@ import android.content.Context;
 import android.graphics.Color;
 import android.media.AudioAttributes;
 import android.net.Uri;
-import android.util.Log;
-
 
 import androidx.core.app.NotificationCompat;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.PluginCall;
 
 import java.util.List;
@@ -32,9 +31,6 @@ public class NotificationChannelManager {
         this.context = context;
         this.notificationManager = manager;
     }
-
-    private static final String TAG = "NotificationChannel: ";
-
 
     private static String CHANNEL_ID = "id";
     private static String CHANNEL_NAME = "name";
@@ -73,7 +69,7 @@ public class NotificationChannelManager {
                 try {
                     notificationChannel.setLightColor(Color.parseColor(lightColor));
                 } catch (IllegalArgumentException ex) {
-                    Log.e(TAG, "Invalid color provided for light color.");
+                    Logger.error(Logger.tags("NotificationChannel"), "Invalid color provided for light color.", null);
                 }
             }
             String sound = channel.getString(CHANNEL_SOUND, null);
@@ -115,8 +111,8 @@ public class NotificationChannelManager {
                 channel.put(CHANNEL_SOUND, notificationChannel.getSound());
                 channel.put(CHANNEL_USE_LIGHTS, notificationChannel.shouldShowLights());
                 channel.put(CHANNEL_LIGHT_COLOR, String.format("#%06X", (0xFFFFFF & notificationChannel.getLightColor())));
-                Log.d(TAG, "visibility " + notificationChannel.getLockscreenVisibility());
-                Log.d(TAG, "importance " + notificationChannel.getImportance());
+                Logger.debug(Logger.tags("NotificationChannel"), "visibility " + notificationChannel.getLockscreenVisibility());
+                Logger.debug(Logger.tags("NotificationChannel"), "importance " + notificationChannel.getImportance());
                 channels.put(channel);
             }
             JSObject result = new JSObject();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationDismissReceiver.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/NotificationDismissReceiver.java
@@ -3,8 +3,7 @@ package com.getcapacitor.plugin.notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 
 /**
@@ -17,7 +16,7 @@ public class NotificationDismissReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     int intExtra = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (intExtra == Integer.MIN_VALUE) {
-      Log.e(LogUtils.getPluginTag("LN"), "Invalid notification dismiss operation");
+      Logger.error(Logger.tags("LN"), "Invalid notification dismiss operation", null);
       return;
     }
     boolean isRemovable = intent.getBooleanExtra(LocalNotificationManager.NOTIFICATION_IS_REMOVABLE_KEY, true);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
@@ -7,8 +7,7 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 import java.util.Date;
 
@@ -29,7 +28,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
     Notification notification = intent.getParcelableExtra(NOTIFICATION_KEY);
     int id = intent.getIntExtra(LocalNotificationManager.NOTIFICATION_INTENT_KEY, Integer.MIN_VALUE);
     if (id == Integer.MIN_VALUE) {
-      Log.e(LogUtils.getPluginTag("LN"), "No valid id supplied");
+      Logger.error(Logger.tags("LN"), "No valid id supplied", null);
     }
     notificationManager.notify(id, notification);
     rescheduleNotificationIfNeeded(context, intent, id);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/AssetUtil.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/AssetUtil.java
@@ -8,11 +8,10 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.StrictMode;
-import android.util.Log;
 
 import androidx.core.content.FileProvider;
 
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -90,7 +89,7 @@ public final class AssetUtil {
         File file      = new File(absPath);
 
         if (!file.exists()) {
-            Log.e(LogUtils.getCoreTag(), "File not found: " + file.getAbsolutePath());
+            Logger.error("File not found: " + file.getAbsolutePath());
             return Uri.EMPTY;
         }
 
@@ -119,7 +118,7 @@ public final class AssetUtil {
             FileOutputStream out = new FileOutputStream(file);
             copyFile(in, out);
         } catch (Exception e) {
-            Log.e(LogUtils.getCoreTag(), "File not found: assets/" + resPath);
+            Logger.error("File not found: assets/" + resPath);
             return Uri.EMPTY;
         }
 
@@ -139,7 +138,7 @@ public final class AssetUtil {
         int resId      = getResId(resPath);
 
         if (resId == 0) {
-            Log.e(LogUtils.getCoreTag(), "File not found: " + resPath);
+            Logger.error("File not found: " + resPath);
             return Uri.EMPTY;
         }
 
@@ -183,11 +182,11 @@ public final class AssetUtil {
             copyFile(in, out);
             return getUriFromFile(file);
         } catch (MalformedURLException e) {
-            Log.e("Asset", "Incorrect URL", e);
+            Logger.error(Logger.tags("Asset"), "Incorrect URL", e);
         } catch (FileNotFoundException e) {
-            Log.e("Asset", "Failed to create new File from HTTP Content", e);
+            Logger.error(Logger.tags("Asset"), "Failed to create new File from HTTP Content", e);
         } catch (IOException e) {
-            Log.e("Asset", "No Input can be created from http Stream", e);
+            Logger.error(Logger.tags("Asset"), "No Input can be created from http Stream", e);
         }
 
         return Uri.EMPTY;
@@ -210,7 +209,7 @@ public final class AssetUtil {
             out.flush();
             out.close();
         } catch (Exception e) {
-            Log.e(LogUtils.getCoreTag(), "Error copiing", e);
+            Logger.error("Error copying", e);
         }
     }
 
@@ -310,7 +309,7 @@ public final class AssetUtil {
         }
 
         if (dir == null) {
-            Log.e("Asset", "Missing cache dir");
+            Logger.error(Logger.tags("Asset"), "Missing cache dir", null);
             return null;
         }
 
@@ -334,7 +333,7 @@ public final class AssetUtil {
             String authority = context.getPackageName() + ".provider";
             return FileProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
-            Log.e(LogUtils.getCoreTag(), "File not supported by provider", e);
+            Logger.error("File not supported by provider", e);
             return Uri.EMPTY;
         }
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/ui/ModalsBottomSheetDialogFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/ui/ModalsBottomSheetDialogFragment.java
@@ -3,7 +3,6 @@ package com.getcapacitor.ui;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.graphics.Color;
-import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.widget.LinearLayout;
@@ -14,7 +13,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-import com.getcapacitor.LogUtils;
+import com.getcapacitor.Logger;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
@@ -104,7 +103,7 @@ public class ModalsBottomSheetDialogFragment extends BottomSheetDialogFragment {
         tv.setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
-            Log.d(LogUtils.getCoreTag(), "CliCKED: " + optionIndex);
+            Logger.debug("CliCKED: " + optionIndex);
 
             if (listener != null) {
               listener.onSelected(optionIndex);
@@ -127,7 +126,7 @@ public class ModalsBottomSheetDialogFragment extends BottomSheetDialogFragment {
         ((BottomSheetBehavior) behavior).setBottomSheetCallback(mBottomSheetBehaviorCallback);
       }
     } catch (JSONException ex) {
-      Log.e(LogUtils.getCoreTag(), "JSON error processing an option for showActions", ex);
+      Logger.error("JSON error processing an option for showActions", ex);
     }
   }
 }


### PR DESCRIPTION
Identical to iOS's `hideLogs` option, this PR adds a `hideLogs` option for Android which hides all native logs from Capacitor and Capacitor plugins if set to `true`.

This was implemented by adding a `Logger` class, which should be used by Capacitor and core Capacitor plugins. 

This implementation was chosen to bring parity between iOS and Android for Capacitor 2.x. In the future it may be a good idea to deprecate this feature in favor of a "log level" setting which devs would be able to configure. 