### PR TITLE
fix: set launchShowDuration to 0 on new projects only

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -28,7 +28,7 @@ public class Splash {
 
   public static final String CONFIG_KEY_PREFIX = "plugins.SplashScreen.";
 
-  public static final int DEFAULT_LAUNCH_SHOW_DURATION = 0;
+  public static final int DEFAULT_LAUNCH_SHOW_DURATION = 3000;
   public static final int DEFAULT_FADE_IN_DURATION = 200;
   public static final int DEFAULT_FADE_OUT_DURATION = 200;
   public static final int DEFAULT_SHOW_DURATION = 3000;

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -181,7 +181,12 @@ export async function getOrCreateConfig(config: Config) {
     appName: config.app.appName,
     bundledWebRuntime: config.app.bundledWebRuntime,
     npmClient: config.cli.npmClient,
-    webDir: basename(resolve(config.app.rootDir, config.app.webDir))
+    webDir: basename(resolve(config.app.rootDir, config.app.webDir)),
+    plugins: {
+      SplashScreen : {
+        launchShowDuration: 0
+      }
+    }
   });
 
   // Store our newly created or found external config as the default

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -11,7 +11,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
   var hideTask: Any?
   var isVisible: Bool = false
 
-  let launchShowDuration = 0
+  let launchShowDuration = 3000
   let launchAutoHide = true
 
   let defaultFadeInDuration = 200


### PR DESCRIPTION
Instead of setting the default native value to 0 as done on https://github.com/ionic-team/capacitor/commit/b29346b2bf9d41ec3be621f80435b306c1027941

set the default values back to 3000 and make new projects have 
```
"plugins": {
    "SplashScreen": {
        "launchShowDuration": 0
    }
}
```
