### PR TITLE
Extend device plugin

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Device.java
@@ -3,6 +3,7 @@ package com.getcapacitor.plugin;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
+import android.content.pm.ApplicationInfo;
 import android.os.BatteryManager;
 import android.os.Environment;
 import android.os.StatFs;
@@ -32,6 +33,8 @@ public class Device extends Plugin {
     r.put("osVersion", android.os.Build.VERSION.RELEASE);
     r.put("appVersion", getAppVersion());
     r.put("appBuild", getAppBuild());
+    r.put("appId", getAppBundleId());
+    r.put("appName", getAppName());
     r.put("platform", getPlatform());
     r.put("manufacturer", android.os.Build.MANUFACTURER);
     r.put("uuid", getUuid());
@@ -86,6 +89,25 @@ public class Device extends Plugin {
     try {
       PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
       return Integer.toString(pinfo.versionCode);
+    } catch(Exception ex) {
+      return "";
+    }
+  }
+
+  private String getAppBundleId() {
+    try {
+      PackageInfo pinfo = getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0);
+      return pinfo.packageName;
+    } catch(Exception ex) {
+      return "";
+    }
+  }
+
+  private String getAppName() {
+    try {
+      ApplicationInfo applicationInfo = getContext().getApplicationInfo();
+      int stringId = applicationInfo.labelRes;
+      return stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getContext().getString(stringId);
     } catch(Exception ex) {
       return "";
     }

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -488,6 +488,14 @@ export interface DeviceInfo {
    */
   appBuild: string;
   /**
+   * The bundle id of the app
+   */
+  appId: string;
+  /**
+   * The display name of the app
+   */
+  appName: string;
+  /**
    * The operating system of the device
    */
   operatingSystem: OperatingSystem;

--- a/core/src/web/device.ts
+++ b/core/src/web/device.ts
@@ -28,6 +28,8 @@ export class DevicePluginWeb extends WebPlugin implements DevicePlugin {
       platform: <'web'> 'web',
       appVersion: '',
       appBuild: '',
+      appId: '',
+      appName: '',
       operatingSystem: uaFields.operatingSystem,
       osVersion: uaFields.osVersion,
       manufacturer: navigator.vendor,

--- a/electron/src/electron/device.ts
+++ b/electron/src/electron/device.ts
@@ -20,6 +20,8 @@ export class DevicePluginElectron extends WebPlugin implements DevicePlugin {
       platform: <'electron'> 'electron',
       appVersion: app.getVersion(),
       appBuild: '',
+      appId: '',
+      appName: '',
       operatingSystem: info.operatingSystem,
       osVersion: info.osVersion,
       manufacturer: navigator.vendor,

--- a/ios/Capacitor/Capacitor/Plugins/Device.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Device.swift
@@ -26,6 +26,8 @@ public class CAPDevicePlugin: CAPPlugin {
       "osVersion": UIDevice.current.systemVersion,
       "appVersion": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
       "appBuild": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "",
+      "appId": Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? "",
+      "appName": Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "",
       "platform": "ios",
       "manufacturer": "Apple",
       "uuid": UIDevice.current.identifierForVendor!.uuidString,


### PR DESCRIPTION
This PR adds `appName` (the app's display name) and `appId` (the app's bundle id) to `Device.getInfo()`.

I thought this can come in handy when gathering debug information. After moving one of my apps over from Cordova, `cordova-plugin-app-version` is the only remaining plugin I can not remove just yet as I need to display the app's name and bundle id.