### PR TITLE
fix(ios): Support CORS when using Live Reload

### DIFF
--- a/ios/Capacitor/Capacitor/CAPAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/CAPAssetHandler.swift
@@ -24,29 +24,48 @@ class CAPAssetHandler: NSObject, WKURLSchemeHandler {
       let localUrl = URL.init(string: url.absoluteString)!
       let fileUrl = URL.init(fileURLWithPath: startPath)
 
+      // CORS support
+      let origin = urlSchemeTask.request.value(forHTTPHeaderField: "origin")
+      var headers =  origin != nil ? [
+        "Access-Control-Allow-Origin": origin!,
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+      ] : [String: String]()
+
       do {
-        var data = Data()
-        if !stringToLoad.contains("cordova.js") {
-          if isMediaExtension(pathExtension: url.pathExtension) {
-            data = try Data(contentsOf: fileUrl, options: Data.ReadingOptions.mappedIfSafe)
-          } else {
-            data = try Data(contentsOf: fileUrl)
+        switch urlSchemeTask.request.httpMethod {
+        case "GET":
+          var data = Data()
+          if !stringToLoad.contains("cordova.js") {
+            if isMediaExtension(pathExtension: url.pathExtension) {
+              data = try Data(contentsOf: fileUrl, options: Data.ReadingOptions.mappedIfSafe)
+            } else {
+              data = try Data(contentsOf: fileUrl)
+            }
           }
+          let mimeType = mimeTypeForExtension(pathExtension: url.pathExtension)
+          let expectedContentLength = data.count
+
+          headers["Content-Type"] = mimeType
+          headers["Cache-Control"] = "no-cache"
+
+          let urlResponse = URLResponse(url: localUrl, mimeType: mimeType, expectedContentLength: expectedContentLength, textEncodingName: nil)
+          let httpResponse = HTTPURLResponse(url: localUrl, statusCode: 200, httpVersion: nil, headerFields: headers)
+          if isMediaExtension(pathExtension: url.pathExtension) {
+              urlSchemeTask.didReceive(urlResponse)
+          } else {
+              urlSchemeTask.didReceive(httpResponse!)
+          }
+          urlSchemeTask.didReceive(data)
+        case "OPTIONS":
+          // CORS preflight
+          let response = HTTPURLResponse(url: localUrl, statusCode: 200, httpVersion: nil, headerFields: headers)
+          urlSchemeTask.didReceive(response!)
+
+        default:
+          // method not allowed
+          let response = HTTPURLResponse(url: localUrl, statusCode: 405, httpVersion: nil, headerFields: headers)
+          urlSchemeTask.didReceive(response!)
         }
-        let mimeType = mimeTypeForExtension(pathExtension: url.pathExtension)
-        let expectedContentLength = data.count
-        let headers =  [
-          "Content-Type": mimeType,
-          "Cache-Control": "no-cache"
-        ]
-        let urlResponse = URLResponse(url: localUrl, mimeType: mimeType, expectedContentLength: expectedContentLength, textEncodingName: nil)
-        let httpResponse = HTTPURLResponse(url: localUrl, statusCode: 200, httpVersion: nil, headerFields: headers)
-        if isMediaExtension(pathExtension: url.pathExtension) {
-            urlSchemeTask.didReceive(urlResponse)
-        } else {
-            urlSchemeTask.didReceive(httpResponse!)
-        }
-        urlSchemeTask.didReceive(data)
       } catch let error as NSError {
         urlSchemeTask.didFailWithError(error)
         return


### PR DESCRIPTION
`_capacitor_file_` HTTP requests fail CORS checks when server.url is set. This PR implements CORS support on iOS. (Sidenote: does not require a fix for Android as `_capacitor_file_` requests are sent to the same origin of the page).

# How to reproduce
```json
// capacitor.config.json
{
  "server": { "url": "http://192.168.15.26:6789" }
  ...
}
```

```javascript
// my-app.js
const url = Capacitor.convertFileSrc(uri)
await fetch(url) // throws
```

```
[Error] Origin http://192.168.15.26:6789 is not allowed by Access-Control-Allow-Origin.
[Error] Failed to load resource: Origin http://192.168.15.26:6789 is not allowed by Access-Control-Allow-Origin. (1588911030406.txt, line 0)
[Error] Fetch API cannot load capacitor://localhost/_capacitor_file_/Users/me/Library/Developer/CoreSimulator/Devices/E60456F7-630E-4574-B7BD-A486C85B06C3/data/Containers/Data/Application/FFE5A297-770F-418D-9331-5833B1CCA94C/Documents/1588911030406.txt due to access control checks.
[Error] TypeError: Origin http://192.168.15.26:6789 is not allowed by Access-Control-Allow-Origin.
  capacitorConsole (user-script:2:78)
  (anonymous function) (bundle.js:4179)
  promiseReactionJob
```