### PR TITLE
fix(android): check if NETWORK_PROVIDER is enabled

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Geolocation.java
@@ -1,8 +1,10 @@
 package com.getcapacitor.plugin;
 
 import android.Manifest;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.Location;
+import android.location.LocationManager;
 import android.os.Build;
 
 import com.getcapacitor.JSObject;
@@ -144,11 +146,18 @@ public class Geolocation extends Plugin {
     int timeout = call.getInt("timeout", 10000);
     fusedLocationClient = LocationServices.getFusedLocationProviderClient(getContext());
 
+    LocationManager lm = (LocationManager)getContext().getSystemService(Context.LOCATION_SERVICE);
+    boolean networkEnabled = false;
+    try {
+      networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    } catch(Exception ex) {}
     LocationRequest locationRequest = new LocationRequest();
     locationRequest.setMaxWaitTime(timeout);
     locationRequest.setInterval(10000);
     locationRequest.setFastestInterval(5000);
-    locationRequest.setPriority(enableHighAccuracy ? LocationRequest.PRIORITY_HIGH_ACCURACY : LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+    int lowPriority = networkEnabled ? LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY : LocationRequest.PRIORITY_LOW_POWER;
+    int priority = enableHighAccuracy ? LocationRequest.PRIORITY_HIGH_ACCURACY : lowPriority;
+    locationRequest.setPriority(priority);
 
     locationCallback = new LocationCallback(){
       @Override


### PR DESCRIPTION
and use `PRIORITY_LOW_POWER` if not enabled, otherwise no location is returned

closes https://github.com/ionic-team/capacitor/issues/2854
