### PR TITLE
feat(IOS/Android/Web): Camera Permission Request

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginRequestCodes.java
@@ -24,4 +24,5 @@ public class PluginRequestCodes {
   public static final int FILESYSTEM_REQUEST_RENAME_PERMISSIONS = 9020;
   public static final int FILESYSTEM_REQUEST_COPY_PERMISSIONS = 9021;
   public static final int FILESYSTEM_REQUEST_ALL_PERMISSIONS = 9022;
+  public static final int CAMERA_REQUEST_PERMISSIONS = 9023;
 }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginListenerHandle } from './definitions';
+import { PermissionRequestResult, PermissionsRequestResult, Plugin, PluginListenerHandle } from './definitions';
 
 export interface PluginRegistry {
   Accessibility: AccessibilityPlugin;
@@ -284,14 +284,16 @@ export interface BrowserPrefetchOptions {
   urls: string[];
 }
 
-//
-
 export interface CameraPlugin extends Plugin {
   /**
    * Prompt the user to pick a photo from an album, or take a new photo
    * with the camera.
    */
   getPhoto(options: CameraOptions): Promise<CameraPhoto>;
+  /*
+   * Return if the permission was granted or not.
+  */
+  requestPermission(): Promise<PermissionRequestResult>;
 }
 
 export interface CameraOptions {
@@ -1161,10 +1163,6 @@ export interface LocalNotificationEnabledResult {
   value: boolean;
 }
 
-export interface NotificationPermissionResponse {
-  granted: boolean;
-}
-
 export interface LocalNotificationsPlugin extends Plugin {
   schedule(options: { notifications: LocalNotification[] }): Promise<LocalNotificationScheduleResult>;
   getPending(): Promise<LocalNotificationPendingList>;
@@ -1174,7 +1172,7 @@ export interface LocalNotificationsPlugin extends Plugin {
   createChannel(channel: NotificationChannel): Promise<void>;
   deleteChannel(channel: NotificationChannel): Promise<void>;
   listChannels(): Promise<NotificationChannelList>;
-  requestPermission(): Promise<NotificationPermissionResponse>;
+  requestPermission(): Promise<PermissionRequestResult>;
   addListener(eventName: 'localNotificationReceived', listenerFunc: (notification: LocalNotification) => void): PluginListenerHandle;
   addListener(eventName: 'localNotificationActionPerformed', listenerFunc: (notificationAction: LocalNotificationActionPerformed) => void): PluginListenerHandle;
 
@@ -1362,6 +1360,7 @@ export interface PermissionResult {
 
 export interface PermissionsPlugin extends Plugin {
   query(options: PermissionsOptions): Promise<PermissionResult>;
+  requestPermissions?: () => Promise<PermissionsRequestResult>;
 }
 
 //
@@ -1612,7 +1611,7 @@ export interface PushNotificationsPlugin extends Plugin {
    * and return if the permission was granted or not.
    * On Android there is no such prompt, so just return as granted.
    */
-  requestPermission(): Promise<NotificationPermissionResponse>;
+  requestPermission(): Promise<PermissionRequestResult>;
   /**
    * Returns the notifications that are visible on the notifications screen.
    */

--- a/core/src/definitions.ts
+++ b/core/src/definitions.ts
@@ -1,12 +1,13 @@
 import { PluginRegistry } from './core-plugin-definitions';
 
-export interface Plugin {
-  addListener(eventName: string, listenerFunc: Function): PluginListenerHandle;
-  requestPermissions?: () => Promise<PermissionsRequestResult>;
-}
+export interface Plugin {}
 
 export interface PermissionsRequestResult {
   results: any[];
+}
+
+export interface PermissionRequestResult {
+  granted: boolean;
 }
 
 export interface PluginListenerHandle {

--- a/core/src/web/camera.ts
+++ b/core/src/web/camera.ts
@@ -1,11 +1,12 @@
-import { WebPlugin } from './index';
-
 import {
-  CameraPlugin,
-  CameraPhoto,
-  CameraOptions,
+  CameraOptions, CameraPhoto, CameraPlugin,
+
+
   CameraResultType
 } from '../core-plugin-definitions';
+import { PermissionRequestResult } from '../definitions';
+import { WebPlugin } from './index';
+
 
 export class CameraPluginWeb extends WebPlugin implements CameraPlugin {
   constructor() {
@@ -70,6 +71,13 @@ export class CameraPluginWeb extends WebPlugin implements CameraPlugin {
           reject(e);
         };
       }
+    });
+  }
+
+  requestPermission(): Promise<PermissionRequestResult> {
+    return new Promise((resolve) => {
+      // TODO
+        resolve({ granted: true });
     });
   }
 }

--- a/core/src/web/local-notifications.ts
+++ b/core/src/web/local-notifications.ts
@@ -1,18 +1,21 @@
-import { WebPlugin } from './index';
-
 import {
-  LocalNotificationsPlugin,
-  LocalNotificationEnabledResult,
+  LocalNotification, LocalNotificationActionType, LocalNotificationEnabledResult,
   LocalNotificationPendingList,
-  LocalNotificationActionType,
-  LocalNotification,
-  LocalNotificationScheduleResult,
-  NotificationPermissionResponse,
+
+
+  LocalNotificationScheduleResult, LocalNotificationsPlugin,
+
+
+
+
+
   NotificationChannel,
   NotificationChannelList
 } from '../core-plugin-definitions';
+import { PermissionRequestResult, PermissionsRequestResult } from '../definitions';
+import { WebPlugin } from './index';
 
-import { PermissionsRequestResult } from '../definitions';
+
 
 export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotificationsPlugin {
   private pending: LocalNotification[] = [];
@@ -112,7 +115,7 @@ export class LocalNotificationsPluginWeb extends WebPlugin implements LocalNotif
     });
   }
 
-  requestPermission(): Promise<NotificationPermissionResponse> {
+  requestPermission(): Promise<PermissionRequestResult> {
     return new Promise((resolve) => {
       Notification.requestPermission((result) => {
         let granted = true;

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -385,4 +385,9 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     return nil
   }
 
+  @objc func requestPermission(_ call: CAPPluginCall) {
+    AVCaptureDevice.requestAccess(for: .video) { granted in
+        call.success(["granted": granted])
+    }
+  }
 }

--- a/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
+++ b/ios/Capacitor/Capacitor/Plugins/DefaultPlugins.m
@@ -31,6 +31,7 @@ CAP_PLUGIN(CAPBrowserPlugin, "Browser",
 
 CAP_PLUGIN(CAPCameraPlugin, "Camera",
   CAP_PLUGIN_METHOD(getPhoto, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(requestPermission, CAPPluginReturnPromise);
 )
 
 CAP_PLUGIN(CAPClipboardPlugin, "Clipboard",


### PR DESCRIPTION
Add Camera permissionRequest :

* [x] IOS
* [x] Android
* [ ] Web

I suggest removing requestPermissions from all plugins and adding this if the plugin needs permission.

```typescript
const { Camera } = Plugins;

await Camera.requestPermission();
```

There is a confusion between requestPermission and requestPermissions, I suggest renaming requestPermission for any request for permission from a plugin.

I need help with requestPermission on the web.
