### PR TITLE
docs: make links to other pages absolute

### DIFF
--- a/site/docs-md/android/configuration.md
+++ b/site/docs-md/android/configuration.md
@@ -41,7 +41,7 @@ You probably also want to set the Activity name to match the App, for apps that 
 
 To enable deeplinking through Android App Links, follow the official Android guide on [Adding Android App Links](https://developer.android.com/studio/write/app-link-indexing). Android Studio comes with a handy wizard for configuring App Links.
 
-Once configured, the [getLaunchUrl in the App API](../../apis/app#method-getLaunchUrl-0) will provide any URL the app was launched with, and the [appUrlOpen event](../../apis/app#method-addListener-1) will fire any time the app receives a new App Link deeplink.
+Once configured, the [getLaunchUrl in the App API](/docs/apis/app#method-getLaunchUrl-0) will provide any URL the app was launched with, and the [appUrlOpen event](/docs/apis/app#method-addListener-1) will fire any time the app receives a new App Link deeplink.
 
 ## Changing Custom URL
 

--- a/site/docs-md/android/index.md
+++ b/site/docs-md/android/index.md
@@ -71,6 +71,6 @@ If your app ran you are now ready to continue developing and building your app. 
 Follow these Android-specific guides for more information on setting permissions for your app, updating dependencies, building
 plugins, and more:
 
-[Configuring and setting permissions for Android &#8250;](./configuration)
+[Configuring and setting permissions for Android &#8250;](/docs/android/configuration)
 
-[Building Native Plugins for Android &#8250;](../plugins)
+[Building Native Plugins for Android &#8250;](/docs/plugins)

--- a/site/docs-md/apis/app/index.md
+++ b/site/docs-md/apis/app/index.md
@@ -22,7 +22,7 @@ deeplinks, opens other apps, and manages persisted plugin state.
 
 To use `canOpenUrl`, you need to set the URL schemes your app will query for in `LSApplicationQueriesSchemes` in `Info.plist`.
 
-Read more about [LSApplicationQueriesSchemes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14) and [configuring Info.plist](../ios/configuration).
+Read more about [LSApplicationQueriesSchemes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14) and [configuring Info.plist](/docs/ios/configuration).
 
 ## Example
 

--- a/site/docs-md/apis/camera/index.md
+++ b/site/docs-md/apis/camera/index.md
@@ -29,7 +29,7 @@ Key: 	`NSPhotoLibraryAddUsageDescription`
 Name: `Privacy - Photo Library Usage Description`  
 Key: 	`NSPhotoLibraryUsageDescription`
 
-Read about [Setting iOS Permissions](../../ios/configuration/) in the [iOS Guide](../../ios/) for more information on setting iOS permissions in Xcode
+Read about [Setting iOS Permissions](/docs/ios/configuration/) in the [iOS Guide](/docs/ios/) for more information on setting iOS permissions in Xcode
 
 ## Android Notes
 
@@ -42,7 +42,7 @@ This API requires the following permissions be added to your `AndroidManifest.xm
 
 The storage permissions are for reading/saving photo files.
 
-Read about [Setting Android Permissions](../../android/configuration/) in the [Android Guide](../../android/) for more information on setting Android permissions.
+Read about [Setting Android Permissions](/docs/android/configuration/) in the [Android Guide](/docs/android/) for more information on setting Android permissions.
 
 Additionally, because the Camera API launches a separate Activity to handle taking the photo, you should listen for `appRestoredResult` in the `App` plugin
 to handle any camera data that was sent in the case your app was terminated by the operating system while the Activity was running.

--- a/site/docs-md/apis/geolocation/index.md
+++ b/site/docs-md/apis/geolocation/index.md
@@ -26,7 +26,7 @@ Key: `NSLocationAlwaysUsageDescription`
 Name: `Privacy - Location When In Use Usage Description`
 Key: `NSLocationWhenInUseUsageDescription`
 
-Read about [Setting iOS Permissions](../ios/configuration/) in the [iOS Guide](../ios/) for more information on setting iOS permissions in Xcode
+Read about [Setting iOS Permissions](/docs/ios/configuration/) in the [iOS Guide](/docs/ios/) for more information on setting iOS permissions in Xcode
 
 ## Android Notes
 
@@ -41,7 +41,7 @@ This API requires the following permissions be added to your `AndroidManifest.xm
 
 The first two permissions ask for location data, both fine and coarse, and the last line is optional but necessary if your app _requires_ GPS to function. You may leave it out, though keep in mind that this may mean your app is installed on devices lacking GPS hardware.
 
-Read about [Setting Android Permissions](../android/configuration/) in the [Android Guide](../android/) for more information on setting Android permissions.
+Read about [Setting Android Permissions](/docs/android/configuration/) in the [Android Guide](/docs/android/) for more information on setting Android permissions.
 
 ## Example
 

--- a/site/docs-md/apis/push-notifications/index.md
+++ b/site/docs-md/apis/push-notifications/index.md
@@ -11,7 +11,7 @@ contributors:
 
 # Push Notifications
 
-The Push Notifications API provides methods for registering a device to receive notifications from a server, along with processing received notifications and responding to them. In contrast, the [Local Notifications](../local-notifications) API provides means for offline, local notification scheduling and processing.
+The Push Notifications API provides methods for registering a device to receive notifications from a server, along with processing received notifications and responding to them. In contrast, the [Local Notifications](/docs/apis/local-notifications) API provides means for offline, local notification scheduling and processing.
 
 ## Enabling Push Notifications Capabilites
 

--- a/site/docs-md/apis/status-bar/index.md
+++ b/site/docs-md/apis/status-bar/index.md
@@ -17,7 +17,7 @@ The StatusBar API Provides methods for configuring the style of the Status Bar, 
 
 ## iOS Note
 
-This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](../ios/configuration) for help.
+This plugin requires "View controller-based status bar appearance" (`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read about [Configuring iOS](/docs/ios/configuration) for help.
 
 The status bar visibility defaults to visible and the style defaults to `StatusBarStyle.Light`. You can change these defaults by adding `UIStatusBarHidden` and or `UIStatusBarStyle` in the `Info.plist`.
 

--- a/site/docs-md/basics/workflow.md
+++ b/site/docs-md/basics/workflow.md
@@ -15,7 +15,7 @@ contributors:
 
 Capacitor turns your web app into a native binary for each platform. Thus, much of your work will consist of developing and then building a mobile-focused web app.
 
-You will interact with the native platform underneath using Capacitor's APIs (such as [Camera](../apis/camera)), or by using existing Cordova plugins with Capacitor's [Cordova Compatibility](./cordova).
+You will interact with the native platform underneath using Capacitor's APIs (such as [Camera](/docs/apis/camera)), or by using existing Cordova plugins with Capacitor's [Cordova Compatibility](/docs/cordova).
 
 As a final step you will build your application using a command similar to
 

--- a/site/docs-md/cordova/using-cordova-plugins.md
+++ b/site/docs-md/cordova/using-cordova-plugins.md
@@ -63,7 +63,7 @@ npx cap ls
 
 Capacitor does not support Cordova install variables, auto configuration, or hooks, due to our philosophy of letting you control your native project source code (meaning things like hooks are unnecessary). If your plugin requires variables or settings to be set, you'll need to apply those configuration settings manually by mapping between the plugin's `plugin.xml` and required settings on iOS and Android.
 
-Consult the [iOS](../ios/configuration) and [Android](../android/configuration) configuration guides for info on how to configure each platform.
+Consult the [iOS](/docs/ios/configuration) and [Android](/docs/android/configuration) configuration guides for info on how to configure each platform.
 
 ## Compatibility Issues
 

--- a/site/docs-md/electron/index.md
+++ b/site/docs-md/electron/index.md
@@ -54,4 +54,4 @@ We will have more info on building Electron plugins soon.
 
 That's pretty much all you need to know to build an Electron app with Capacitor!
 
-Follow the [Development Workflow](../basics/workflow) guide to continue building and testing your app.
+Follow the [Development Workflow](/docs/basics/workflow) guide to continue building and testing your app.

--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -18,7 +18,7 @@ set of UI controls which you will most likely need unless you're building a game
 
 ## Before you start
 
-Make sure you have all the required [Dependencies](./dependencies) installed for the platforms you will be building for. Most importantly,
+Make sure you have all the required [Dependencies](/docs/getting-started/dependencies) installed for the platforms you will be building for. Most importantly,
 make sure you update CocoaPods using `pod repo update` before starting a new project, if you plan on building for iOS using a Mac.
 
 ## Adding Capacitor to an existing Ionic App

--- a/site/docs-md/guides/deep-links.md
+++ b/site/docs-md/guides/deep-links.md
@@ -35,7 +35,7 @@ For illustrative purposes, https://beerswift.app will be used as the web app lin
 
 ## Deep Link Routing using the Capacitor App API
 
-When the native app is opened after a deep link is clicked, the mobile OS doesn't automatically know where to route the user. This must be implemented within the app itself using the Capacitor [App API](../apis/app) on app startup.
+When the native app is opened after a deep link is clicked, the mobile OS doesn't automatically know where to route the user. This must be implemented within the app itself using the Capacitor [App API](/docs/apis/app) on app startup.
 
 If your website and app paths don't match, you will need to implement more advanced url pattern matching (see [this guide](https://devdactic.com/universal-links-ionic/) for examples). If your mobile app and web app use the same codebase though, this is very straightforward - just redirect to the same URL. The following examples assume this.
 

--- a/site/docs-md/guides/ionic-framework-app.md
+++ b/site/docs-md/guides/ionic-framework-app.md
@@ -14,7 +14,7 @@ contributors:
 Capacitor makes it easy to build web apps that run natively on iOS, Android, desktop, and the web. In this guide, we'll add Camera functionality to an Ionic Angular app that works on the web, iOS, and Android. Ready to capture photos using just one JavaScript method call?  Let's get started.
 
 ## Required Dependencies
-Building and deploying iOS and Android apps require additional dependencies, including an iOS and Android device. Please [follow the instructions here](../getting-started/dependencies) before continuing.
+Building and deploying iOS and Android apps require additional dependencies, including an iOS and Android device. Please [follow the instructions here](/docs/getting-started/dependencies) before continuing.
 
 ## Prepare an Ionic App
 If you have an existing Ionic app, skip this section. If not, let's create an Ionic app first. In a Terminal, install Ionic (this also updates to the latest version of Ionic):
@@ -72,7 +72,7 @@ npx cap add android
 Upon running these commands, both `android` and `ios` folders at the root of the project are created. These are entirely separate native project artifacts that should be considered part of your Ionic app (i.e., check them into source control).
 
 ## Adding Camera Functionality
-Next up, we'll add the ability to take photos with the device's camera using the Capacitor [Camera API](../apis/camera).
+Next up, we'll add the ability to take photos with the device's camera using the Capacitor [Camera API](/docs/apis/camera).
 
 To begin, open the Tab2 HTML page under the `src/app/tab2` folder. Add an image tag that will display the current photo taken with the camera and add an Ionic fab button that will open the camera when clicked:
 
@@ -212,7 +212,7 @@ Within Xcode, click on `App` in the Project Navigator on the left-hand side, the
 
 ![Xcode - Selecting Development Team](/assets/img/docs/guides/ionic-framework/xcode-signing.png)
 
-Next, for the Camera plugin to work, we must configure the "Privacy - Camera Usage" permission. iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. To set this, the `Info.plist` file must be modified ([more details here](../ios/configuration/)). To access it, click "Info," then expand "Custom iOS Target Properties."
+Next, for the Camera plugin to work, we must configure the "Privacy - Camera Usage" permission. iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. To set this, the `Info.plist` file must be modified ([more details here](/docs/ios/configuration/)). To access it, click "Info," then expand "Custom iOS Target Properties."
 
 ![Xcode Custom iOS Target Properties](/assets/img/docs/guides/ionic-framework/xcode-info-plist.png)
 
@@ -272,6 +272,6 @@ Once again, upon tapping the Camera button on Tab Two, the permission prompt sho
 
 We created a cross-platform Ionic Angular app that runs on the web, Android, and iOS. Using the Capacitor Camera API, we added the ability to use the device's camera with just a few lines of code.
 
-What's next? Try adding another API, such as [Toasts](../apis/toast) or [Push Notifications](../apis/push-notifications). Looking to create custom native functionality? Create a [Capacitor plugin](../plugins/). This is just the beginning of your Capacitor journey. 
+What's next? Try adding another API, such as [Toasts](/docs/apis/toast) or [Push Notifications](/docs/apis/push-notifications). Looking to create custom native functionality? Create a [Capacitor plugin](/docs/plugins/). This is just the beginning of your Capacitor journey. 
 
 Happy app building!

--- a/site/docs-md/guides/push-notifications-firebase.md
+++ b/site/docs-md/guides/push-notifications-firebase.md
@@ -18,7 +18,7 @@ For the purposes of registering and monitoring for push notifications from Fireb
 
 ## Required Dependencies
 
-Building and deploying iOS and Android applications using Capacitor requires a bit of setup. Please [follow the instructions to install the necessary Capacitor dependencies here](../getting-started/dependencies) before continuing.
+Building and deploying iOS and Android applications using Capacitor requires a bit of setup. Please [follow the instructions to install the necessary Capacitor dependencies here](/docs/getting-started/dependencies) before continuing.
 
 To test push notifications on iOS, Apple requires that you have [a paid Apple Developer account](https://developer.apple.com/) and a *physical* iOS device.
 
@@ -255,7 +255,7 @@ iOS push notifications are significantly more complicated to set up than Android
 1. [Setup the proper Development or Production certificates & provisioning profiles](https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7) for your iOS application in the Apple Developer Portal
 2. [Create an APNS certificate or key](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns) for either Development or Production in the Apple Developer Portal
 3. [Ensure Push Notification capabilities have been enabled](https://help.apple.com/xcode/mac/current/#/dev88ff319e7) in your application in Xcode
-4. Have a physical iOS device as per the guidelines in the [Dependencies](../getting-started/dependencies) documentation
+4. Have a physical iOS device as per the guidelines in the [Dependencies](/docs/getting-started/dependencies) documentation
 
 ### Integrating Firebase with our native iOS app
 

--- a/site/docs-md/ios/index.md
+++ b/site/docs-md/ios/index.md
@@ -59,6 +59,6 @@ If your app ran you are now ready to continue developing and building your app. 
 
 Follow these guides for more information on each topic:
 
-[Configuring and setting permissions for iOS &#8250;](./configuration)
+[Configuring and setting permissions for iOS &#8250;](/docs/ios/configuration)
 
-[Building Native Plugins for iOS &#8250;](../plugins)
+[Building Native Plugins for iOS &#8250;](/docs/plugins)

--- a/site/docs-md/plugins/android.md
+++ b/site/docs-md/plugins/android.md
@@ -15,7 +15,7 @@ contributors:
 
 ## Getting Started
 
-To get started, first generate a plugin as shown in the [Getting Started](./#getting-started) section of the Plugin guide.
+To get started, first generate a plugin as shown in the [Getting Started](/docs/plugins/#getting-started) section of the Plugin guide.
 
 Next, open `your-plugin/android/` in Android Studio. You then want to navigate to the `.java` file for your plugin, which changes depending on the Plugin ID and Plugin Class Name you used when creating the plugin.
 

--- a/site/docs-md/plugins/index.md
+++ b/site/docs-md/plugins/index.md
@@ -89,4 +89,4 @@ Your package can now be installed using `npm install your-plugin` in any Capacit
 
 Now it's up to you to make your plugin do something truly awesome!
 
-Follow the [iOS](./ios) guide for information on using Swift (or Obj-C) to build an iOS plugin, the [Android](./android) guide for building Android plugins with Java, the [Web](./web) guide for implementing web and PWA functionality for your plugin, and the [Custom JavaScript](./js) guide for information on how to build a custom JavaScript plugin (i.e. in addition to Capacitor's auto-JS plugin binding).
+Follow the [iOS](/docs/plugins/ios) guide for information on using Swift (or Obj-C) to build an iOS plugin, the [Android](/docs/plugins/android) guide for building Android plugins with Java, the [Web](/docs/plugins/web) guide for implementing web and PWA functionality for your plugin, and the [Custom JavaScript](/docs/plugins/js) guide for information on how to build a custom JavaScript plugin (i.e. in addition to Capacitor's auto-JS plugin binding).

--- a/site/docs-md/plugins/ios.md
+++ b/site/docs-md/plugins/ios.md
@@ -15,7 +15,7 @@ contributors:
 
 ## Getting Started
 
-To get started, first generate a plugin as shown in the [Getting Started](./#getting-started) section of the Plugin guide.
+To get started, first generate a plugin as shown in the [Getting Started](/docs/plugins/#getting-started) section of the Plugin guide.
 
 Next, open `your-plugin/ios/Plugin.xcworkspace` in Xcode.
 

--- a/site/docs-md/plugins/js.md
+++ b/site/docs-md/plugins/js.md
@@ -15,7 +15,7 @@ contributors:
 
 ## Getting Started
 
-To build a custom JavaScript frontend for Capacitor, first follow the [Getting Started](../plugins) section of the plugin guide.
+To build a custom JavaScript frontend for Capacitor, first follow the [Getting Started](/docs/plugins) section of the plugin guide.
 
 Next, build out your plugin any way you see fit! The generated plugin template comes with TypeScript and a simple build process ready to go. You can adopt that (recommended) or remove those files and start fresh.
 

--- a/site/docs-md/plugins/web.md
+++ b/site/docs-md/plugins/web.md
@@ -13,7 +13,7 @@ contributors:
 
 ## Getting Started
 
-To get started, first generate a plugin as shown in the [Getting Started](./#getting-started) section of the Plugin guide.
+To get started, first generate a plugin as shown in the [Getting Started](/docs/plugins/#getting-started) section of the Plugin guide.
 
 Next, open `your-plugin/src/web.ts` in your editor of choice.
 

--- a/site/docs-md/web/index.md
+++ b/site/docs-md/web/index.md
@@ -14,7 +14,7 @@ contributors:
 
 Chances are, you already have Capacitor installed in your app if you're using Capacitor to build an iOS, or Android app. In capacitor, the `web` platform is just the web project that powers your app!
 
-If you don't have Capacitor installed yet, consult the [Installation](./getting-started) guide before continuing.
+If you don't have Capacitor installed yet, consult the [Installation](/docs/getting-started/) guide before continuing.
 
 #### Using Capacitor as a Module
 


### PR DESCRIPTION
there is a problem in the relative links that don't work depending on if the page ends in / or not, we have received a lot of PRs changing some links back and fort, but they just break the other url.

making them absolute should avoid the problem