### PR TITLE
Document injection into head element

### DIFF
--- a/site/docs-md/getting-started/index.md
+++ b/site/docs-md/getting-started/index.md
@@ -27,7 +27,7 @@ make sure you update CocoaPods using `pod repo update` before starting a new pro
 
 ## Adding Capacitor to an existing web app
 
-Capacitor was designed to drop-in to any existing modern JS web app. A valid `package.json` file and a folder containing all web assets are required to get started.
+Capacitor was designed to drop-in to any existing modern JS web app. A valid `package.json` file and a folder containing all web assets are required to get started. Capacitor assumes that it can inject itself into the `head` element in the main `index.html` file.
 
 To add Capacitor to your web app, run the following commands:
 


### PR DESCRIPTION
Document that Capacitor assumes it can inject itself into the `head` element

as discussed in:

- https://github.com/ionic-team/capacitor/issues/1572#issuecomment-495720601
- https://github.com/ionic-team/capacitor/issues/1572#issuecomment-495726425
- https://forum.ionicframework.com/t/unable-to-inject-capacitor/178713

I ran into this when migrating a small test app from Cordova to Capacitor, and it took me some research to find the solution.

I will completely understand if this proposal needs to be cleaned up, just hoping we can help someone else avoid this kind of a pitfall.