### PR TITLE
Filesystem plugin methods

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -1,12 +1,11 @@
 package com.getcapacitor.plugin;
 
 import android.Manifest;
-import android.content.Context;
 import android.content.pm.PackageManager;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
-import android.os.Environment;
 import android.util.Base64;
+
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
@@ -15,6 +14,7 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.PluginRequestCodes;
+
 import org.json.JSONException;
 
 import java.io.BufferedWriter;
@@ -67,63 +67,6 @@ public class Filesystem extends Plugin {
         return StandardCharsets.US_ASCII;
     }
     return null;
-  }
-
-  private File getDirectory(String directory) {
-    Context c = bridge.getContext();
-    switch(directory) {
-      case "DOCUMENTS":
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
-      case "DATA":
-        return c.getFilesDir();
-      case "CACHE":
-        return c.getCacheDir();
-      case "EXTERNAL":
-        return c.getExternalFilesDir(null);
-      case "EXTERNAL_STORAGE":
-        return Environment.getExternalStorageDirectory();
-    }
-    return null;
-  }
-
-  private File getFileObject(String path, String directory) {
-    if (directory == null) {
-      Uri u = Uri.parse(path);
-      if (u.getScheme() == null || u.getScheme().equals("file")) {
-        return new File(u.getPath());
-      }
-    }
-
-    File androidDirectory = this.getDirectory(directory);
-
-    if (androidDirectory == null) {
-      return null;
-    } else {
-      if(!androidDirectory.exists()) {
-        androidDirectory.mkdir();
-      }
-    }
-
-    return new File(androidDirectory, path);
-  }
-
-  private InputStream getInputStream(String path, String directory) throws IOException {
-    if (directory == null) {
-      Uri u = Uri.parse(path);
-      if (u.getScheme().equals("content")) {
-        return getContext().getContentResolver().openInputStream(u);
-      } else {
-        return new FileInputStream(new File(u.getPath()));
-      }
-    }
-
-    File androidDirectory = this.getDirectory(directory);
-
-    if (androidDirectory == null) {
-      throw new IOException("Directory not found");
-    }
-
-    return new FileInputStream(new File(androidDirectory, path));
   }
 
   private String readFileAsString(InputStream is, String encoding) throws IOException {

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -42,5 +42,7 @@
 -(id)getConfigValue:(NSString *) key;
 -(void)setCenteredPopover:(UIViewController *) vc;
 -(BOOL)supportsPopover;
+-(NSSearchPathDirectory)getDirectory:(NSString *)directory;
+-(NSURL *)getFileUrl:(NSString *)path directory:(NSString *)directoryOption;
 
 @end

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -155,5 +155,32 @@
   }
 }
 
+/**
+ * Get the SearchPathDirectory corresponding to the JS string
+ */
+-(NSSearchPathDirectory)getDirectory:(NSString *) directory {
+  NSArray *directories = @[@"DOCUMENTS", @"CACHE"];
+
+  switch ([directories indexOfObject:directory]) {
+    case 0:
+          return NSDocumentDirectory;
+    case 1:
+          return NSCachesDirectory;
+    default:
+          return NSDocumentDirectory;
+  }
+}
+
+-(NSURL *)getFileUrl:(NSString *)path directory:(NSString *)directoryOption {
+    if ([path hasPrefix:@"file://"]) {
+        return [NSURL fileURLWithPath:path];
+    }
+
+    NSSearchPathDirectory directory = [self getDirectory:directoryOption];
+    NSURL *dir = [NSFileManager.defaultManager URLsForDirectory:directory inDomains:NSUserDomainMask].firstObject;
+
+    return [dir URLByAppendingPathComponent:path];
+}
+
 @end
 

--- a/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Filesystem.swift
@@ -4,38 +4,6 @@ import Foundation
 @objc(CAPFilesystemPlugin)
 public class CAPFilesystemPlugin : CAPPlugin {
   let DEFAULT_DIRECTORY = "DOCUMENTS"
-  
-  /**
-   * Get the SearchPathDirectory corresponding to the JS string
-   */
-  func getDirectory(directory: String) -> FileManager.SearchPathDirectory {
-    switch directory {
-    case "DOCUMENTS":
-      return .documentDirectory
-    case "CACHE":
-      return .cachesDirectory
-    default:
-      return .documentDirectory
-    }
-  }
-  
-  /**
-   * Get the URL for this file, supporting file:// paths and
-   * files with directory mappings.
-   */
-  func getFileUrl(_ path: String, _ directoryOption: String) -> URL? {
-    if path.starts(with: "file://") {
-      return URL(string: path)
-    }
-    
-    let directory = getDirectory(directory: directoryOption)
-    
-    guard let dir = FileManager.default.urls(for: directory, in: .userDomainMask).first else {
-      return nil
-    }
-    
-    return dir.appendingPathComponent(path)
-  }
 
   /**
    * Helper for handling errors
@@ -56,7 +24,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
     
-    guard let fileUrl = getFileUrl(file, directoryOption) else {
+    guard let fileUrl = getFileUrl(file, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -97,7 +65,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
       
     let directoryOption = call.get("directory", String.self) ?? DEFAULT_DIRECTORY
 
-    guard let fileUrl = getFileUrl(file, directoryOption) else {
+    guard let fileUrl = getFileUrl(file, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -147,7 +115,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self) ?? DEFAULT_DIRECTORY
-    guard let fileUrl = getFileUrl(file, directoryOption) else {
+    guard let fileUrl = getFileUrl(file, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -206,7 +174,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self) ?? DEFAULT_DIRECTORY
-    guard let fileUrl = getFileUrl(file, directoryOption) else {
+    guard let fileUrl = getFileUrl(file, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -233,7 +201,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     
     let recursive = call.get("recursive", Bool.self, false)!
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    guard let fileUrl = getFileUrl(path, directoryOption) else {
+    guard let fileUrl = getFileUrl(path, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -257,7 +225,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    guard let fileUrl = getFileUrl(path, directoryOption) else {
+    guard let fileUrl = getFileUrl(path, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -293,7 +261,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    guard let fileUrl = getFileUrl(path, directoryOption) else {
+    guard let fileUrl = getFileUrl(path, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -321,7 +289,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    guard let fileUrl = getFileUrl(path, directoryOption) else {
+    guard let fileUrl = getFileUrl(path, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -347,7 +315,7 @@ public class CAPFilesystemPlugin : CAPPlugin {
     }
     
     let directoryOption = call.get("directory", String.self, DEFAULT_DIRECTORY)!
-    guard let fileUrl = getFileUrl(path, directoryOption) else {
+    guard let fileUrl = getFileUrl(path, directory:directoryOption) else {
       handleError(call, "Invalid path")
       return
     }
@@ -388,12 +356,12 @@ public class CAPFilesystemPlugin : CAPPlugin {
       toDirectoryOption = directoryOption;
     }
     
-    guard let fromUrl = getFileUrl(from, directoryOption) else {
+    guard let fromUrl = getFileUrl(from, directory:directoryOption) else {
       handleError(call, "Invalid from path")
       return
     }
     
-    guard let toUrl = getFileUrl(to, toDirectoryOption) else {
+    guard let toUrl = getFileUrl(to, directory:toDirectoryOption) else {
       handleError(call, "Invalid to path")
       return
     }


### PR DESCRIPTION
When developing a plugin that works with the filesystem (eg zip plugin), it's really handy to be able to pass the same { directory, path } syntax that the Filesystem methods use. This change pulls the helper methods that can convert a directory/path to a URL (iOS) or File (Android) so a plugin can really easily get hold of a native object representing the target file.