### PR TITLE
fix(android): remove bintray publishing plugin to fix Gradle 6+ issues

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -20,14 +20,12 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath 'com.novoda:bintray-release:0.9.1'
     }
 }
 
 tasks.withType(Javadoc).all { enabled = false }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 29
@@ -72,20 +70,4 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
-}
-
-def version = System.getenv("BINTRAY_PKG_VERSION")
-
-publish {
-    userOrg = 'ionic-team'
-    repoName = 'capacitor'
-    groupId = 'ionic-team'
-    artifactId = 'capacitor-android'
-    if (version != null) {
-        publishVersion = System.getenv("BINTRAY_PKG_VERSION")
-    } else {
-        publishVersion = '0.0.0'
-    }
-    desc = 'Capacitor Android Runtime'
-    website = 'https://github.com/ionic-team/capacitor'
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,5 +26,4 @@ git push --follow-tags origin master
 #rm -rf capacitor-ios
 
 # Do the actual native deploys second, because they require tags/releases in github
-bash scripts/deploy/android.sh
 bash scripts/deploy/pods.sh

--- a/scripts/deploy/android.sh
+++ b/scripts/deploy/android.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Deploying android v$LERNA_VERSION"
-
-cd android
-
-export BINTRAY_PKG_VERSION=$LERNA_VERSION
-
-./gradlew clean build -b capacitor/build.gradle  -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true bintrayUpload -PbintrayUser=$BINTRAY_USER -PbintrayKey=$BINTRAY_KEY -PdryRun=false


### PR DESCRIPTION
`com.novoda:bintray` is not compatible with Gradle 6+ required in Android Studio 4, and it appears we are no longer using this as originally intended. Publishing logic for capacitor-android library module is not required for Capacitor apps to function. 

Resolves #3003
