### PR TITLE
fix(dependencies): peer dependencies to ~2.1.0

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@capacitor/core": "~2.0.0"
+    "@capacitor/core": "~2.1.0"
   },
   "gitHead": "844c0feba4a801ee5041429a82d0f805c9e665b0"
 }


### PR DESCRIPTION
npm WARN @capacitor/android@2.1.0 requires a peer of @capacitor/core@~2.0.0 but none is installed. You must install peer dependencies yourself.

Not sure if you wan't ^ or ~ but, I think ~ should be fine