### PR TITLE
fix(android): LocalNotification `on` not working properly

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
@@ -108,14 +108,9 @@ public class DateMatch {
         next.set(incrementUnit, next.get(incrementUnit) + 1);
       }
     }
-    // SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-    // Logger.info(Logger.tags("LN"), "Next notification set to " + sdf.format(next.getTime()));
+    
     return next.getTimeInMillis();
   }
-
-  // private boolean matchesUnit(Integer unit, Calendar current, Calendar next) {
-  //     return next.get(unit) < current.get(unit);
-  // }
 
   private Calendar buildNextTriggerTime(Date date) {
     Calendar next = buildCalendar(date);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
@@ -108,7 +108,7 @@ public class DateMatch {
         next.set(incrementUnit, next.get(incrementUnit) + 1);
       }
     }
-    
+    next.set(Calendar.SECOND, 0);
     return next.getTimeInMillis();
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
@@ -73,6 +73,8 @@ public class DateMatch {
   private Calendar buildCalendar(Date date) {
     Calendar cal = Calendar.getInstance();
     cal.setTime(date);
+    cal.set(Calendar.MILLISECOND, 0);
+    cal.set(Calendar.SECOND, 0);
     return cal;
   }
 
@@ -108,7 +110,6 @@ public class DateMatch {
         next.set(incrementUnit, next.get(incrementUnit) + 1);
       }
     }
-    next.set(Calendar.SECOND, 0);
     return next.getTimeInMillis();
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/DateMatch.java
@@ -92,46 +92,52 @@ public class DateMatch {
    * Postpone trigger if first schedule matches the past
    */
   private long postponeTriggerIfNeeded(Calendar current, Calendar next) {
-    int currentYear = current.get(Calendar.YEAR);
-    if (matchesUnit(Calendar.YEAR, current, next)) {
-      next.set(Calendar.YEAR, currentYear + 1);
-      this.unit = Calendar.YEAR;
-    } else if (matchesUnit(Calendar.MONTH, current, next)) {
-      next.set(Calendar.YEAR, currentYear + 1);
-      this.unit = Calendar.MONTH;
-    } else if (matchesUnit(Calendar.DAY_OF_MONTH, current, next)) {
-      next.set(Calendar.MONTH, current.get(Calendar.MONTH) + 1);
-      this.unit = Calendar.DAY_OF_MONTH;
-    } else if (matchesUnit(Calendar.HOUR_OF_DAY, current, next)) {
-      next.set(Calendar.DAY_OF_MONTH, current.get(Calendar.DAY_OF_MONTH) + 1);
-      this.unit = Calendar.DAY_OF_MONTH;
-    } else if (matchesUnit(Calendar.MINUTE, current, next)) {
-      next.set(Calendar.HOUR_OF_DAY, current.get(Calendar.HOUR_OF_DAY) + 1);
-      this.unit = Calendar.MINUTE;
+    if (next.getTimeInMillis() <= current.getTimeInMillis() && unit != -1) {
+      Integer incrementUnit = -1;
+      if (unit == Calendar.YEAR || unit == Calendar.MONTH) {
+        incrementUnit = Calendar.YEAR;
+      } else if (unit == Calendar.DAY_OF_MONTH) {
+        incrementUnit = Calendar.MONTH;
+      } else if (unit == Calendar.HOUR_OF_DAY) {
+        incrementUnit = Calendar.DAY_OF_MONTH;
+      } else if (unit == Calendar.MINUTE) {
+        incrementUnit = Calendar.HOUR_OF_DAY;
+      }
+
+      if (incrementUnit != -1) {
+        next.set(incrementUnit, next.get(incrementUnit) + 1);
+      }
     }
+    // SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    // Logger.info(Logger.tags("LN"), "Next notification set to " + sdf.format(next.getTime()));
     return next.getTimeInMillis();
   }
 
-  private boolean matchesUnit(Integer unit, Calendar current, Calendar next) {
-    return next.get(unit) < current.get(unit);
-  }
+  // private boolean matchesUnit(Integer unit, Calendar current, Calendar next) {
+  //     return next.get(unit) < current.get(unit);
+  // }
 
   private Calendar buildNextTriggerTime(Date date) {
     Calendar next = buildCalendar(date);
     if (year != null) {
       next.set(Calendar.YEAR, year);
+      if (unit == -1) unit = Calendar.YEAR;
     }
     if (month != null) {
       next.set(Calendar.MONTH, month);
+      if (unit == -1) unit = Calendar.MONTH;
     }
     if (day != null) {
       next.set(Calendar.DAY_OF_MONTH, day);
+      if (unit == -1) unit = Calendar.DAY_OF_MONTH;
     }
     if (hour != null) {
       next.set(Calendar.HOUR_OF_DAY, hour);
+      if (unit == -1) unit = Calendar.HOUR_OF_DAY;
     }
     if (minute != null) {
       next.set(Calendar.MINUTE, minute);
+      if (unit == -1) unit = Calendar.MINUTE;
     }
     return next;
   }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -32,6 +32,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
@@ -338,9 +339,12 @@ public class LocalNotificationManager {
     // Cron like scheduler
     DateMatch on = schedule.getOn();
     if (on != null) {
+      long trigger = on.nextTrigger(new Date());
       notificationIntent.putExtra(TimedNotificationPublisher.CRON_KEY, on.toMatchString());
       pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-      alarmManager.setExact(AlarmManager.RTC, on.nextTrigger(new Date()), pendingIntent);
+      alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+      Logger.info(Logger.tags("LN"), "notification " + request.getId() + " will next fire at " + sdf.format(new Date(trigger)));
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/LocalNotificationManager.java
@@ -344,7 +344,7 @@ public class LocalNotificationManager {
       pendingIntent = PendingIntent.getBroadcast(context, request.getId(), notificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
       alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
       SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-      Logger.info(Logger.tags("LN"), "notification " + request.getId() + " will next fire at " + sdf.format(new Date(trigger)));
+      Logger.debug(Logger.tags("LN"), "notification " + request.getId() + " will next fire at " + sdf.format(new Date(trigger)));
     }
   }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import com.getcapacitor.Logger;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -42,8 +43,10 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
       long trigger = date.nextTrigger(new Date());
       Intent clone = (Intent) intent.clone();
       PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, PendingIntent.FLAG_CANCEL_CURRENT);
-      alarmManager.set(AlarmManager.RTC, trigger, pendingIntent);
+      alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+      Logger.info(Logger.tags("LN"), "notification " + id + " will next fire at " + sdf.format(new Date(trigger)));
     }
   }
-
+  
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/notification/TimedNotificationPublisher.java
@@ -45,7 +45,7 @@ public class TimedNotificationPublisher extends BroadcastReceiver {
       PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, clone, PendingIntent.FLAG_CANCEL_CURRENT);
       alarmManager.setExact(AlarmManager.RTC, trigger, pendingIntent);
       SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-      Logger.info(Logger.tags("LN"), "notification " + id + " will next fire at " + sdf.format(new Date(trigger)));
+      Logger.debug(Logger.tags("LN"), "notification " + id + " will next fire at " + sdf.format(new Date(trigger)));
     }
   }
   


### PR DESCRIPTION
I've read the contributing docs and I hope I'm doing this properly, please feel free to educate me on how to best approach this.

I needed to use the cron-like `on` notifications on a project of mine to make daily notifications happen at a certain time (like every day at 8:30 am) and noticed the Android implementation didn't work properly. On iOS, it all appears to be handled by `DateComponents`, but on Android it's got a more complex custom implementation.

It's a bit hard to find documentation, but after examining the native code, it appears that the `on` style notifications are supposed to let you:

- pass a minute and have a notification repeat each hour (passing 15 would trigger every hour at :15)
- pass an hour and a minute and have a notification repeat each day (passing 14 and 30 would result in a notification at 2:30pm each day, exactly my use case and what led me to investigate this)
- pass a day, hour, and minute and have a notification repeat for example on the 5th of every month at 8:30am.
- pass a month, day, hour, and minute and have a notification repeat each year for example on May 1st at 3pm.

I could be wrong in my understanding, of course.

On the iOS side, Apple's [documentation for `DateComponents`](https://developer.apple.com/documentation/foundation/datecomponents) isn't very clear, tbh.

Googling turned up some problems people were having ([link](https://github.com/ionic-team/capacitor/discussions/2752), [link](https://github.com/ionic-team/capacitor/issues/2747)), and I ran into my own issues as well. When trying to have a notification fire on the hour, it sometimes fired not on the hour, and if I passed hour and minute, I would sometimes get a notification that triggered at the next whole hour instead of the next day, and when I passed hour and omitted minute, I ended up with a notification that repeated ad infinitum as soon as I dismissed it, etc.

The existing logic appeared to be incomplete. It calculates the next time the notification should fire by first taking the current moment, setting the provided hour, minute etc, seeing if the resulting trigger time is in the past, and then bumping it by a certain amount. But it was only comparing to see if one unit was less than another (i.e. if hour < hour or if minute < minute), and sometimes it bumped by the wrong amount. Now it compares the timestamp of the two dates and explicitly remembers how much each iteration of the notification should be advanced by, according to the largest unit specified.

I've fixed it for my use case, i.e. I can pass hour and minute, and if device time is 2:15pm and I schedule it for 2:30pm, it goes off 15 min later, and if device time is 2:30 pm and I schedule it for 2:15pm, it schedules for the next day at 2:15pm. I left a logging statement commented out in the code for now that helped me test it and verify it's working - I expect to remove it before merge. The logic should be sound for the longer-repeating cases as well, though I haven't tested those on-device yet (I can certainly do that if I'm going about this right).

Please let me know how to proceed next, I am very impressed with this platform and am excited to be building my app on it, and if I can also contribute something back, so much the better. Thanks!

