### PR TITLE
chore(cli): print warning when adding electron

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -95,6 +95,7 @@ export class Config implements CliConfig {
   };
 
   platforms: string[] = [];
+  knownCommunityPlatforms = ['electron'];
 
   constructor(os: string, currentWorkingDir: string, cliBinDir: string) {
     this.initOS(os);

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -36,6 +36,16 @@ export async function addCommand(config: Config, selectedPlatformName: string) {
       log(result);
     } else {
       logError(`platform ${selectedPlatformName} not found`);
+
+      if (config.knownCommunityPlatforms.includes(selectedPlatformName)) {
+        log(
+          `Try installing the platform first:\n` +
+            `   ${chalk.bold(
+              `npm install @capacitor-community/${selectedPlatformName}`,
+            )}\n` +
+            `Then, try adding it again.`,
+        );
+      }
     }
   } else {
     const platformName = await config.askPlatform(


### PR DESCRIPTION
When people run `npx cap add electron` in Capacitor 3, we probably want to point them in the right direction. First, they install it, then they can add it to their app.

closes https://github.com/ionic-team/capacitor/issues/3140