### PR TITLE
feat: Allow plugins to override navigation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -224,6 +224,19 @@ public class Bridge {
   }
 
   public boolean launchIntent(Uri url) {
+    /*
+    * Give plugins the chance to handle the url
+    */
+    for (Map.Entry<String, PluginHandle> entry : plugins.entrySet()) {
+      Plugin plugin = entry.getValue().getInstance();
+      if (plugin != null) {
+        Boolean result = plugin.shouldOpenExternalUrl(url);
+        if (result != null) {
+          return !result;
+        }
+      }
+    }
+
     if (!url.toString().contains(appUrl) && !appAllowNavigationMask.matches(url.getHost())) {
       try {
         Intent openIntent = new Intent(Intent.ACTION_VIEW, url);

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -230,9 +230,9 @@ public class Bridge {
     for (Map.Entry<String, PluginHandle> entry : plugins.entrySet()) {
       Plugin plugin = entry.getValue().getInstance();
       if (plugin != null) {
-        Boolean result = plugin.shouldOpenExternalUrl(url);
-        if (result != null) {
-          return !result;
+        Boolean shouldOverrideLoad = plugin.shouldOverrideLoad(url);
+        if (shouldOverrideLoad != null) {
+          return shouldOverrideLoad;
         }
       }
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -550,17 +550,13 @@ public class Plugin {
   protected void handleOnDestroy() {}
 
   /**
-   * Hook for blocking the launching of Intents by the Capacitor application.
-   *
-   * This will be called when the WebView will not navigate to a page, but
-   * could launch an intent to handle the URL. Return false to block this: if
-   * any plugin returns false, Capacitor will block the navigation. If all
-   * plugins return null, the default policy will be enforced. If at least one
-   * plugin returns true, and no plugins return false, then the URL will be
-   * opened in the WebView.
+   * Give the plugins a chance to take control when a URL is about to be loaded in the WebView.
+   * Returning true causes the WebView to abort loading the URL.
+   * Returning false causes the WebView to continue loading the URL.
+   * Returning null will defer to the default Capacitor policy
    */
   @SuppressWarnings("unused")
-  public Boolean shouldOpenExternalUrl(Uri url) { return null; }
+  public Boolean shouldOverrideLoad(Uri url) { return null; }
 
   /**
    * Start a new Activity.

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -547,6 +548,19 @@ public class Plugin {
    * Handle onDestroy
    */
   protected void handleOnDestroy() {}
+
+  /**
+   * Hook for blocking the launching of Intents by the Capacitor application.
+   *
+   * This will be called when the WebView will not navigate to a page, but
+   * could launch an intent to handle the URL. Return false to block this: if
+   * any plugin returns false, Capacitor will block the navigation. If all
+   * plugins return null, the default policy will be enforced. If at least one
+   * plugin returns true, and no plugins return false, then the URL will be
+   * opened in the WebView.
+   */
+  @SuppressWarnings("unused")
+  public Boolean shouldOpenExternalUrl(Uri url) { return null; }
 
   /**
    * Start a new Activity.

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -252,6 +252,24 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DecidePolicyForNavigationAction.name()), object: navigationAction)
     let navUrl = navigationAction.request.url!
+    
+    /*
+     * Give plugins the chance to handle the url
+     */
+    if let plugins = bridge?.plugins {
+      for pluginObject in plugins {
+        let plugin = pluginObject.value
+        let selector = NSSelectorFromString("shouldOverrideLoadWith:navigationType:")
+        if plugin.responds(to: selector) {
+          let shouldAllowRequest = plugin.shouldOverrideLoad(with: navigationAction.request, navigationType: navigationAction.navigationType)
+          if (shouldAllowRequest) {
+            decisionHandler(.allow)
+            return
+          }
+        }
+      }
+    }
+    
     if let allowNavigation = allowNavigationConfig, let requestHost = navUrl.host {
       for pattern in allowNavigation {
         if matchHost(host: requestHost, pattern: pattern.lowercased()) {
@@ -267,8 +285,6 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
       return
     }
 
-    // TODO: Allow plugins to handle this. See
-    // https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/608d64191405b233c01a939f5755f8b1fdd97f8c/src/ios/CDVWKWebViewEngine.m#L609
     decisionHandler(.allow)
   }
 

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -259,12 +259,17 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     if let plugins = bridge?.plugins {
       for pluginObject in plugins {
         let plugin = pluginObject.value
-        let selector = NSSelectorFromString("shouldOverrideLoadWith:navigationType:")
+        let selector = NSSelectorFromString("shouldOverrideLoad:")
         if plugin.responds(to: selector) {
-          let shouldAllowRequest = plugin.shouldOverrideLoad(with: navigationAction.request, navigationType: navigationAction.navigationType)
-          if (shouldAllowRequest) {
-            decisionHandler(.allow)
-            return
+          let shouldOverrideLoad = plugin.shouldOverrideLoad(navigationAction)
+          if (shouldOverrideLoad != nil) {
+            if (shouldOverrideLoad == true) {
+              decisionHandler(.cancel)
+              return
+            } else if shouldOverrideLoad == false {
+              decisionHandler(.allow)
+              return
+            }
           }
         }
       }

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -24,6 +24,7 @@
 - (void)addListener:(CAPPluginCall *)call;
 - (void)removeListener:(CAPPluginCall *)call;
 - (void)removeAllListeners:(CAPPluginCall *)call;
+- (BOOL)shouldOverrideLoadWith:(NSURLRequest *)request navigationType:(WKNavigationType)navigationType;
 
 // Called after init if the plugin wants to do
 // some loading so the plugin author doesn't

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -24,7 +24,13 @@
 - (void)addListener:(CAPPluginCall *)call;
 - (void)removeListener:(CAPPluginCall *)call;
 - (void)removeAllListeners:(CAPPluginCall *)call;
-- (BOOL)shouldOverrideLoadWith:(NSURLRequest *)request navigationType:(WKNavigationType)navigationType;
+/**
+ * Give the plugins a chance to take control when a URL is about to be loaded in the WebView.
+ * Returning true causes the WebView to abort loading the URL.
+ * Returning false causes the WebView to continue loading the URL.
+ * Returning nil will defer to the default Capacitor policy
+ */
+- (NSNumber *)shouldOverrideLoad:(WKNavigationAction *)navigationAction;
 
 // Called after init if the plugin wants to do
 // some loading so the plugin author doesn't


### PR DESCRIPTION
variation of #2307 

changes:
Android method renamed from `shouldOpenExternalUrl ` to `shouldOverrideLoad` (more similar to the Android WebView method, and matches the iOS name). Logic changes, false load, true abort, null default.

ios method renamed from `shouldOverrideLoadWith` to `shouldOverrideLoad`, with a single `WKNavigationAction` param instead of two (you can get both request and navigationType from it).
Method return type changed from Bool to NSNumber so it can return nil.
And as it can return nil now, change logic to work as on Android (false load, true abort, nil default)

closes #2307 
closes https://github.com/ionic-team/capacitor/issues/70

