### PR TITLE
fix(SplashScreen): show method not resolving if autoHide is false

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -243,6 +243,11 @@ public class Splash {
               }
             }
           }, showDuration);
+        } else {
+          // If no autoHide, call complete
+          if (splashListener != null) {
+            splashListener.completed();
+          }
         }
       }
 

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -183,6 +183,8 @@ public class CAPSplashScreenPlugin: CAPPlugin {
             self.hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: isLaunchSplash)
             completion()
           }
+        } else {
+            completion()
         }
       }
     }


### PR DESCRIPTION
When using the plugin in TS, the call `Splash.show({autoHide:false})` was never resolving the returned promise because the native call to complete the call was never invoked. It was only called with autoHide = true.

fixes: #3143 