### PR TITLE
fixes issue where top level arrays were black holed

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -372,8 +372,13 @@ public class Http extends Plugin {
 
     if (contentType != null) {
       if (contentType.contains("application/json")) {
-        JSObject jsonValue = new JSObject(builder.toString());
-        ret.put("data", jsonValue);
+        try {
+          JSObject jsonValue = new JSObject(builder.toString());
+          ret.put("data", jsonValue);
+        } catch (JSONException e) {
+          JSArray jsonValue = new JSArray(builder.toString());
+          ret.put("data", jsonValue);
+        }
       } else {
         ret.put("data", builder.toString());
       }

--- a/ios/Capacitor/Capacitor/Plugins/Http/Http.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Http/Http.swift
@@ -314,9 +314,7 @@ public class CAPHttpPlugin: CAPPlugin {
     let contentType = response.allHeaderFields["Content-Type"] as? String
 
     if data != nil && contentType != nil && contentType!.contains("application/json") {
-      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) as? [String: Any] {
-        print("Got json")
-        print(json)
+      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) {
           // handle json...
         ret["data"] = json
       }


### PR DESCRIPTION
This fixes an issue where the capacitor plugin only accepts top level json objects as a response. According to the JSON spec, top level constructs must be either objects or arrays. This should permit both.