### PR TITLE
fix: send error on photos picker dismiss on ios 13

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -200,6 +200,10 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     self.call?.error("User cancelled photos app")
   }
 
+  public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    self.call?.error("User cancelled photos app")
+  }
+
   public func imagePickerController(_ picker: UIImagePickerController,
                                     didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
     var image: UIImage?


### PR DESCRIPTION
On iOS 13 `presentationControllerDidDismiss` is called instead of `popoverPresentationControllerDidDismissPopover`

closes https://github.com/ionic-team/capacitor/issues/3008