### PR TITLE
[Docs] Add basic guide for generating Splash Screen/icons

### DIFF
--- a/site/docs-md/README.md
+++ b/site/docs-md/README.md
@@ -20,6 +20,7 @@
   * [Cordova/Ionic Native Plugins](cordova/using-cordova-plugins.md)
   * [Known Incompatible Plugins](cordova/known-incompatible-plugins.md)
 * Guides
+  * [Splash Screens and Icons](guides/splash-screens-icons.md)
   * [Ionic Framework Camera App](guides/ionic-framework-app.md)
   * [Push Notifications - Firebase](guides/push-notifications-firebase.md)
   * [Deep Links](guides/deep-links.md)

--- a/site/docs-md/cordova/migrating-from-cordova-to-capacitor.md
+++ b/site/docs-md/cordova/migrating-from-cordova-to-capacitor.md
@@ -68,7 +68,22 @@ Both android and ios folders at the root of the project are created. These are e
 
 ## Splash Screens and Icons
 
-If you've previously created icon and splash screen images, they can be found in the top-level `resources` folder of your project. [Follow this guide](https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/) to move them over to each native project.
+If you've previously created icon and splash screen images, they can be found in the top-level `resources` folder of your project. With those images in place, you can use the `cordova-res` tool to generate icons and splash screens for Capacitor-based iOS and Android projects.
+
+First, install `cordova-res`:
+
+```bash
+$ npm install -g cordova-res
+```
+
+Next, run the following to regenerate the images and copy them into the native projects:
+
+```bash
+$ cordova-res ios --skip-config --copy
+$ cordova-res android --skip-config --copy
+```
+
+[Complete details here](https://github.com/ionic-team/cordova-res#capacitor).
 
 ## Migrate Plugins
 

--- a/site/docs-md/guides/splash-screens-icons.md
+++ b/site/docs-md/guides/splash-screens-icons.md
@@ -1,0 +1,32 @@
+---
+title: Creating Splash Screens and Icons
+description: Use cordova-res to generate resource images for native projects
+url: /docs/guides/splash-screens-and-icons
+contributors:
+  - dotnetkow
+---
+
+#  Creating Splash Screens and Icons
+
+Initial support for splash screen and icon generation is now available. For complete details, see the [cordova-res docs](https://github.com/ionic-team/cordova-res).
+
+First, install `cordova-res`:
+
+```bash
+$ npm install -g cordova-res
+```
+
+`cordova-res` expects a Cordova-like structure: place one icon and one splash screen file in a top-level `resources` folder within your project, like so:
+
+```
+resources/
+├── icon.png
+└── splash.png
+```
+
+Next, run the following to generate all images then copy them into the native projects:
+
+```bash
+$ cordova-res ios --skip-config --copy
+$ cordova-res android --skip-config --copy
+```


### PR DESCRIPTION
While v1.0 milestone is ongoing for cordova-res, generating splash screens and icons comes up a lot in the community. With the recent addition of Capacitor support (native projects) in cordova-res, I'm opening this simple PR to get folks started.

It's intentionally as short as possible, since we know the package name will change, how to run it will inevitably change, etc.