### PR TITLE
docs(StatusBar): Fix 'Configuring iOS' link

### DIFF
--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -17,7 +17,7 @@ The StatusBar API Provides methods for configuring the style of the Status Bar, 
 
 ## iOS Note
 
-This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](../ios/configuration) for help.
+This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](../../ios/configuration) for help.
 
 The status bar visibility defaults to visible and the style defaults to `StatusBarStyle.Light`. You can change these defaults by adding `UIStatusBarHidden` and or `UIStatusBarStyle` in the `Info.plist`.
 


### PR DESCRIPTION
This PR fixes the 'Configuring iOS' link under iOS notes on the [Status Bar](https://capacitor.ionicframework.com/docs/apis/status-bar/#ios-note) docs page.

![Capture](https://user-images.githubusercontent.com/8324407/82405546-d7c9b280-9a81-11ea-984c-f928a59a4849.PNG)
