### PR TITLE
Rename applinks.json to assetlinks.json

### DIFF
--- a/site/docs-md/guides/deep-links.md
+++ b/site/docs-md/guides/deep-links.md
@@ -209,10 +209,10 @@ Next, use Google's [Asset Links tool](https://developers.google.com/digital-asse
 
 ![Android Identifier Config](/assets/img/docs/guides/deep-links/android-config.png)
 
-Copy the JSON output into a new local file under `.well-known/applinks.json`.
+Copy the JSON output into a new local file under `.well-known/assetlinks.json`.
 
 ```json
-// applinks.json
+// assetlinks.json
 [
   {
     "relation": ["delegate_permission/common.handle_all_urls"],


### PR DESCRIPTION
When creating `applinks.json` (as opposed to Google's requirement to call the file `assetlinks.json`, I get the following error when clicking "Test statement" in the [Google Statement List Generator and Tester](https://developers.google.com/digital-asset-links/tools/generator):

> No app deep linking permission found for nl.APP_NAME.app at app.APP_NAME.nl.

Renaming to `assetlinks.json` (like Google also recommends) [solves this issue](https://developer.android.com/training/app-links/verify-site-associations). Updated the docs to reflect this change.