### PR TITLE
fix(cli): Avoid duplicate usesCleartextTraffic attribute

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -413,12 +413,13 @@ export async function writeCordovaAndroidManifest(cordovaPlugins: Plugin[], conf
       }
     });
   });
-  let cleartext = config.app.extConfig.server?.cleartext ? 'android:usesCleartextTraffic="true"' : '';
+  let cleartextString = 'android:usesCleartextTraffic="true"';
+  let cleartext = config.app.extConfig.server?.cleartext && !applicationXMLAttributes.includes(cleartextString) ? cleartextString : '';
   let content = `<?xml version='1.0' encoding='utf-8'?>
 <manifest package="capacitor.android.plugins"
 xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:amazon="http://schemas.amazon.com/apk/res/android">
-<application ${applicationXMLAttributes.join('\n')}${cleartext}>
+<application ${applicationXMLAttributes.join('\n')} ${cleartext}>
 ${applicationXMLEntries.join('\n')}
 </application>
 ${rootXMLEntries.join('\n')}


### PR DESCRIPTION
If using `cordova-plugin-cleartext`, the `usesCleartextTraffic` gets added twice, and doesn't have a whitespace between them, so fails to build.

This PR adds the whitespace and also prevent the second usesCleartextTraffic attribute being added if some plugin already added it.