### PR TITLE
chore(android): Make androidx.exifinterface version configurable

### DIFF
--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -7,6 +7,7 @@ ext {
     androidxMaterialVersion =  '1.1.0-rc02'
     androidxBrowserVersion =  '1.2.0'
     androidxLocalbroadcastmanagerVersion =  '1.0.0'
+    androidxExifInterfaceVersion = '1.2.0'
     firebaseMessagingVersion =  '20.1.2'
     playServicesLocationVersion =  '17.0.0'
     junitVersion =  '4.12'

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -4,6 +4,7 @@ ext {
     androidxMaterialVersion =  project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.1.0-rc02'
     androidxBrowserVersion =  project.hasProperty('androidxBrowserVersion') ? rootProject.ext.androidxBrowserVersion : '1.2.0'
     androidxLocalbroadcastmanagerVersion =  project.hasProperty('androidxLocalbroadcastmanagerVersion') ? rootProject.ext.androidxLocalbroadcastmanagerVersion : '1.0.0'
+    androidxExifInterfaceVersion =  project.hasProperty('androidxExifInterfaceVersion') ? rootProject.ext.androidxExifInterfaceVersion : '1.2.0'
     firebaseMessagingVersion =  project.hasProperty('firebaseMessagingVersion') ? rootProject.ext.firebaseMessagingVersion : '20.1.2'
     playServicesLocationVersion =  project.hasProperty('playServicesLocationVersion') ? rootProject.ext.playServicesLocationVersion : '17.0.0'
     junitVersion =  project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.12'
@@ -64,13 +65,13 @@ dependencies {
     implementation "com.google.android.material:material:$androidxMaterialVersion"
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:$androidxLocalbroadcastmanagerVersion"
+    implementation "androidx.exifinterface:exifinterface:$androidxExifInterfaceVersion"
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation "com.google.android.gms:play-services-location:$playServicesLocationVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
     testImplementation 'org.json:json:20140107'
     testImplementation 'org.mockito:mockito-inline:2.25.1'
 }


### PR DESCRIPTION
add `androidxExifInterfaceVersion` variable into the `variables.gradle` file with value set to 1.2.0
use the variable in capacitor's build.gradle file but also default to 1.2.0 if not set
