### PR TITLE
fix(android): make readFile don't return newlines on base64 strings

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -144,7 +144,7 @@ public class Filesystem extends Plugin {
     }
     fileInputStreamReader.close();
 
-    return new String(Base64.encodeToString(byteStream.toByteArray(), Base64.DEFAULT));
+    return new String(Base64.encodeToString(byteStream.toByteArray(), Base64.NO_WRAP));
   }
 
   @PluginMethod()


### PR DESCRIPTION
On Android, the default action of Filesystem.readFile creates a malformed base64 string with newlines added.

This is acceptable in the browser when displaying images, for example, but not when base64 data is expected.

ref [https://developer.android.com/reference/android/util/Base64#NO_WRAP]
