### PR TITLE
docs(splash): Full Screen & Immersive are android only

### DIFF
--- a/site/docs-md/apis/splash-screen/index.md
+++ b/site/docs-md/apis/splash-screen/index.md
@@ -108,7 +108,7 @@ To set the color of the spinner use `spinnerColor`, values are either `#RGB` or 
 
 Then run `npx cap copy` to apply these changes.
 
-## Full Screen & Immersive
+## Full Screen & Immersive (Android only)
 
 You can enable `splashFullScreen` to hide status bar, or `splashImmersive` to hide both status bar and software navigation buttons. If both options are enabled `splashImmersive` takes priority, as it also fulfils `splashFullScreen` functionality.
 


### PR DESCRIPTION
document that `splashFullScreen` and `splashImmersive` are android only

closes https://github.com/ionic-team/capacitor/issues/2934