### PR TITLE
Bugfix/http json array response

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSArray.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSArray.java
@@ -13,6 +13,10 @@ public class JSArray extends JSONArray {
     super();
   }
 
+  public JSArray(String json) throws JSONException {
+    super(json);
+  }
+
   public JSArray(Collection copyFrom) {
     super(copyFrom);
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -372,8 +372,13 @@ public class Http extends Plugin {
 
     if (contentType != null) {
       if (contentType.contains("application/json")) {
-        JSObject jsonValue = new JSObject(builder.toString());
-        ret.put("data", jsonValue);
+        try {
+          JSObject jsonValue = new JSObject(builder.toString());
+          ret.put("data", jsonValue);
+        } catch (JSONException e) {
+          JSArray jsonValue = new JSArray(builder.toString());
+          ret.put("data", jsonValue);
+        }
       } else {
         ret.put("data", builder.toString());
       }

--- a/ios/Capacitor/Capacitor/Plugins/Http/Http.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Http/Http.swift
@@ -314,9 +314,7 @@ public class CAPHttpPlugin: CAPPlugin {
     let contentType = response.allHeaderFields["Content-Type"] as? String
 
     if data != nil && contentType != nil && contentType!.contains("application/json") {
-      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) as? [String: Any] {
-        print("Got json")
-        print(json)
+      if let json = try? JSONSerialization.jsonObject(with: data!, options: .mutableContainers) {
           // handle json...
         ret["data"] = json
       }


### PR DESCRIPTION
JSArray doesn't expose json constructor, but I think it should. The corollary exists in JSObject. This helps the issue where the http-api's top level json arrays get ignored.