### PR TITLE
Clarify "missing web assets directory" error message

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -29,9 +29,12 @@ export async function checkWebDir(config: Config): Promise<string | null> {
   }
   if (!await existsAsync(config.app.webDirAbs)) {
     return `Capacitor could not find the web assets directory "${config.app.webDirAbs}".
-    Please create it, and make sure it has an index.html file. You can change
-    the path of this directory in capacitor.config.json.
-    More info: https://capacitor.ionicframework.com/docs/basics/configuring-your-app`;
+    Please create it and make sure it has an index.html file. You can change
+    the path of this directory in capacitor.config.json (webDir option).
+
+    If building an Ionic app, run 'ionic build'. Otherwise, your framework's build process 
+    of choice, typically 'npm run build'.
+    More info: https://capacitor.ionicframework.com/docs/basics/building-your-app`;
   }
 
   if (!await existsAsync(join(config.app.webDirAbs, 'index.html'))) {

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -30,8 +30,9 @@ export async function checkWebDir(config: Config): Promise<string | null> {
   if (!await existsAsync(config.app.webDirAbs)) {
     return `Capacitor could not find the web assets directory "${config.app.webDirAbs}".
     Please create it and make sure it has an index.html file. You can change
-    the path of this directory in capacitor.config.json (webDir option). You may need 
-    to compile the web assets for your app (typically 'npm run build').
+    the path of this directory in capacitor.config.json (webDir option).
+    
+    You may need to compile the web assets for your app (typically 'npm run build').
     More info: https://capacitor.ionicframework.com/docs/basics/building-your-app`;
   }
 

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -31,7 +31,6 @@ export async function checkWebDir(config: Config): Promise<string | null> {
     return `Capacitor could not find the web assets directory "${config.app.webDirAbs}".
     Please create it and make sure it has an index.html file. You can change
     the path of this directory in capacitor.config.json (webDir option).
-    
     You may need to compile the web assets for your app (typically 'npm run build').
     More info: https://capacitor.ionicframework.com/docs/basics/building-your-app`;
   }

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -30,10 +30,8 @@ export async function checkWebDir(config: Config): Promise<string | null> {
   if (!await existsAsync(config.app.webDirAbs)) {
     return `Capacitor could not find the web assets directory "${config.app.webDirAbs}".
     Please create it and make sure it has an index.html file. You can change
-    the path of this directory in capacitor.config.json (webDir option).
-
-    If building an Ionic app, run 'ionic build'. Otherwise, your framework's build process 
-    of choice, typically 'npm run build'.
+    the path of this directory in capacitor.config.json (webDir option). You may need 
+    to compile the web assets for your app (typically 'npm run build').
     More info: https://capacitor.ionicframework.com/docs/basics/building-your-app`;
   }
 


### PR DESCRIPTION
Update the error message displayed when a user tries to add a native platform to their project, before having built their web code.

Changes:
- Fix the More Info link to point to the correct page (/basics/building-your-app instead of /basics/configuring-your-app).
- Help the user by telling them _which_ property to change in capacitor config (webDir).
- Added build details for both Ionic apps and non-Ionic apps.

Wasn't sure how to format correctly for newlines - this function doesn't use log("") like the others.