### PR TITLE
iOS memory cleanup

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -58,8 +58,9 @@ enum BridgeError: Error {
     self.scheme = scheme
 
     super.init()
-
-    self.notificationsDelegate.bridge = self;
+    
+    self.messageHandlerWrapper.bridge = self
+    self.notificationsDelegate.bridge = self
     localUrl = "\(self.scheme)://\(config.getString("server.hostname") ?? "localhost")"
     exportCoreJS(localUrl: localUrl!)
     registerPlugins()

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -65,8 +65,8 @@ enum BridgeError: Error {
     registerPlugins()
     setupCordovaCompatibility()
     bindObservers()
-    NotificationCenter.default.addObserver(forName: CAPBridge.tmpVCAppeared.name, object: .none, queue: .none) { _ in
-      self.tmpWindow = nil
+    NotificationCenter.default.addObserver(forName: CAPBridge.tmpVCAppeared.name, object: .none, queue: .none) { [weak self] _ in
+      self?.tmpWindow = nil
     }
   }
   
@@ -187,15 +187,19 @@ enum BridgeError: Error {
   func bindObservers() {
     let appStatePlugin = getOrLoadPlugin(pluginName: "App") as? CAPAppPlugin
     
-    NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { (notification) in
+    NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { [weak self, weak appStatePlugin] (notification) in
       CAPLog.print("APP ACTIVE")
-      self.isActive = true
-      appStatePlugin?.fireChange(isActive: self.isActive)
+      self?.isActive = true
+      if let strongSelf = self {
+        appStatePlugin?.fireChange(isActive: strongSelf.isActive)
+      }
     }
-    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { (notification) in
+    NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { [weak self, weak appStatePlugin] (notification) in
       CAPLog.print("APP INACTIVE")
-      self.isActive = false
-      appStatePlugin?.fireChange(isActive: self.isActive)
+      self?.isActive = false
+      if let strongSelf = self {
+        appStatePlugin?.fireChange(isActive: strongSelf.isActive)
+      }
     }
   }
   

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -432,24 +432,24 @@ enum BridgeError: Error {
     }
     
     // Create a plugin call object and handle the success/error callbacks
-    dispatchQueue.async {
+    dispatchQueue.async { [weak self] in
       //let startTime = CFAbsoluteTimeGetCurrent()
       
       let pluginCall = CAPPluginCall(callbackId: call.callbackId, options: call.options, success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
         if result != nil {
-          self.toJs(result: JSResult(call: call, result: result!.data ?? [:]), save: pluginCall?.isSaved ?? false)
+          self?.toJs(result: JSResult(call: call, result: result!.data ?? [:]), save: pluginCall?.isSaved ?? false)
         } else {
-          self.toJs(result: JSResult(call: call, result: [:]), save: pluginCall?.isSaved ?? false)
+          self?.toJs(result: JSResult(call: call, result: [:]), save: pluginCall?.isSaved ?? false)
         }
       }, error: {(error: CAPPluginCallError?) -> Void in
         let description = error?.error?.localizedDescription ?? ""
-        self.toJsError(error: JSResultError(call: call, message: error!.message, errorMessage: description, error: error!.data, code: error!.code))
+        self?.toJsError(error: JSResultError(call: call, message: error!.message, errorMessage: description, error: error!.data, code: error!.code))
       })!
       
       plugin.perform(selector, with: pluginCall)
       
       if pluginCall.isSaved {
-        self.savePluginCall(pluginCall)
+        self?.savePluginCall(pluginCall)
       }
       
       //let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -317,7 +317,7 @@ enum BridgeError: Error {
     
     let bridgeType = pluginType as! CAPBridgedPlugin.Type
     let p = pluginType.init(bridge: self, pluginId: bridgeType.pluginId(), pluginName: bridgeType.jsName())
-    p!.load()
+    p.load()
     self.plugins[bridgeType.jsName()] = p
     return p
   }
@@ -424,7 +424,7 @@ enum BridgeError: Error {
     }
     
     if !plugin.responds(to: selector) {
-      CAPLog.print("⚡️  Error: Plugin \(plugin.getId()!) does not respond to method call \"\(call.method)\" using selector \"\(selector!)\".")
+      CAPLog.print("⚡️  Error: Plugin \(plugin.getId()) does not respond to method call \"\(call.method)\" using selector \"\(selector!)\".")
       CAPLog.print("⚡️  Ensure plugin method exists, uses @objc in its declaration, and arguments match selector without callbacks in CAP_PLUGIN_METHOD.")
       CAPLog.print("⚡️  Learn more: \(docLink(DocLinks.CAPPluginMethodSelector.rawValue))")
       return
@@ -533,8 +533,8 @@ enum BridgeError: Error {
    */
   @objc public func evalWithPlugin(_ plugin: CAPPlugin, js: String) {
     let wrappedJs = """
-    window.Capacitor.withPlugin('\(plugin.getId()!)', function(plugin) {
-      if(!plugin) { console.error('Unable to execute JS in plugin, no such plugin found for id \(plugin.getId()!)'); }
+    window.Capacitor.withPlugin('\(plugin.getId())', function(plugin) {
+      if(!plugin) { console.error('Unable to execute JS in plugin, no such plugin found for id \(plugin.getId())'); }
       \(js)
     });
     """

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -20,9 +20,9 @@ enum BridgeError: Error {
   private static var lastUrl: URL?
   
   public var messageHandlerWrapper: CAPMessageHandlerWrapper
-  public var bridgeDelegate: CAPBridgeDelegate
-  @objc public var viewController: UIViewController {
-    return bridgeDelegate.bridgedViewController!
+  public weak var bridgeDelegate: CAPBridgeDelegate?
+  @objc public var viewController: UIViewController? {
+    return bridgeDelegate?.bridgedViewController
   }
   
   private var localUrl: String?
@@ -387,7 +387,7 @@ enum BridgeError: Error {
   public func alert(_ title: String, _ message: String, _ buttonTitle: String = "OK") {
     let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
     alert.addAction(UIAlertAction(title: buttonTitle, style: UIAlertAction.Style.default, handler: nil))
-    self.viewController.present(alert, animated: true, completion: nil)
+    self.viewController?.present(alert, animated: true, completion: nil)
   }
 
   func docLink(_ url: String) -> String {
@@ -596,7 +596,7 @@ enum BridgeError: Error {
   }
   
   @objc public func getWebView() -> WKWebView? {
-    return self.bridgeDelegate.bridgedWebView
+    return self.bridgeDelegate?.bridgedWebView
   }
 
   public func getLocalUrl() -> String {
@@ -605,7 +605,7 @@ enum BridgeError: Error {
 
   @objc public func presentVC(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
     if viewControllerToPresent.modalPresentationStyle == .popover {
-      self.viewController.present(viewControllerToPresent, animated: flag, completion: completion)
+      self.viewController?.present(viewControllerToPresent, animated: flag, completion: completion)
     } else {
       self.tmpWindow = UIWindow.init(frame: UIScreen.main.bounds)
       self.tmpWindow!.rootViewController = TmpViewController.init()
@@ -616,7 +616,7 @@ enum BridgeError: Error {
 
   @objc public func dismissVC(animated flag: Bool, completion: (() -> Void)? = nil) {
     if self.tmpWindow == nil {
-      self.viewController.dismiss(animated: flag, completion: completion)
+      self.viewController?.dismiss(animated: flag, completion: completion)
     } else {
       self.tmpWindow!.rootViewController!.dismiss(animated: flag, completion: completion)
       self.tmpWindow = nil

--- a/ios/Capacitor/Capacitor/CAPBridgeDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeDelegate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol CAPBridgeDelegate {
+public protocol CAPBridgeDelegate: class {
   var bridgedWebView: WKWebView? { get }
   var bridgedViewController: UIViewController? { get }
 }

--- a/ios/Capacitor/Capacitor/CAPMessageHandlerWrapper.swift
+++ b/ios/Capacitor/Capacitor/CAPMessageHandlerWrapper.swift
@@ -1,0 +1,29 @@
+//
+//  CAPMessageHandlerWrapper.swift
+//
+
+import Foundation
+import WebKit
+
+public class CAPMessageHandlerWrapper: NSObject, WKScriptMessageHandler {
+    weak var bridge: CAPBridge?
+    fileprivate(set) var contentController = WKUserContentController()
+    let handlerName = "bridge"
+    
+    public init(bridge: CAPBridge? = nil) {
+        super.init()
+        self.bridge = bridge
+        contentController.add(self, name: handlerName)
+    }
+    
+    func cleanUp() {
+        contentController.removeScriptMessageHandler(forName: handlerName)
+    }
+    
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let bridge = bridge else {
+          return
+        }
+        bridge.bridgeDelegate.userContentController(userContentController, didReceive: message, bridge: bridge)
+    }
+}

--- a/ios/Capacitor/Capacitor/CAPMessageHandlerWrapper.swift
+++ b/ios/Capacitor/Capacitor/CAPMessageHandlerWrapper.swift
@@ -24,6 +24,6 @@ public class CAPMessageHandlerWrapper: NSObject, WKScriptMessageHandler {
         guard let bridge = bridge else {
           return
         }
-        bridge.bridgeDelegate.userContentController(userContentController, didReceive: message, bridge: bridge)
+        bridge.bridgeDelegate?.userContentController(userContentController, didReceive: message, bridge: bridge)
     }
 }

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -7,40 +7,40 @@
 
 @interface CAPPlugin : NSObject
 
-@property (nonatomic, strong) WKWebView *webView;
-@property (nonatomic, strong) NSString *pluginId;
-@property (nonatomic, strong) NSString *pluginName;
-@property (nonatomic, strong) CAPBridge *bridge;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<CAPPluginCall *>*> *eventListeners;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, id> *retainedEventArguments;
+@property (nonatomic, weak, nullable) WKWebView *webView;
+@property (nonatomic, weak, nullable) CAPBridge *bridge;
+@property (nonatomic, strong, nonnull) NSString *pluginId;
+@property (nonatomic, strong, nonnull) NSString *pluginName;
+@property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, NSMutableArray<CAPPluginCall *>*> *eventListeners;
+@property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *retainedEventArguments;
 
-- (instancetype) initWithBridge:(CAPBridge*) bridge pluginId:(NSString*) pluginId pluginName:(NSString*) pluginName;
-- (void)addEventListener:(NSString *) eventName listener:(CAPPluginCall *)listener;
-- (void)removeEventListener:(NSString *) eventName listener:(CAPPluginCall *)listener;
-- (void)notifyListeners:(NSString *) eventName data:(NSDictionary<NSString *, id>*)data;
-- (void)notifyListeners:(NSString *) eventName data:(NSDictionary<NSString *, id>*)data retainUntilConsumed:(BOOL)retain;
-- (NSArray<CAPPluginCall *>*)getListeners:(NSString *)eventName;
-- (BOOL)hasListeners:(NSString *)eventName;
-- (void)addListener:(CAPPluginCall *)call;
-- (void)removeListener:(CAPPluginCall *)call;
-- (void)removeAllListeners:(CAPPluginCall *)call;
+- (instancetype _Nonnull) initWithBridge:(CAPBridge* _Nonnull) bridge pluginId:(NSString* _Nonnull) pluginId pluginName:(NSString* _Nonnull) pluginName;
+- (void)addEventListener:(NSString* _Nonnull)eventName listener:(CAPPluginCall* _Nonnull)listener;
+- (void)removeEventListener:(NSString* _Nonnull)eventName listener:(CAPPluginCall* _Nonnull)listener;
+- (void)notifyListeners:(NSString* _Nonnull)eventName data:(NSDictionary<NSString *, id>* _Nullable)data;
+- (void)notifyListeners:(NSString* _Nonnull)eventName data:(NSDictionary<NSString *, id>* _Nullable)data retainUntilConsumed:(BOOL)retain;
+- (NSArray<CAPPluginCall *>* _Nullable)getListeners:(NSString* _Nonnull)eventName;
+- (BOOL)hasListeners:(NSString* _Nonnull)eventName;
+- (void)addListener:(CAPPluginCall* _Nonnull)call;
+- (void)removeListener:(CAPPluginCall* _Nonnull)call;
+- (void)removeAllListeners:(CAPPluginCall* _Nonnull)call;
 /**
  * Give the plugins a chance to take control when a URL is about to be loaded in the WebView.
  * Returning true causes the WebView to abort loading the URL.
  * Returning false causes the WebView to continue loading the URL.
  * Returning nil will defer to the default Capacitor policy
  */
-- (NSNumber *)shouldOverrideLoad:(WKNavigationAction *)navigationAction;
+- (NSNumber* _Nullable)shouldOverrideLoad:(WKNavigationAction* _Nonnull)navigationAction;
 
 // Called after init if the plugin wants to do
 // some loading so the plugin author doesn't
 // need to override init()
--(void) load;
--(NSString *)getId;
--(BOOL)getBool:(CAPPluginCall*) call field:(NSString *)field defaultValue:(BOOL)defaultValue;
--(NSString *) getString:(CAPPluginCall *)call field:(NSString *)field defaultValue:(NSString *)defaultValue;
--(id)getConfigValue:(NSString *) key;
--(void)setCenteredPopover:(UIViewController *) vc;
+-(void)load;
+-(NSString* _Nonnull)getId;
+-(BOOL)getBool:(CAPPluginCall* _Nonnull) call field:(NSString* _Nonnull)field defaultValue:(BOOL)defaultValue;
+-(NSString* _Nullable)getString:(CAPPluginCall* _Nonnull)call field:(NSString* _Nonnull)field defaultValue:(NSString* _Nonnull)defaultValue;
+-(id _Nullable)getConfigValue:(NSString* _Nonnull)key;
+-(void)setCenteredPopover:(UIViewController* _Nonnull)vc;
 -(BOOL)supportsPopover;
 
 @end

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -142,9 +142,11 @@
  * Configure popover sourceRect, sourceView and permittedArrowDirections to show it centered
  */
 -(void)setCenteredPopover:(UIViewController *) vc {
-  vc.popoverPresentationController.sourceRect = CGRectMake(self.bridge.viewController.view.center.x, self.bridge.viewController.view.center.y, 0, 0);
-  vc.popoverPresentationController.sourceView = self.bridge.viewController.view;
-  vc.popoverPresentationController.permittedArrowDirections = 0;
+  if (self.bridge.viewController != nil) {
+    vc.popoverPresentationController.sourceRect = CGRectMake(self.bridge.viewController.view.center.x, self.bridge.viewController.view.center.y, 0, 0);
+    vc.popoverPresentationController.sourceView = self.bridge.viewController.view;
+    vc.popoverPresentationController.permittedArrowDirections = 0;
+  }
 }
 
 -(BOOL)supportsPopover {

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -157,5 +157,9 @@
   }
 }
 
+- (NSNumber*)shouldOverrideLoad:(WKNavigationAction*)navigationAction {
+    return nil;
+}
+
 @end
 

--- a/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPUNUserNotificationCenterDelegate.swift
@@ -2,7 +2,7 @@ import UserNotifications
 
 public class CAPUNUserNotificationCenterDelegate : NSObject, UNUserNotificationCenterDelegate  {
 
-  public var bridge: CAPBridge?
+  public weak var bridge: CAPBridge?
   // Local list of notification id -> JSObject for storing options
   // between notification requets
   var notificationRequestLookup = [String:JSObject]()

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -19,24 +19,25 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
     let toolbarColor = call.getString("toolbarColor")
     let url = URL(string: urlString)
     if let scheme = url?.scheme, ["http", "https"].contains(scheme.lowercased()) {
-      DispatchQueue.main.async {
-        self.vc = SFSafariViewController.init(url: url!)
-        self.vc!.delegate = self
+    DispatchQueue.main.async { [weak self] in
+        let safariVC = SFSafariViewController.init(url: url!)
+        safariVC.delegate = self
         let presentationStyle = call.getString("presentationStyle")
-        if presentationStyle != nil && presentationStyle == "popover" && self.supportsPopover() {
-          self.vc!.modalPresentationStyle = .popover
-          self.setCenteredPopover(self.vc)
+        if presentationStyle != nil && presentationStyle == "popover" && (self?.supportsPopover() ?? false) {
+          safariVC.modalPresentationStyle = .popover
+          self?.setCenteredPopover(safariVC)
         } else {
-          self.vc!.modalPresentationStyle = .fullScreen
+          safariVC.modalPresentationStyle = .fullScreen
         }
 
         if toolbarColor != nil {
-          self.vc!.preferredBarTintColor = UIColor(fromHex: toolbarColor!)
+          safariVC.preferredBarTintColor = UIColor(fromHex: toolbarColor!)
         }
-
-        self.bridge.presentVC(self.vc!, animated: true, completion: {
+        
+        self?.bridge?.presentVC(safariVC, animated: true, completion: {
           call.success()
         })
+        self?.vc = safariVC
       }
     } else {
       call.error("Invalid URL")
@@ -48,7 +49,7 @@ public class CAPBrowserPlugin : CAPPlugin, SFSafariViewControllerDelegate {
       call.success()
     }
     DispatchQueue.main.async {
-      self.bridge.dismissVC(animated: true) {
+      self.bridge?.dismissVC(animated: true) {
         call.success()
       }
     }

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -49,9 +49,9 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
 
     // Make sure they have all the necessary info.plist settings
     if let missingUsageDescription = checkUsageDescriptions() {
-      bridge.modulePrint(self, missingUsageDescription)
+      bridge?.modulePrint(self, missingUsageDescription)
       call.error(missingUsageDescription)
-      bridge.alert("Camera Error", "Missing required usage description. See console for more information")
+      bridge?.alert("Camera Error", "Missing required usage description. See console for more information")
       return
     }
 
@@ -120,40 +120,43 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }))
 
     self.setCenteredPopover(alert)
-    self.bridge.viewController.present(alert, animated: true, completion: nil)
+    self.bridge?.viewController.present(alert, animated: true, completion: nil)
   }
 
   func showCamera(_ call: CAPPluginCall) {
-    if self.bridge.isSimulator() || !UIImagePickerController.isSourceTypeAvailable(UIImagePickerController.SourceType.camera) {
-      self.bridge.modulePrint(self, "Camera not available in simulator")
-      self.bridge.alert("Camera Error", "Camera not available in Simulator")
+    if (self.bridge?.isSimulator() ?? false) || !UIImagePickerController.isSourceTypeAvailable(UIImagePickerController.SourceType.camera) {
+      self.bridge?.modulePrint(self, "Camera not available in simulator")
+      self.bridge?.alert("Camera Error", "Camera not available in Simulator")
       call.error("Camera not available while running in Simulator")
       return
     }
 
-    AVCaptureDevice.requestAccess(for: .video) { granted in
+    AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
         if granted {
           DispatchQueue.main.async {
+            guard let strongSelf = self else {
+                return
+            }
             let presentationStyle = call.getString("presentationStyle")
             if presentationStyle != nil && presentationStyle == "popover" {
-              self.configurePicker()
+              strongSelf.configurePicker()
             } else {
-              self.imagePicker!.modalPresentationStyle = .fullScreen
+              strongSelf.imagePicker!.modalPresentationStyle = .fullScreen
             }
 
-            self.imagePicker!.sourceType = .camera
+            strongSelf.imagePicker!.sourceType = .camera
 
-            if self.settings.direction.rawValue == "REAR" {
+            if strongSelf.settings.direction.rawValue == "REAR" {
               if UIImagePickerController.isCameraDeviceAvailable(.rear) {
-                self.imagePicker!.cameraDevice = .rear
+                strongSelf.imagePicker!.cameraDevice = .rear
               }
-            } else if self.settings.direction.rawValue == "FRONT" {
+            } else if strongSelf.settings.direction.rawValue == "FRONT" {
               if UIImagePickerController.isCameraDeviceAvailable(.front) {
-                self.imagePicker!.cameraDevice = .front
+                strongSelf.imagePicker!.cameraDevice = .front
               }
             }
 
-            self.bridge.viewController.present(self.imagePicker!, animated: true, completion: nil)
+            strongSelf.bridge?.viewController.present(strongSelf.imagePicker!, animated: true, completion: nil)
           }
         } else {
             call.error("User denied access to camera")
@@ -182,7 +185,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
   private func presentPhotos() {
     self.configurePicker()
     self.imagePicker!.sourceType = .photoLibrary
-    self.bridge.viewController.present(self.imagePicker!, animated: true, completion: nil)
+    self.bridge?.viewController.present(self.imagePicker!, animated: true, completion: nil)
   }
 
   private func configurePicker() {
@@ -273,7 +276,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
       ])
     } else if settings.resultType == CameraResultType.uri.rawValue {
       let path = try! saveTemporaryImage(jpeg)
-      guard let webPath = CAPFileManager.getPortablePath(host: bridge.getLocalUrl(), uri: URL(string: path)) else {
+      guard let webPath = CAPFileManager.getPortablePath(host: bridge?.getLocalUrl() ?? "", uri: URL(string: path)) else {
         call?.reject("Unable to get portable path to file")
         return
       }

--- a/ios/Capacitor/Capacitor/Plugins/Camera.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Camera.swift
@@ -120,7 +120,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
     }))
 
     self.setCenteredPopover(alert)
-    self.bridge?.viewController.present(alert, animated: true, completion: nil)
+    self.bridge?.viewController?.present(alert, animated: true, completion: nil)
   }
 
   func showCamera(_ call: CAPPluginCall) {
@@ -156,7 +156,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
               }
             }
 
-            strongSelf.bridge?.viewController.present(strongSelf.imagePicker!, animated: true, completion: nil)
+            strongSelf.bridge?.viewController?.present(strongSelf.imagePicker!, animated: true, completion: nil)
           }
         } else {
             call.error("User denied access to camera")
@@ -185,7 +185,7 @@ public class CAPCameraPlugin : CAPPlugin, UIImagePickerControllerDelegate, UINav
   private func presentPhotos() {
     self.configurePicker()
     self.imagePicker!.sourceType = .photoLibrary
-    self.bridge?.viewController.present(self.imagePicker!, animated: true, completion: nil)
+    self.bridge?.viewController?.present(self.imagePicker!, animated: true, completion: nil)
   }
 
   private func configurePicker() {

--- a/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Geolocation.swift
@@ -106,9 +106,9 @@ public class CAPGeolocationPlugin : CAPPlugin {
       CAPLog.print("Must supply id")
       return
     }
-    let savedCall = bridge.getSavedCall(callbackId)
+    let savedCall = bridge?.getSavedCall(callbackId)
     if savedCall != nil {
-      bridge.releaseCall(savedCall!)
+      bridge?.releaseCall(savedCall!)
       
       if self.watchLocationHandler != nil {
         self.watchLocationHandler?.stopUpdating()

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -40,6 +40,10 @@ typedef enum : NSUInteger {
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wprotocol"
+// suppressing warnings of the type: "Class 'CAPKeyboard' does not conform to protocol 'CAPBridgedPlugin'"
+// protocol conformance for this class is implemented by a macro and clang isn't detecting that
 @implementation CAPKeyboard
 
 NSTimer *hideTimer;
@@ -354,5 +358,5 @@ static IMP WKOriginalImp;
 }
 
 @end
-
+#pragma clang diagnostic pop
 

--- a/ios/Capacitor/Capacitor/Plugins/Keyboard.m
+++ b/ios/Capacitor/Capacitor/Plugins/Keyboard.m
@@ -196,8 +196,14 @@ NSString* UITraitsClassString;
   if (statusBarHeight == 40) {
     _paddingBottom = _paddingBottom + 20;
   }
-  CGRect f = [[[[UIApplication sharedApplication] delegate] window] bounds];
-  CGRect wf = self.webView.frame;
+  CGRect f, wf = CGRectZero;
+  id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
+  if (delegate != nil && [delegate respondsToSelector:@selector(window)]) {
+    f = [[delegate window] bounds];
+  }
+  if (self.webView != nil) {
+    wf = self.webView.frame;
+  }
   switch (self.keyboardResizes) {
     case ResizeBody:
     {

--- a/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/LocalNotifications.swift
@@ -70,7 +70,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       // Schedule the request.
       let request = UNNotificationRequest(identifier: "\(identifier)", content: content, trigger: trigger)
       
-      self.bridge.notificationsDelegate.notificationRequestLookup[request.identifier] = notification
+      self.bridge?.notificationsDelegate.notificationRequestLookup[request.identifier] = notification
       
       let center = UNUserNotificationCenter.current()
       center.add(request) { (error : Error?) in
@@ -97,7 +97,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
    * Request notification permission
    */
   @objc func requestPermission(_ call: CAPPluginCall) {
-    self.bridge.notificationsDelegate.requestPermissions() { granted, error in
+    self.bridge?.notificationsDelegate.requestPermissions() { granted, error in
         guard error == nil else {
             call.error(error!.localizedDescription)
             return
@@ -129,8 +129,8 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
       CAPLog.print("num of pending notifications \(notifications.count)")
       CAPLog.print(notifications)
       
-      let ret = notifications.map({ (notification) -> [String:Any] in
-        return self.bridge.notificationsDelegate.makePendingNotificationRequestJSObject(notification)
+      let ret = notifications.compactMap({ [weak self] (notification) -> [String:Any]? in
+        return self?.bridge?.notificationsDelegate.makePendingNotificationRequestJSObject(notification)
       })
       call.success([
         "notifications": ret
@@ -340,7 +340,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     createdCategories.append(generalCategory)
     for type in actionTypes {
       guard let id = type["id"] as? String else {
-        bridge.modulePrint(self, "Action type must have an id field")
+        bridge?.modulePrint(self, "Action type must have an id field")
         continue
       }
       let hiddenBodyPlaceholder = type["iosHiddenPreviewsBodyPlaceholder"] as? String ?? ""
@@ -374,7 +374,7 @@ public class CAPLocalNotificationsPlugin : CAPPlugin {
     
     for action in actions {
       guard let id = action["id"] as? String else {
-        bridge.modulePrint(self, "Action must have an id field")
+        bridge?.modulePrint(self, "Action must have an id field")
         continue
       }
       let title = action["title"] as? String ?? ""

--- a/ios/Capacitor/Capacitor/Plugins/Modals.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Modals.swift
@@ -19,7 +19,7 @@ public class CAPModalsPlugin : CAPPlugin {
     }))
     
     DispatchQueue.main.async { [weak self] in
-      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
+      self?.bridge?.viewController?.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -45,7 +45,7 @@ public class CAPModalsPlugin : CAPPlugin {
     }))
     
     DispatchQueue.main.async { [weak self] in
-      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
+      self?.bridge?.viewController?.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -83,7 +83,7 @@ public class CAPModalsPlugin : CAPPlugin {
         ])
       }))
       
-      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
+      self?.bridge?.viewController?.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -98,7 +98,7 @@ public class CAPModalsPlugin : CAPPlugin {
     
     DispatchQueue.main.async { [weak self] in
       if let alertController = self?.buildActionSheet(call, title: title, message: message, options: options) {
-        self?.bridge?.viewController.present(alertController, animated: true, completion: nil)
+        self?.bridge?.viewController?.present(alertController, animated: true, completion: nil)
       }
     }
   }

--- a/ios/Capacitor/Capacitor/Plugins/Modals.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Modals.swift
@@ -18,8 +18,8 @@ public class CAPModalsPlugin : CAPPlugin {
       call.success()
     }))
     
-    DispatchQueue.main.async {
-      self.bridge.viewController.present(alert, animated: true, completion: nil)
+    DispatchQueue.main.async { [weak self] in
+      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -44,8 +44,8 @@ public class CAPModalsPlugin : CAPPlugin {
       ])
     }))
     
-    DispatchQueue.main.async {
-      self.bridge.viewController.present(alert, animated: true, completion: nil)
+    DispatchQueue.main.async { [weak self] in
+      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -62,7 +62,7 @@ public class CAPModalsPlugin : CAPPlugin {
     
     let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
     
-    DispatchQueue.main.async {
+    DispatchQueue.main.async { [weak self] in
       
       alert.addTextField { (textField) in
         textField.placeholder = inputPlaceholder
@@ -83,7 +83,7 @@ public class CAPModalsPlugin : CAPPlugin {
         ])
       }))
       
-      self.bridge.viewController.present(alert, animated: true, completion: nil)
+      self?.bridge?.viewController.present(alert, animated: true, completion: nil)
     }
   }
   
@@ -96,10 +96,10 @@ public class CAPModalsPlugin : CAPPlugin {
 
     let options = call.getArray("options", JSObject.self) ?? []
     
-    DispatchQueue.main.async {
-      let alertController = self.buildActionSheet(call, title: title, message: message, options: options)
-
-      self.bridge.viewController.present(alertController, animated: true, completion: nil)
+    DispatchQueue.main.async { [weak self] in
+      if let alertController = self?.buildActionSheet(call, title: title, message: message, options: options) {
+        self?.bridge?.viewController.present(alertController, animated: true, completion: nil)
+      }
     }
   }
   

--- a/ios/Capacitor/Capacitor/Plugins/Network/Network.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Network/Network.swift
@@ -6,18 +6,18 @@ public class CAPNetworkPlugin : CAPPlugin {
   
   public override func load() {
     CAPLog.print("Loading network plugin")
-    reachability.whenReachable = { reachability in
+    reachability.whenReachable = { [weak self] reachability in
       if reachability.connection == .wifi {
         CAPLog.print("Reachable via WiFi")
-        self.notifyStatusChangeListeners(connected: true, type: "wifi")
+        self?.notifyStatusChangeListeners(connected: true, type: "wifi")
       } else {
         CAPLog.print("Reachable via Cellular")
-        self.notifyStatusChangeListeners(connected: true, type: "cellular")
+        self?.notifyStatusChangeListeners(connected: true, type: "cellular")
       }
     }
-    reachability.whenUnreachable = { _ in
+    reachability.whenUnreachable = { [weak self] _ in
       CAPLog.print("Not reachable")
-      self.notifyStatusChangeListeners(connected: false, type: "none")
+      self?.notifyStatusChangeListeners(connected: false, type: "none")
     }
   
     do {

--- a/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
+++ b/ios/Capacitor/Capacitor/Plugins/PushNotifications.swift
@@ -33,7 +33,7 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    * Request notification permission
    */
   @objc func requestPermission(_ call: CAPPluginCall) {
-    self.bridge.notificationsDelegate.requestPermissions() { granted, error in
+    self.bridge?.notificationsDelegate.requestPermissions() { granted, error in
         guard error == nil else {
             call.error(error!.localizedDescription)
             return
@@ -46,9 +46,9 @@ public class CAPPushNotificationsPlugin : CAPPlugin {
    * Get notifications in Notification Center
    */
   @objc func getDeliveredNotifications(_ call: CAPPluginCall) {
-    UNUserNotificationCenter.current().getDeliveredNotifications(completionHandler: { (notifications) in
-      let ret = notifications.map({ (notification) -> [String:Any] in
-        return self.bridge.notificationsDelegate.makePushNotificationRequestJSObject(notification.request)
+    UNUserNotificationCenter.current().getDeliveredNotifications(completionHandler: { [weak self] (notifications) in
+      let ret = notifications.compactMap({ (notification) -> [String:Any]? in
+        return self?.bridge?.notificationsDelegate.makePushNotificationRequestJSObject(notification.request)
       })
       call.success([
         "notifications": ret

--- a/ios/Capacitor/Capacitor/Plugins/Share.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Share.swift
@@ -47,7 +47,7 @@ public class CAPSharePlugin : CAPPlugin {
       }
       
       self?.setCenteredPopover(actionController)
-      self?.bridge?.viewController.present(actionController, animated: true, completion: nil)
+      self?.bridge?.viewController?.present(actionController, animated: true, completion: nil)
     }
   }
 }

--- a/ios/Capacitor/Capacitor/Plugins/Share.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Share.swift
@@ -24,7 +24,7 @@ public class CAPSharePlugin : CAPPlugin {
       return
     }
     
-    DispatchQueue.main.async {
+    DispatchQueue.main.async { [weak self] in
       let actionController = UIActivityViewController(activityItems: items, applicationActivities: nil)
       
       if title != nil {
@@ -46,8 +46,8 @@ public class CAPSharePlugin : CAPPlugin {
         ])
       }
       
-      self.setCenteredPopover(actionController)
-      self.bridge.viewController.present(actionController, animated: true, completion: nil)
+      self?.setCenteredPopover(actionController)
+      self?.bridge?.viewController.present(actionController, animated: true, completion: nil)
     }
   }
 }

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -65,7 +65,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     }
 
     // Observe for changes on frame and bounds to handle rotation resizing
-    let parentView = bridge.viewController.view
+    let parentView = bridge?.viewController.view
     parentView?.addObserver(self, forKeyPath: "frame", options: .new, context: nil)
     parentView?.addObserver(self, forKeyPath: "bounds", options: .new, context: nil)
 
@@ -79,7 +79,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
 
   func tearDown() {
     isVisible = false
-    bridge.viewController.view.isUserInteractionEnabled = true
+    bridge?.viewController.view.isUserInteractionEnabled = true
     imageView.removeFromSuperview()
 
     if showSpinner {
@@ -91,12 +91,12 @@ public class CAPSplashScreenPlugin: CAPPlugin {
   // the parent view observers fire
   func updateSplashImageBounds() {
     guard let delegate = UIApplication.shared.delegate else {
-      bridge.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
+      bridge?.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
       return
     }
 
     guard let window = delegate.window as? UIWindow else {
-      bridge.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
+      bridge?.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
       return
     }
     imageView.image = image
@@ -119,7 +119,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
       return
     }
 
-    let view = bridge.viewController.view
+    let view = bridge?.viewController.view
     view?.addSubview(imageView)
 
     if showSpinner {
@@ -138,7 +138,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
         self.imageView.backgroundColor = UIColor(fromHex: backgroundColor!)
       }
 
-      let view = self.bridge.viewController.view
+      let view = self.bridge?.viewController.view
 
       if self.showSpinner {
         if spinnerStyle != nil {

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -65,7 +65,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     }
 
     // Observe for changes on frame and bounds to handle rotation resizing
-    let parentView = bridge?.viewController.view
+    let parentView = bridge?.viewController?.view
     parentView?.addObserver(self, forKeyPath: "frame", options: .new, context: nil)
     parentView?.addObserver(self, forKeyPath: "bounds", options: .new, context: nil)
 
@@ -79,7 +79,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
 
   func tearDown() {
     isVisible = false
-    bridge?.viewController.view.isUserInteractionEnabled = true
+    bridge?.viewController?.view.isUserInteractionEnabled = true
     imageView.removeFromSuperview()
 
     if showSpinner {
@@ -119,7 +119,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
       return
     }
 
-    let view = bridge?.viewController.view
+    let view = bridge?.viewController?.view
     view?.addSubview(imageView)
 
     if showSpinner {
@@ -133,54 +133,55 @@ public class CAPSplashScreenPlugin: CAPPlugin {
   }
 
   func showSplash(showDuration: Int, fadeInDuration: Int, fadeOutDuration: Int, autoHide: Bool, backgroundColor: String?, spinnerStyle: String?, spinnerColor: String?, completion: @escaping () -> Void, isLaunchSplash: Bool) {
-    DispatchQueue.main.async {
-      if backgroundColor != nil {
-        self.imageView.backgroundColor = UIColor(fromHex: backgroundColor!)
+    DispatchQueue.main.async { [weak self] in
+      guard let strongSelf = self, let view = strongSelf.bridge?.viewController?.view else {
+        return
       }
-
-      let view = self.bridge?.viewController.view
-
-      if self.showSpinner {
+      if backgroundColor != nil {
+        strongSelf.imageView.backgroundColor = UIColor(fromHex: backgroundColor!)
+      }
+      
+      if strongSelf.showSpinner {
         if spinnerStyle != nil {
           switch spinnerStyle!.lowercased() {
           case "small":
-            self.spinner.style = .white
+            strongSelf.spinner.style = .white
           default:
-            self.spinner.style = .whiteLarge
+            strongSelf.spinner.style = .whiteLarge
           }
         }
 
         if spinnerColor != nil {
-          self.spinner.color = UIColor(fromHex: spinnerColor!)
+          strongSelf.spinner.color = UIColor(fromHex: spinnerColor!)
         }
       }
 
       if !isLaunchSplash {
-        view?.addSubview(self.imageView)
+        view.addSubview(strongSelf.imageView)
 
-        if self.showSpinner {
-          view?.addSubview(self.spinner)
-          self.spinner.centerXAnchor.constraint(equalTo: view!.centerXAnchor).isActive = true
-          self.spinner.centerYAnchor.constraint(equalTo: view!.centerYAnchor).isActive = true
+        if strongSelf.showSpinner {
+          view.addSubview(strongSelf.spinner)
+          strongSelf.spinner.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+          strongSelf.spinner.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         }
       }
 
-      view?.isUserInteractionEnabled = false
+      view.isUserInteractionEnabled = false
 
-      UIView.transition(with: self.imageView, duration: TimeInterval(Double(fadeInDuration) / 1000), options: .curveLinear, animations: {
-          self.imageView.alpha = 1
+      UIView.transition(with: strongSelf.imageView, duration: TimeInterval(Double(fadeInDuration) / 1000), options: .curveLinear, animations: {
+          strongSelf.imageView.alpha = 1
 
-          if self.showSpinner {
-            self.spinner.alpha = 1
+          if strongSelf.showSpinner {
+            strongSelf.spinner.alpha = 1
           }
         }) { (finished: Bool) in
-        self.isVisible = true
+        strongSelf.isVisible = true
 
         if autoHide {
-          self.hideTask = DispatchQueue.main.asyncAfter(
+          strongSelf.hideTask = DispatchQueue.main.asyncAfter(
             deadline: DispatchTime.now() + (Double(showDuration) / 1000)
           ) {
-            self.hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: isLaunchSplash)
+            strongSelf.hideSplash(fadeOutDuration: fadeOutDuration, isLaunchSplash: isLaunchSplash)
             completion()
           }
         } else {

--- a/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
+++ b/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
@@ -8,8 +8,8 @@ import Foundation
 public class CAPStatusBarPlugin: CAPPlugin {
 
   public override func load() {
-    NotificationCenter.default.addObserver(forName: CAPBridge.statusBarTappedNotification.name, object: .none, queue: .none) { _ in
-      self.bridge.triggerJSEvent(eventName: "statusTap", target: "window")
+    NotificationCenter.default.addObserver(forName: CAPBridge.statusBarTappedNotification.name, object: .none, queue: .none) { [weak self] _ in
+      self?.bridge.triggerJSEvent(eventName: "statusTap", target: "window")
     }
   }
 

--- a/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
+++ b/ios/Capacitor/Capacitor/Plugins/StatusBar.swift
@@ -9,7 +9,7 @@ public class CAPStatusBarPlugin: CAPPlugin {
 
   public override func load() {
     NotificationCenter.default.addObserver(forName: CAPBridge.statusBarTappedNotification.name, object: .none, queue: .none) { [weak self] _ in
-      self?.bridge.triggerJSEvent(eventName: "statusTap", target: "window")
+      self?.bridge?.triggerJSEvent(eventName: "statusTap", target: "window")
     }
   }
 
@@ -18,12 +18,12 @@ public class CAPStatusBarPlugin: CAPPlugin {
 
     if let style = options["style"] as? String {
       if style == "DARK" {
-        bridge.setStatusBarStyle(.lightContent)
+        bridge?.setStatusBarStyle(.lightContent)
       } else if style == "LIGHT" {
         if #available(iOS 13.0, *) {
-          bridge.setStatusBarStyle(.darkContent)
+          bridge?.setStatusBarStyle(.darkContent)
         } else {
-          bridge.setStatusBarStyle(.default)
+          bridge?.setStatusBarStyle(.default)
         }
       }
     }
@@ -38,33 +38,36 @@ public class CAPStatusBarPlugin: CAPPlugin {
   func setAnimation(_ call: CAPPluginCall) {
     let animation = call.getString("animation", "SLIDE")
     if animation == "FADE" {
-      bridge.setStatusBarAnimation(.fade)
+      bridge?.setStatusBarAnimation(.fade)
     } else if animation == "NONE" {
-      bridge.setStatusBarAnimation(.none)
+      bridge?.setStatusBarAnimation(.none)
     } else {
-      bridge.setStatusBarAnimation(.slide)
+      bridge?.setStatusBarAnimation(.slide)
     }
   }
   
   @objc func hide(_ call: CAPPluginCall) {
     setAnimation(call)
-    bridge.setStatusBarVisible(false)
+    bridge?.setStatusBarVisible(false)
     call.success()
   }
   
   @objc func show(_ call: CAPPluginCall) {
     setAnimation(call)
-    bridge.setStatusBarVisible(true)
+    bridge?.setStatusBarVisible(true)
     call.success()
   }
 
   @objc func getInfo(_ call: CAPPluginCall) {
-    DispatchQueue.main.async {
+    DispatchQueue.main.async { [weak self] in
+      guard let bridge = self?.bridge else {
+        return
+      }
       let style: String
       if #available(iOS 13.0, *) {
-        switch self.bridge.getStatusBarStyle() {
+        switch bridge.getStatusBarStyle() {
         case .default:
-          if self.bridge.getUserInterfaceStyle() == UIUserInterfaceStyle.dark {
+            if bridge.getUserInterfaceStyle() == UIUserInterfaceStyle.dark {
             style = "DARK"
           } else {
             style = "LIGHT"
@@ -75,7 +78,7 @@ public class CAPStatusBarPlugin: CAPPlugin {
           style = "LIGHT"
         }
       } else {
-        if self.bridge.getStatusBarStyle() == .lightContent {
+        if bridge.getStatusBarStyle() == .lightContent {
           style = "DARK"
         } else {
           style = "LIGHT"
@@ -83,7 +86,7 @@ public class CAPStatusBarPlugin: CAPPlugin {
       }
 
       call.success([
-        "visible": self.bridge.getStatusBarVisible(),
+        "visible": bridge.getStatusBarVisible(),
         "style": style
       ])
     }

--- a/ios/Capacitor/Capacitor/Plugins/Toast.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Toast.swift
@@ -12,9 +12,13 @@ public class CAPToastPlugin : CAPPlugin {
     }
     let durationType = call.get("duration", String.self, "short")!
     let duration = durationType == "long" ? 3500 : 2000
-    let position = call.get("position", String.self, "bottom")
-
-    showToast(vc: self.bridge!.viewController, text: text, duration: duration, position: position!, completion: {(isCompleted) in
+    let position = call.get("position", String.self, "bottom")!
+    
+    guard let vc = bridge?.viewController else {
+      call.error("Unable to display toast!")
+      return
+    }
+    showToast(vc: vc, text: text, duration: duration, position: position, completion: {(isCompleted) in
       call.success()
     });
   }

--- a/ios/Capacitor/Capacitor/Plugins/WebView.swift
+++ b/ios/Capacitor/Capacitor/Plugins/WebView.swift
@@ -5,24 +5,27 @@ public class CAPWebViewPlugin : CAPPlugin {
 
   @objc func setServerBasePath(_ call: CAPPluginCall) {
     let path = call.getString("path")
-    let vc = bridge.viewController as! CAPBridgeViewController
-    vc.setServerBasePath(path: path!)
-    call.success()
+    if let vc = bridge?.viewController as? CAPBridgeViewController {
+      vc.setServerBasePath(path: path!)
+      call.success()
+    }
   }
 
   @objc func getServerBasePath(_ call: CAPPluginCall) {
-    let vc = bridge.viewController as! CAPBridgeViewController
-    let path = vc.getServerBasePath()
-    call.success([
-      "path": path
-    ])
+    if let vc = bridge?.viewController as? CAPBridgeViewController {
+      let path = vc.getServerBasePath()
+      call.success([
+        "path": path
+      ])
+    }
   }
 
   @objc func persistServerBasePath(_ call: CAPPluginCall) {
-    let vc = bridge.viewController as! CAPBridgeViewController
-    let path = vc.getServerBasePath()
-    let defaults = UserDefaults.standard
-    defaults.set(path, forKey: "serverBasePath")
-    call.success()
+    if let vc = bridge?.viewController as? CAPBridgeViewController {
+      let path = vc.getServerBasePath()
+      let defaults = UserDefaults.standard
+      defaults.set(path, forKey: "serverBasePath")
+      call.success()
+    }
   }
 }


### PR DESCRIPTION
Assorted collection of changes cherry-picked from exploratory work. Primary focus on breaking retain cycles, clarifying ownership, and avoiding implicit retentions.

- Relationships reworked to make parent and delegate relationships weak
- Added nullability annotations to Plugin API
- Split WKUserContentController into a separate object to fix a retain cycle (expected to be revisited in future refactoring)
- Added capture lists to avoid implicit retains of self in blocks
- Minor fixes for some warnings