### PR TITLE
chore(cli): add deprecation notice for all electron commands

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -516,3 +516,8 @@ export async function checkNPMVersion() {
   }
   return null;
 }
+
+export function electronWarning() {
+  logWarn(`The electron platform is deprecated!`);
+  log(`\nPlease use the Capacitor Community Electron Platform: https://github.com/capacitor-community/electron\n`);
+}

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -5,7 +5,7 @@ import { addElectron } from '../electron/add';
 import { addIOS, addIOSChecks } from '../ios/add';
 import { editProjectSettingsAndroid } from '../android/common';
 import { editProjectSettingsIOS } from '../ios/common';
-import { check, checkAppConfig, checkPackage, checkWebDir, hasYarn, log, logError, logFatal, logInfo, logWarn, resolvePlatform, runCommand, runPlatformHook, runTask, writePrettyJSON } from '../common';
+import { check, checkAppConfig, checkPackage, checkWebDir, electronWarning, hasYarn, log, logError, logFatal, logInfo, resolvePlatform, runPlatformHook, runTask, writePrettyJSON } from '../common';
 import { sync } from './sync';
 
 import chalk from 'chalk';
@@ -133,9 +133,4 @@ function webWarning() {
   log(`\nIn Capacitor, the 'web' platform is just your web app!`);
   log(`For example, if you have a React or Angular project, the 'web' platform is that project.`);
   log(`To add Capacitor functionality to your web app, follow the Web Getting Started Guide: https://capacitorjs.com/docs/web`);
-}
-
-function electronWarning() {
-  logWarn(`The electron platform is deprecated!`);
-  log(`\nPlease use the Capacitor Community Electron Platform: https://github.com/capacitor-community/electron\n`);
 }

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { checkWebDir, hasYarn, log, logError, logFatal, logInfo, resolveNode, resolvePlatform, runCommand, runPlatformHook, runTask } from '../common';
+import { checkWebDir, electronWarning, hasYarn, log, logError, logFatal, logInfo, resolveNode, resolvePlatform, runPlatformHook, runTask } from '../common';
 import { existsAsync } from '../util/fs';
 import { allSerial } from '../util/promise';
 import { copyWeb } from '../web/copy';
@@ -58,6 +58,7 @@ export async function copy(config: Config, platformName: string) {
     } else if (platformName === config.electron.name) {
       await copyElectron(config);
       await copyCapacitorConfig(config, config.electron.platformDir);
+      electronWarning();
     } else {
       throw `Platform ${platformName} is not valid.`;
     }

--- a/cli/src/tasks/doctor.ts
+++ b/cli/src/tasks/doctor.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { log, readJSON, resolveNode, resolveNodeFrom, runCommand } from '../common';
+import { electronWarning, log, readJSON, resolveNode, resolveNodeFrom, runCommand } from '../common';
 import { doctorAndroid } from '../android/doctor';
 import { doctorElectron } from '../electron/doctor';
 import { doctorIOS } from '../ios/doctor';
@@ -67,6 +67,7 @@ export async function doctor(config: Config, platformName: string) {
     await doctorAndroid(config);
   } else if (platformName === config.electron.name) {
     await doctorElectron(config);
+    electronWarning();
   } else if (platformName === config.web.name) {
     return Promise.resolve();
   } else {

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -1,5 +1,5 @@
 import { Config } from '../config';
-import { hasYarn, log, logError, logFatal, logInfo, resolvePlatform, runPlatformHook, runTask } from '../common';
+import { electronWarning, hasYarn, log, logError, logFatal, logInfo, resolvePlatform, runPlatformHook, runTask } from '../common';
 import { openAndroid } from '../android/open';
 import { openElectron } from '../electron/open';
 import { openIOS } from '../ios/open';
@@ -44,6 +44,7 @@ export async function open(config: Config, platformName: string) {
   } else if (platformName === config.web.name) {
     return Promise.resolve();
   } else if (platformName === config.electron.name) {
+    electronWarning();
     return openElectron(config);
   } else {
     throw `Platform ${platformName} is not valid.`;

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -2,7 +2,7 @@ import { Config } from '../config';
 import { updateAndroid } from '../android/update';
 import { updateIOS, updateIOSChecks } from '../ios/update';
 import { allSerial } from '../util/promise';
-import { CheckFunction, check, checkPackage, hasYarn, log, logError, logFatal, logInfo, resolvePlatform, runCommand, runPlatformHook, runTask } from '../common';
+import { CheckFunction, check, checkPackage, electronWarning, hasYarn, log, logError, logFatal, logInfo, resolvePlatform, runCommand, runPlatformHook, runTask } from '../common';
 
 import chalk from 'chalk';
 
@@ -48,6 +48,7 @@ export function updateChecks(config: Config, platforms: string[]): CheckFunction
     } else if (platformName === config.web.name) {
       return [];
     } else if (platformName === config.electron.name) {
+      electronWarning();
       return [];
     } else {
       throw `Platform ${platformName} is not valid.`;


### PR DESCRIPTION
https://github.com/ionic-team/capacitor/pull/3263 is only warning in add, so will only on new projects or users adding electron for the first time, but existing electron users won't notice and they need to move too because all commands are being removed in v3.

So this PR adds the deprecation notice in all electron commands