### PR TITLE
POC: native camera localization

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -23,6 +23,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.PluginRequestCodes;
+import com.getcapacitor.android.R;
 import com.getcapacitor.plugin.camera.CameraResultType;
 import com.getcapacitor.plugin.camera.CameraSettings;
 import com.getcapacitor.plugin.camera.CameraSource;
@@ -105,9 +106,9 @@ public class Camera extends Plugin {
   private void showPrompt(final PluginCall call) {
     // We have all necessary permissions, open the camera
     JSObject fromPhotos = new JSObject();
-    fromPhotos.put("title", "From Photos");
+    fromPhotos.put("title", getContext().getResources().getString(R.string.from_photos));
     JSObject takePicture = new JSObject();
-    takePicture.put("title", "Take Picture");
+    takePicture.put("title", getContext().getResources().getString(R.string.take_picture));
     Object[] options = new Object[] {
       fromPhotos,
       takePicture

--- a/android/capacitor/src/main/res/values/strings.xml
+++ b/android/capacitor/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="picture">Picture</string>
     <string name="request_permission">Allow this app to take pictures</string>
     <string name="camera_error">Unable to use camera</string>
+    <string name="take_picture">Take Picture</string>
+    <string name="from_photos">From Photos</string>
 </resources>

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -102,11 +102,11 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
   func showPrompt(_ call: CAPPluginCall) {
     // Build the action sheet
     let alert = UIAlertController(title: "Photo", message: nil, preferredStyle: UIAlertController.Style.actionSheet)
-    alert.addAction(UIAlertAction(title: "From Photos", style: .default, handler: { (action: UIAlertAction) in
+    alert.addAction(UIAlertAction(title: NSLocalizedString("From Photos", comment: ""), style: .default, handler: { (action: UIAlertAction) in
       self.showPhotos(call)
     }))
 
-    alert.addAction(UIAlertAction(title: "Take Picture", style: .default, handler: { (action: UIAlertAction) in
+    alert.addAction(UIAlertAction(title: NSLocalizedString("Take Picture", comment: ""), style: .default, handler: { (action: UIAlertAction) in
       self.showCamera(call)
     }))
 


### PR DESCRIPTION
This is a POC for how the plugin localization is done in the native way.

This would require the user to add the native localizations in their project.

For iOS this is creating a `Localizable.strings` file with this content:

```
"From Photos" = "From Photos";
"Take Picture" = "Take Picture";
```
And then localize the file adding supported languages to the project and replacing the strings after the `=` (the ones before are keys that also act as default value)

For Android it requires adding in the user project localized `strings.xml` files and adding

```
<string name="take_picture">translation for Take Picture</string>
<string name="from_photos">translation for From Photos</string>
```