### PR TITLE
fix(ios/keyboard): update frame immediately when keyboard hides

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -116,6 +116,7 @@ NSString* UITraitsClassString;
     [self.bridge triggerWindowJSEventWithEventName:@"keyboardWillHide"];
     [self notifyListeners:@"keyboardWillHide" data:nil];
   }];
+  [[NSRunLoop currentRunLoop] addTimer:hideTimer forMode:NSRunLoopCommonModes];
 }
 
 - (void)onKeyboardWillShow:(NSNotification *)notification
@@ -171,7 +172,7 @@ NSString* UITraitsClassString;
   if (delay == 0) {
     [self _updateFrame];
   } else {
-    [weakSelf performSelector:action withObject:nil afterDelay:delay];
+    [weakSelf performSelector:action withObject:nil afterDelay:delay inModes:@[NSRunLoopCommonModes]];
   }
 }
 


### PR DESCRIPTION
Currently, when the keyboard hides, if the user is scrolling in the webview the `keyboardWillHide` event won't fire and the frame won't update until the scrolling stops. See this app that hides the keyboard when scrolling starts:

Current Behavior:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15218748/83536366-1e2b0280-a4c1-11ea-99cd-d3bac22f506c.gif)

Fixed Behavior:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/15218748/83536400-297e2e00-a4c1-11ea-9d39-204abcd23477.gif)
