### PR TITLE
test(cli): run tests with max workers, not in band

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,7 @@
     "lint": "tslint --project tsconfig.json",
     "assets": "node scripts/copy-assets.js",
     "prepublishOnly": "npm run build",
-    "test": "jest -i",
+    "test": "jest --maxWorkers=4",
     "watch": "npm run assets && tsc -w"
   },
   "files": [


### PR DESCRIPTION
This should make the CLI tests run faster.