### PR TITLE
fix: requestPermission reflects user settings

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/LocalNotifications.java
@@ -2,6 +2,8 @@ package com.getcapacitor.plugin;
 
 import android.content.Intent;
 
+import androidx.core.app.NotificationManagerCompat;
+
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.NativePlugin;
@@ -91,9 +93,9 @@ public class LocalNotifications extends Plugin {
 
   @PluginMethod()
   public void requestPermission(PluginCall call) {
-    JSObject result = new JSObject();
-    result.put("granted", true);
-    call.success(result);
+    JSObject data = new JSObject();
+    data.put("granted", manager.areNotificationsEnabled());
+    call.success(data);
   }
 
   @PluginMethod()


### PR DESCRIPTION
fixes #3252 

I understand if this is working as intended, if so feel free to disregard. I felt it could be nice to unify the api so that one could call `requestPermission` as a way to check for notifications being permitted/enabled on both iOS and Android.