### PR TITLE
fix(android): incorrect keyboard height

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Keyboard.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Keyboard.java
@@ -9,6 +9,7 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
 import android.view.inputmethod.InputMethodManager;
 
 import com.getcapacitor.JSObject;
@@ -54,18 +55,19 @@ public class Keyboard extends Plugin {
             // cache properties for later use
             int rootViewHeight = rootView.getRootView().getHeight();
             int resultBottom = r.bottom;
-
-            // calculate screen height differently for android versions >= 21: Lollipop 5.x, Marshmallow 6.x
-            //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
             int screenHeight;
 
-            if (Build.VERSION.SDK_INT >= 21) {
+            if (Build.VERSION.SDK_INT >= 23) {
+              WindowInsets windowInsets = rootView.getRootWindowInsets();
+              int stableInsetBottom = windowInsets.getStableInsetBottom();
+              screenHeight = rootViewHeight - stableInsetBottom;
+            } else {
+              // calculate screen height differently for android versions <23: Lollipop 5.x, Marshmallow 6.x
+              //http://stackoverflow.com/a/29257533/3642890 beware of nexus 5
               Display display = getActivity().getWindowManager().getDefaultDisplay();
               Point size = new Point();
               display.getSize(size);
               screenHeight = size.y;
-            } else {
-              screenHeight = rootViewHeight;
             }
 
             int heightDiff = screenHeight - resultBottom;


### PR DESCRIPTION
At the moment, the Keyboard plugin returns incorrect keyboard height on Android phones with cutouts. This fixes it by subtracting the size of the bottom cutout from the total screen height. 

I also removed obsolete code ensuring backwards-compatibility with Android SDK versions <21 since Capacitor doesn't support these versions.