### PR TITLE
fix(android): LocalNotification action not dismissing notification

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -87,9 +87,9 @@ public class LocalNotificationManager {
       dataJson.put("inputValue", input.toString());
     }
     String menuAction = data.getStringExtra(LocalNotificationManager.ACTION_INTENT_KEY);
-    if (menuAction != DEFAULT_PRESS_ACTION) {
-      dismissVisibleNotification(notificationId);
-    }
+
+    dismissVisibleNotification(notificationId);
+
     dataJson.put("actionId", menuAction);
     JSONObject request = null;
     try {


### PR DESCRIPTION
I've noticed some actions are not dismissing the notification when you choose an action, all of them should, so removing the check. 