### PR TITLE
fix(dependencies): peer dependencies to ~2.1.0

### DIFF
--- a/scripts/deploy/package.json.template
+++ b/scripts/deploy/package.json.template
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@capacitor/core": "~2.0.0"
+    "@capacitor/core": "~2.1.0"
   },
   "scripts": {
     "prepublishOnly": "bash ../scripts/setversion.sh"


### PR DESCRIPTION
npm WARN @capacitor/ios@2.1.0 requires a peer of @capacitor/core@~2.0.0 but none is installed. You must install peer dependencies yourself.

Not sure if you wan't ^ or ~ but, I think ~ should be fine