### PR TITLE
feat: Add common hideLogs option

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Logger.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Logger.java
@@ -79,6 +79,6 @@ public class Logger {
   }
 
   protected static boolean shouldLog() {
-    return !Config.getBoolean("android.hideLogs", false);
+    return !Config.getBoolean("android.hideLogs", Config.getBoolean("hideLogs", false));
   }
 }

--- a/ios/Capacitor/Capacitor/CAPLog.swift
+++ b/ios/Capacitor/Capacitor/CAPLog.swift
@@ -11,7 +11,7 @@ public class CAPLog {
   }
 
   public static func hideLogs() -> Bool {
-    if let hideLogs = config.getValue("ios.hideLogs") as? Bool {
+    if let hideLogs = (config.getValue("ios.hideLogs") as? Bool) ?? (config.getValue("hideLogs") as? Bool) {
       return hideLogs
     }
     return false

--- a/site/docs-md/basics/configuring-your-app.md
+++ b/site/docs-md/basics/configuring-your-app.md
@@ -55,6 +55,10 @@ The current ones you might configure are:
   // Android Studio install path, but you may change it manually.
   "windowsAndroidStudioPath": "C:\Program Files\Android\Android Studio\bin\studio64.exe",
 
+  // A Boolean value that determines whether to hide native logs for iOS and Android. The preference is ignored if it's also declared inside ios or android
+  // Default is false
+  "hideLogs": true
+
   // Server object contains port and url configurations 
   "server": {
     // You can make the app to load an external url (i.e. to live reload)
@@ -101,7 +105,11 @@ The current ones you might configure are:
     // any WebViews of this application.
     // This flag can be enabled in order to facilitate debugging of web layouts
     // and JavaScript code running inside WebViews.
-    "webContentsDebuggingEnabled": true
+    "webContentsDebuggingEnabled": true,
+
+    // A Boolean value that determines whether to hide native Android logs or not
+    // Default is false
+    "hideLogs": true
   },
   "ios": {
     // User agent of Capacitor WebView for iOS
@@ -126,7 +134,8 @@ The current ones you might configure are:
     // A Boolean value that determines whether pressing on a link displays a preview of
     // the destination for the link.
     "allowsLinkPreview": false,
-    // A Boolean value that determines whether to hide native logs or not
+
+    // A Boolean value that determines whether to hide native iOS logs or not
     // Default is false
     "hideLogs": true
   },


### PR DESCRIPTION
At the moment hideLogs has to be specified by platform, this allows a common hideLogs root preference to set both platforms at once.
It still respects the platform preference if set.

Also document the preference