### PR TITLE
fix(android): remember camera prompt selection after permission result

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -119,8 +119,10 @@ public class Camera extends Plugin {
       @Override
       public void onSelect(int index) {
         if (index == 0) {
+          settings.setSource(CameraSource.PHOTOS);
           openPhotos(call);
         } else if (index == 1) {
+          settings.setSource(CameraSource.CAMERA);
           openCamera(call);
         }
       }


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor/issues/2106