### PR TITLE
docs(deep-links): clarify apple-app-site-association file

### DIFF
--- a/site/docs-md/guides/deep-links.md
+++ b/site/docs-md/guides/deep-links.md
@@ -158,7 +158,7 @@ Next, create the site association file (`apple-app-site-association`).
 
 > Note: Despite being a JSON file, do not save it with a file extension.
 
-An example of the `apple-app-site-association` file is below. Be sure to replace `TEAMID.BUNDLEID` with your own IDs (example: `8L65AZE66A.com.netkosoft.beerswift`)
+An example of the `apple-app-site-association` file is below. Be sure to replace `TEAMID.BUNDLEID` with your own IDs (example: `8L65AZE66A.com.netkosoft.beerswift`).
 
 ```json
 {

--- a/site/docs-md/guides/deep-links.md
+++ b/site/docs-md/guides/deep-links.md
@@ -4,6 +4,7 @@ description: Implement deep linking functionality in an iOS and Android app
 url: /docs/guides/deep-links
 contributors:
   - dotnetkow
+  - jaydrogers
 ---
 
 # Deep Linking with Universal and App Links
@@ -157,14 +158,14 @@ Next, create the site association file (`apple-app-site-association`).
 
 > Note: Despite being a JSON file, do not save it with a file extension.
 
+An example of the `apple-app-site-association` file is below. Be sure to replace `TEAMID.BUNDLEID` with your own IDs (example: `8L65AZE66A.com.netkosoft.beerswift`)
+
 ```json
-// apple-app-site-association
 {
     "applinks": {
         "apps": [],
         "details": [
             {
-                // example: 8L65AZE66A.com.netkosoft.beerswift
                 "appID": "TEAMID.BUNDLEID",
                 "paths": ["*"]
             }


### PR DESCRIPTION
I was working with the `apple-app-site-association` file today, banging my head against the wall why it wasn't working.

Then I realized there was a comment at the top of the file that was causing my file to be interpreted as a file to be downloaded (not a content-type of JSON). LOL, programming...

I created this PR to hopefully help clarify the example a little bit more and prevent others from running into the same issue (although I know I am the dumb one 😀)

Thanks for your hard work 🙏

Let me know if you have any questions!