### PR TITLE
fix(cordova): Exclude framework headers

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -219,6 +219,7 @@ async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, 
   }
   if (customFrameworks.length > 0) {
     frameworkDeps.push(`s.vendored_frameworks = '${customFrameworks.join(`', '`)}'`);
+    frameworkDeps.push(`s.exclude_files = 'sources/**/*.framework/Headers/*.h'`);
   }
   if (sourceFrameworks.length > 0) {
     frameworkDeps.push(`s.vendored_libraries = '${sourceFrameworks.join(`', '`)}'`);


### PR DESCRIPTION
framework headers are being added as plugins source code an that is causing problems when there are mixed swift and objective-c plugins because of the generated CocoaPods umbrella.

This change prevents CocoaPods from adding the files as they are not needed because they are in the .framework already and avoids those conflicts.

Some reported issues that had this problem:
https://github.com/ionic-team/capacitor/issues/2357
https://github.com/ionic-team/capacitor/issues/2625