### PR TITLE
fix(cli): avoid infinite loop on scoped dependencies

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -310,7 +310,7 @@ export async function checkAndInstallDependencies(config: Config, plugins: Plugi
     if (allDependencies) {
       await Promise.all(allDependencies.map(async (dep: any) => {
         let plugin = dep.$.id;
-        if (plugin.includes('@')) {
+        if (plugin.includes('@') && plugin.indexOf('@') !== 0) {
           plugin = plugin.split('@')[0];
         }
         if (cordovaPlugins.filter(p => p.id === plugin || p.xml.$.id === plugin).length === 0) {


### PR DESCRIPTION
remove the @ from the dependency only if it's not on the start of the plugin name, in that case it's a scope, not a version. 