### PR TITLE
fix(ios): Create tmpWindow when is needed and destroy it when not needed

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -9,8 +9,7 @@ enum BridgeError: Error {
 
 @objc public class CAPBridge : NSObject {
 
-  let tmpWindow = UIWindow.init(frame: UIScreen.main.bounds)
-  let tmpVC = TmpViewController.init()
+  var tmpWindow: UIWindow?
   @objc public static let statusBarTappedNotification = Notification(name: Notification.Name(rawValue: "statusBarTappedNotification"))
   @objc public static let tmpVCAppeared = Notification(name: Notification.Name(rawValue: "tmpViewControllerAppeared"))
   public static var CAP_SITE = "https://capacitor.ionicframework.com/"
@@ -66,10 +65,8 @@ enum BridgeError: Error {
     registerPlugins()
     setupCordovaCompatibility()
     bindObservers()
-    self.tmpWindow.rootViewController = tmpVC
-    self.tmpWindow.makeKeyAndVisible()
     NotificationCenter.default.addObserver(forName: CAPBridge.tmpVCAppeared.name, object: .none, queue: .none) { _ in
-      self.tmpWindow.isHidden = true
+      self.tmpWindow = nil
     }
   }
   
@@ -601,16 +598,19 @@ enum BridgeError: Error {
     if viewControllerToPresent.modalPresentationStyle == .popover {
       self.viewController.present(viewControllerToPresent, animated: flag, completion: completion)
     } else {
-      self.tmpWindow.makeKeyAndVisible()
-      self.tmpVC.present(viewControllerToPresent, animated: flag, completion: completion)
+      self.tmpWindow = UIWindow.init(frame: UIScreen.main.bounds)
+      self.tmpWindow!.rootViewController = TmpViewController.init()
+      self.tmpWindow!.makeKeyAndVisible()
+      self.tmpWindow!.rootViewController!.present(viewControllerToPresent, animated: flag, completion: completion)
     }
   }
 
   @objc public func dismissVC(animated flag: Bool, completion: (() -> Void)? = nil) {
-    if self.tmpWindow.isHidden {
+    if self.tmpWindow == nil {
       self.viewController.dismiss(animated: flag, completion: completion)
     } else {
-      self.tmpVC.dismiss(animated: flag, completion: completion)
+      self.tmpWindow!.rootViewController!.dismiss(animated: flag, completion: completion)
+      self.tmpWindow = nil
     }
   }
 

--- a/ios/Capacitor/Capacitor/TmpViewController.swift
+++ b/ios/Capacitor/Capacitor/TmpViewController.swift
@@ -1,8 +1,20 @@
 import UIKit
 
 class TmpViewController: UIViewController {
+    var count = 0
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        NotificationCenter.default.post(CAPBridge.tmpVCAppeared)
+        // On iOS 11-12 viewDidAppear is called when TmpViewController is created and
+        // when the presented VC gets dismissed.
+        // On iOS 13 only when the presented VC gets dismissed.
+        // We only want to send the notification when the presented VC gets dismissed.
+        if #available(iOS 13, *) {
+            count += 2
+        } else {
+            count += 1
+        }
+        if count > 1 {
+            NotificationCenter.default.post(CAPBridge.tmpVCAppeared)
+        }
     }
 }


### PR DESCRIPTION
instead of having the tmpWindow always present, init it when it's needed and destroy it when it's not needed so it doesn't mess up with orientation plugin

closes https://github.com/ionic-team/capacitor/issues/2977
closes https://github.com/ionic-team/capacitor/issues/2892