### PR TITLE
fix(cordova): Add cordova-support-google-services to incompatible list

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -337,7 +337,7 @@ export function getIncompatibleCordovaPlugins(platform: string) {
   let pluginList = ['cordova-plugin-splashscreen', 'cordova-plugin-ionic-webview', 'cordova-plugin-crosswalk-webview',
   'cordova-plugin-wkwebview-engine', 'cordova-plugin-console', 'cordova-plugin-music-controls',
   'cordova-plugin-add-swift-support', 'cordova-plugin-ionic-keyboard', 'cordova-plugin-braintree',
-  '@ionic-enterprise/filesystem', '@ionic-enterprise/keyboard', '@ionic-enterprise/splashscreen'];
+  '@ionic-enterprise/filesystem', '@ionic-enterprise/keyboard', '@ionic-enterprise/splashscreen', 'cordova-support-google-services'];
   if (platform === 'ios') {
     pluginList.push('cordova-plugin-googlemaps', 'cordova-plugin-statusbar', '@ionic-enterprise/statusbar');
   }


### PR DESCRIPTION
the plugin just apply plugin com.google.gms.google-services, but Capacitor already does it, so it's not needed and makes the apply of Capacitor to fail and show the `google-services.json not found, google-services plugin not applied. Push Notifications won't work` that might confuse users, so make the CLI skip it.