### PR TITLE
docs: add capacitor-stripe plugin

### DIFF
--- a/site/docs-md/community/plugins.md
+++ b/site/docs-md/community/plugins.md
@@ -88,6 +88,7 @@ Are we missing your awesome plugin? [Add it to this page](https://github.com/ion
 | ----------------------- | ----------- | ------ | ------ |
 | NFC | `capacitor-nfc` | <https://github.com/adrynov/Capacitor-NFC-Plugin> | Android only |
 | Heartland Form | `capacitor-heartland-form` | <https://github.com/philmerrell/capacitor-heartland-form> | |
+| Stripe | `capacitor-stripe` | <https://github.com/zyra/capacitor-stripe> | Beta version |
 | Stripe Terminal | `capacitor-stripe-terminal` | <https://github.com/eventOneHQ/capacitor-stripe-terminal> | iOS only |
 
 


### PR DESCRIPTION
This PR adds [capacitor-stripe plugin](https://github.com/zyra/capacitor-stripe)