### PR TITLE
Pass custom plugins to BridgeFragment

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
@@ -76,6 +76,10 @@ public class BridgeFragment extends Fragment {
         loadConfig(this.getActivity().getApplicationContext(), this.getActivity());
     }
 
+    public void addPlugin(Class<? extends Plugin> plugin) {
+        this.initialPlugins.add(plugin);
+    }
+
     /**
      * Load the WebView and create the Bridge
      */


### PR DESCRIPTION
The purpose of `BridgeFragment` is to integrate Capacitor into existing Android apps in cases where `BridgeActivity` would not fit into the existing native UI.
This is nice because it enables a gradual transition from a native codebase to Capacitor.

However, it is unclear how custom plugins should be passed to `BridgeFragment`.
Therefore, this PR introduces a new method to mimic the usage pattern of `BridgeActivity`.