### PR TITLE
fix: revert static Config class

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -90,7 +90,7 @@ public class Bridge {
   public static final String CAPACITOR_CONTENT_START = "/_capacitor_content_";
 
   // Loaded Capacitor config
-  private Config config;
+  private CapConfig config;
 
   // A reference to the main activity for the app
   private final Activity context;
@@ -148,7 +148,8 @@ public class Bridge {
     handlerThread.start();
     taskHandler = new Handler(handlerThread.getLooper());
 
-    this.config = new Config(getActivity().getAssets(), config);
+    Config.load(getActivity());
+    this.config = new CapConfig(getActivity().getAssets(), config);
     Logger.init(this.config);
 
     // Initialize web view and message handler for it
@@ -335,7 +336,7 @@ public class Bridge {
       return this.config.getString("server.androidScheme", CAPACITOR_HTTP_SCHEME);
   }
 
-  public Config getConfig() {
+  public CapConfig getConfig() {
     return this.config;
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -1,42 +1,35 @@
 package com.getcapacitor;
 
-import android.app.Activity;
+import android.content.res.AssetManager;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.JSONArray;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
 /**
- * @deprecated use getBridge().getConfig() instead of the static Config
+ * Management interface for accessing values in capacitor.config.json
  */
-public class Config {
+public class CapConfig {
 
   private JSONObject config = new JSONObject();
 
-  private static Config instance;
-
-  private static Config getInstance() {
-    if (instance == null) {
-      instance = new Config();
+  public CapConfig(AssetManager assetManager, JSONObject config) {
+    if (config != null) {
+      this.config = config;
+    } else {
+      // Load our capacitor.config.json
+      this.loadConfig(assetManager);
     }
-    return instance;
   }
 
-  /**
-   * @deprecated
-   */
-  public static void load(Activity activity) {
-    Config.getInstance().loadConfig(activity);
-  }
-
-  private void loadConfig(Activity activity) {
+  private void loadConfig(AssetManager assetManager) {
     BufferedReader reader = null;
     try {
-      reader = new BufferedReader(new InputStreamReader(activity.getAssets().open("capacitor.config.json")));
+      reader = new BufferedReader(new InputStreamReader(assetManager.open("capacitor.config.json")));
 
       // do reading, usually loop until end of file reading
       StringBuilder b = new StringBuilder();
@@ -62,12 +55,9 @@ public class Config {
     }
   }
 
-  /**
-   * @deprecated
-   */
-  public static JSONObject getObject(String key) {
+  public JSONObject getObject(String key) {
     try {
-      return getInstance().config.getJSONObject(key);
+      return this.config.getJSONObject(key);
     } catch (Exception ex) {
     }
     return null;
@@ -86,20 +76,14 @@ public class Config {
     return o;
   }
 
-  /**
-   * @deprecated
-   */
-  public static String getString(String key) {
+  public String getString(String key) {
     return getString(key, null);
   }
 
-  /**
-   * @deprecated
-   */
-  public static String getString(String key, String defaultValue) {
+  public String getString(String key, String defaultValue) {
     String k = getConfigKey(key);
     try {
-      JSONObject o = getInstance().getConfigObjectDeepest(key);
+      JSONObject o = this.getConfigObjectDeepest(key);
 
       String value = o.getString(k);
       if (value == null) {
@@ -110,26 +94,20 @@ public class Config {
     return defaultValue;
   }
 
-  /**
-   * @deprecated
-   */
-  public static boolean getBoolean(String key, boolean defaultValue) {
+  public boolean getBoolean(String key, boolean defaultValue) {
     String k = getConfigKey(key);
     try {
-      JSONObject o = getInstance().getConfigObjectDeepest(key);
+      JSONObject o = this.getConfigObjectDeepest(key);
 
       return o.getBoolean(k);
     } catch (Exception ex) {}
     return defaultValue;
   }
 
-  /**
-   * @deprecated
-   */
-  public static int getInt(String key, int defaultValue) {
+  public int getInt(String key, int defaultValue) {
     String k = getConfigKey(key);
     try {
-      JSONObject o = getInstance().getConfigObjectDeepest(key);
+      JSONObject o = this.getConfigObjectDeepest(key);
       return o.getInt(k);
     } catch (Exception ignore) {
       // value was not found
@@ -137,10 +115,7 @@ public class Config {
     return defaultValue;
   }
 
-  /**
-   * @deprecated
-   */
-  private static String getConfigKey(String key) {
+  private String getConfigKey(String key) {
     String[] parts = key.split("\\.");
     if (parts.length > 0) {
       return parts[parts.length - 1];
@@ -148,20 +123,14 @@ public class Config {
     return null;
   }
 
-  /**
-   * @deprecated
-   */
-  public static String[] getArray(String key) {
+  public String[] getArray(String key) {
     return getArray(key, null);
   }
 
-  /**
-   * @deprecated
-   */
-  public static String[] getArray(String key, String[] defaultValue) {
+  public String[] getArray(String key, String[] defaultValue) {
     String k = getConfigKey(key);
     try {
-      JSONObject o = getInstance().getConfigObjectDeepest(key);
+      JSONObject o = this.getConfigObjectDeepest(key);
 
       JSONArray a = o.getJSONArray(k);
       if (a == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -17,7 +17,7 @@ public class CapacitorWebView extends WebView {
 
   @Override
   public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-    Config config = new Config(getContext().getAssets(), null);
+    CapConfig config = new CapConfig(getContext().getAssets(), null);
     boolean captureInput = config.getBoolean("android.captureInput", false);
     if (captureInput) {
       if (capInputConnection == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Logger.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Logger.java
@@ -5,7 +5,7 @@ import android.util.Log;
 
 public class Logger {
   public static final String LOG_TAG_CORE = "Capacitor";
-  public static Config config;
+  public static CapConfig config;
 
   private static Logger instance;
 
@@ -16,11 +16,11 @@ public class Logger {
     return instance;
   }
 
-  public static void init(Config config) {
+  public static void init(CapConfig config) {
     Logger.getInstance().loadConfig(config);
   }
 
-  private void loadConfig(Config config) {
+  private void loadConfig(CapConfig config) {
       this.config = config;
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -42,7 +42,7 @@ public class Splash {
   private static boolean isVisible = false;
   private static boolean isHiding = false;
 
-  private static void buildViews(Context c, Config config) {
+  private static void buildViews(Context c, CapConfig config) {
     if (splashImage == null) {
       String splashResourceName = config.getString(CONFIG_KEY_PREFIX + "androidSplashResourceName", "splash");
 
@@ -165,7 +165,7 @@ public class Splash {
    * Show the splash screen on launch without fading in
    * @param a
    */
-  public static void showOnLaunch(final BridgeActivity a, Config config) {
+  public static void showOnLaunch(final BridgeActivity a, CapConfig config) {
     Integer duration = config.getInt(CONFIG_KEY_PREFIX + "launchShowDuration", DEFAULT_LAUNCH_SHOW_DURATION);
     Boolean autohide = config.getBoolean(CONFIG_KEY_PREFIX + "launchAutoHide", DEFAULT_AUTO_HIDE);
 
@@ -193,7 +193,7 @@ public class Splash {
                           final int fadeOutDuration,
                           final boolean autoHide,
                           final SplashListener splashListener,
-                          final Config config) {
+                          final CapConfig config) {
     show(a, showDuration, fadeInDuration, fadeOutDuration, autoHide, splashListener, false, config);
   }
 
@@ -214,7 +214,7 @@ public class Splash {
                           final boolean autoHide,
                           final SplashListener splashListener,
                           final boolean isLaunchSplash,
-                          final Config config) {
+                          final CapConfig config) {
     wm = (WindowManager)a.getSystemService(Context.WINDOW_SERVICE);
 
     if (a.isFinishing()) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -20,6 +20,7 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.RemoteInput;
 
+import com.getcapacitor.CapConfig;
 import com.getcapacitor.Config;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
@@ -56,9 +57,9 @@ public class LocalNotificationManager {
   private Context context;
   private Activity activity;
   private NotificationStorage storage;
-  private Config config;
+  private CapConfig config;
 
-  public LocalNotificationManager(NotificationStorage notificationStorage, Activity activity, Context context, Config config) {
+  public LocalNotificationManager(NotificationStorage notificationStorage, Activity activity, Context context, CapConfig config) {
     storage = notificationStorage;
     this.activity = activity;
     this.context = context;


### PR DESCRIPTION
When[ I made](https://github.com/ionic-team/capacitor/pull/3055) Config class non static, it broke plugins using it

This PR reverts the changes in Config class, deprecates it and introduces CapConfig class that is the current non static Config

