### PR TITLE
fix(android): Splash.show not resolving if splash is visible

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Splash.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Splash.java
@@ -237,6 +237,7 @@ public class Splash {
     buildViews(a, config);
 
     if (isVisible) {
+      splashListener.completed();
       return;
     }
 


### PR DESCRIPTION
Fixes #3261 .

The issue was a check done: if the splash is visible, it was returning without completing the call.