### PR TITLE
feat(ios): Add ios capacitor config to use a custom wkwebview

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -72,7 +72,13 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
       webViewConfiguration.applicationNameForUserAgent = appendUserAgent
     }
 
-    webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+    let moduleName = Bundle.main.infoDictionary!["CFBundleName"] as! String
+    if let customWebView = capConfig.getString("ios.customWebView"), let webViewClass = NSClassFromString(moduleName.replacingOccurrences(of: " ", with: "_")+"."+customWebView) as? (WKWebView).Type{
+        webView = webViewClass.init(frame: .zero, configuration: webViewConfiguration)
+    } else {
+      webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+    }
+
     webView?.scrollView.bounces = false
     let availableInsets = ["automatic", "scrollableAxes", "never", "always"]
     if let contentInset = (capConfig.getValue("ios.contentInset") as? String),


### PR DESCRIPTION
I needed I way to hide the context menu when text is selected on ios which it seems to be impossible in iOS13 (css doesn't work). I created this pull request to give users the possibility to create a custom wkwebview and use it. This way I can write a class like this (always extend WKWebView): 
```swift
class CustomWKWebView: WKWebView{
    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
        return false
    }
}
```
and use it to hide the context menu. 
User could add this in capacitor.config.json to enable this feature otherwise normal WKWebView is used:
```json
{
  "ios":{
    "customWebView":"NameOfTheCustomWebView"
  }
}
```

Let me know what do you think about this solution