### PR TITLE
add preserveAspectRatio to CameraOptions while resizing an image

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -343,12 +343,7 @@ public class Camera extends Plugin {
     if (saveToGallery && (imageEditedFileSavePath != null || imageFileSavePath != null)) {
       try {
         String fileToSave = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
-        MediaStore.Images.Media.insertImage(
-            getActivity().getContentResolver(),
-            fileToSave,
-            "IMG_" + UUID.randomUUID().toString(),
-            ""
-        );
+        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSave, "", "");
       } catch (FileNotFoundException e) {
         Logger.error(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
       }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * The Camera plugin makes it easy to take a photo or have the user select a photo
@@ -182,6 +183,7 @@ public class Camera extends Plugin {
     settings.setHeight(call.getInt("height", 0));
     settings.setShouldResize(settings.getWidth() > 0 || settings.getHeight() > 0);
     settings.setShouldCorrectOrientation(call.getBoolean("correctOrientation", CameraSettings.DEFAULT_CORRECT_ORIENTATION));
+    settings.setPreserveAspectRatio(call.getBoolean("preserveAspectRatio", false));
     try {
       settings.setSource(CameraSource.valueOf(call.getString("source", CameraSource.PROMPT.getSource())));
     } catch (IllegalArgumentException ex) {
@@ -410,7 +412,12 @@ public class Camera extends Plugin {
     }
 
     if (settings.isShouldResize()) {
-      final Bitmap newBitmap = ImageUtils.resize(bitmap, settings.getWidth(), settings.getHeight());
+      final Bitmap newBitmap = ImageUtils.resize(
+          bitmap,
+          settings.getWidth(),
+          settings.getHeight(),
+          settings.getPreserveAspectRatio()
+      );
       bitmap = replaceBitmap(bitmap, newBitmap);
     }
     return bitmap;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.UUID;
 
 /**
  * The Camera plugin makes it easy to take a photo or have the user select a photo

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -343,7 +343,12 @@ public class Camera extends Plugin {
     if (saveToGallery && (imageEditedFileSavePath != null || imageFileSavePath != null)) {
       try {
         String fileToSave = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
-        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSave, "", "");
+        MediaStore.Images.Media.insertImage(
+            getActivity().getContentResolver(),
+            fileToSave,
+            "IMG_" + UUID.randomUUID().toString(),
+            ""
+        );
       } catch (FileNotFoundException e) {
         Logger.error(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
       }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraSettings.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/CameraSettings.java
@@ -15,6 +15,7 @@ public class CameraSettings {
     private int width = 0;
     private int height = 0;
     private CameraSource source = CameraSource.PROMPT;
+    private boolean preserveAspectRatio = false;
 
     public CameraResultType getResultType() {
         return resultType;
@@ -82,5 +83,13 @@ public class CameraSettings {
 
     public void setSource(CameraSource source) {
         this.source = source;
+    }
+
+    public void setPreserveAspectRatio(boolean preserveAspectRatio) {
+        this.preserveAspectRatio = preserveAspectRatio;
+    }
+
+    public boolean getPreserveAspectRatio() {
+        return this.preserveAspectRatio;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -18,6 +18,17 @@ import java.io.InputStream;
 public class ImageUtils {
 
   /**
+   * Resize an image to the given width and height.
+   * @param bitmap
+   * @param width
+   * @param height
+   * @return a new, scaled Bitmap
+   */
+  public static Bitmap resize(Bitmap bitmap, final int width, final int height) {
+    ImageUtils.resize(bitmap, width, height, false)
+  }
+
+  /**
    * Resize an image to the given width and height considering the preserveAspectRatio flag.
    * @param bitmap
    * @param width

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -18,6 +18,21 @@ import java.io.InputStream;
 public class ImageUtils {
 
   /**
+   * Resize an image to the given width and height considering the preserveAspectRatio flag.
+   * @param bitmap
+   * @param width
+   * @param height
+   * @param preserveAspectRatio
+   * @return a new, scaled Bitmap
+   */
+  public static Bitmap resize(Bitmap bitmap, final int width, final int height, final boolean preserveAspectRatio) {
+    if (preserveAspectRatio) {
+        return ImageUtils.resizePreservingAspectRatio(bitmap, width, height);
+    }
+    return ImageUtils.resizeImageWithoutPreservingAspectRatio(bitmap, width, height);
+  }
+
+  /**
    * Resize an image to the given width and height. Leave one dimension 0 to
    * perform an aspect-ratio scale on the provided dimension.
    * @param bitmap
@@ -25,7 +40,7 @@ public class ImageUtils {
    * @param height
    * @return a new, scaled Bitmap
    */
-  public static Bitmap resize(Bitmap bitmap, final int width, final int height) {
+  private static Bitmap resizeImageWithoutPreservingAspectRatio(Bitmap bitmap, final int width, final int height) {
     float aspect = bitmap.getWidth() / (float) bitmap.getHeight();
     if (width > 0 && height > 0) {
       return Bitmap.createScaledBitmap(bitmap, width, height, false);
@@ -36,6 +51,33 @@ public class ImageUtils {
     }
 
     return bitmap;
+  }
+
+  /**
+   * Resize an image to the given max width and max height. Constraint can be put
+   * on one dimension, or both. Resize will always preserve aspect ratio.
+   * @param bitmap
+   * @param desiredMaxWidth
+   * @param desiredMaxHeight
+   * @return a new, scaled Bitmap
+   */
+  private static Bitmap resizePreservingAspectRatio(Bitmap bitmap, final int desiredMaxWidth, final int desiredMaxHeight) {
+    int width = bitmap.getWidth();
+    int height = bitmap.getHeight();
+
+    // 0 is treated as 'no restriction'
+    int maxHeight = desiredMaxHeight == 0 ? height : desiredMaxHeight;
+    int maxWidth = desiredMaxWidth == 0 ? width : desiredMaxWidth;
+
+    // resize with preserved aspect ratio
+    float newWidth = Math.min(width, maxWidth);
+    float newHeight = (height * newWidth) / width;
+
+    if (newHeight > maxHeight) {
+        newWidth = (width * maxHeight) / height;
+        newHeight = maxHeight;
+    }
+    return Bitmap.createScaledBitmap(bitmap, Math.round(newWidth), Math.round(newHeight), false);
   }
 
   /**

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -25,7 +25,7 @@ public class ImageUtils {
    * @return a new, scaled Bitmap
    */
   public static Bitmap resize(Bitmap bitmap, final int width, final int height) {
-    return ImageUtils.resize(bitmap, width, height, false)
+    return ImageUtils.resize(bitmap, width, height, false);
   }
 
   /**

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/camera/ImageUtils.java
@@ -25,7 +25,7 @@ public class ImageUtils {
    * @return a new, scaled Bitmap
    */
   public static Bitmap resize(Bitmap bitmap, final int width, final int height) {
-    ImageUtils.resize(bitmap, width, height, false)
+    return ImageUtils.resize(bitmap, width, height, false)
   }
 
   /**

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -322,9 +322,9 @@ export interface CameraOptions {
    */
   height?: number;
   /**
-   * Wheter to preserve the aspect ratio of the image.
-   * If the this flag is true the width and height will be used as max values
-   * and the aspect ratio will be preserved
+   * Whether to preserve the aspect ratio of the image.
+   * If this flag is true, the width and height will be used as max values
+   * and the aspect ratio will be preserved.
    * Default: false
    */
   preserveAspectRatio?: boolean;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -325,7 +325,7 @@ export interface CameraOptions {
    * Whether to preserve the aspect ratio of the image.
    * If this flag is true, the width and height will be used as max values
    * and the aspect ratio will be preserved. This is only relevant when
-   * both a width and height is passed. When only width or height is provided
+   * both a width and height are passed. When only width or height is provided
    * the aspect ratio is always preserved (and this option is a no-op).
    *
    * A future major version will change this behavior to be default,

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -324,7 +324,12 @@ export interface CameraOptions {
   /**
    * Whether to preserve the aspect ratio of the image.
    * If this flag is true, the width and height will be used as max values
-   * and the aspect ratio will be preserved.
+   * and the aspect ratio will be preserved. This is only relevant when
+   * both a width and height is passed. When only width or height is provided
+   * the aspect ratio is always preserved (and this option is a no-op).
+   *
+   * A future major version will change this behavior to be default,
+   * and may also remove this option altogether.
    * Default: false
    */
   preserveAspectRatio?: boolean;

--- a/core/src/core-plugin-definitions.ts
+++ b/core/src/core-plugin-definitions.ts
@@ -322,6 +322,13 @@ export interface CameraOptions {
    */
   height?: number;
   /**
+   * Wheter to preserve the aspect ratio of the image.
+   * If the this flag is true the width and height will be used as max values
+   * and the aspect ratio will be preserved
+   * Default: false
+   */
+  preserveAspectRatio?: boolean;
+  /**
    * Whether to automatically rotate the image "up" to correct for orientation
    * in portrait mode
    * Default: true

--- a/example/src/pages/camera/camera.html
+++ b/example/src/pages/camera/camera.html
@@ -26,4 +26,5 @@
   <button (click)="takePictureFile()" ion-button color="primary">File URI</button>
   <button (click)="testImageSize()" ion-button color="primary">Image Size Test (#307)</button>
   <button (click)="testAndroidBreak()" ion-button color="primary">Photos Orientation Test (#319)</button>
+  <button (click)="takePicturePreservingAspectRatio()" ion-button color="primary">Preserving Aspect Ratio</button>
 </ion-content>

--- a/example/src/pages/camera/camera.ts
+++ b/example/src/pages/camera/camera.ts
@@ -187,4 +187,19 @@ export class CameraPage {
     console.log('Got image back', image.path, image.webPath, image.format, image.exif);
     this.image = this.sanitizer.bypassSecurityTrustResourceUrl(image && (image.dataUrl));
   }
+
+  async takePicturePreservingAspectRatio() {
+    const image = await Plugins.Camera.getPhoto({
+      quality: 80,
+      resultType: CameraResultType.Uri,
+      source: CameraSource.Camera,
+      saveToGallery: true,
+      correctOrientation: true,
+      height: 1920,
+      width: 1920,
+      preserveAspectRatio: true,
+    });
+    console.log('Got image back', image.path, image.webPath, image.format, image.exif);
+    this.image = this.sanitizer.bypassSecurityTrustResourceUrl(image.webPath);
+  }
 }


### PR DESCRIPTION
This PR is a re-opening of #3297 because of wrong base branch and a retry of #2050 and should fix ionic-team/capacitor-plugins#2 (also the discussion #1952). I've used the Android implementation of @sandstrom (shout-out) and also did an implementation for iOS.

There's now a `preserveAspectRatio` flag on CameraOptions which is set to `false` by default.

I've also fixed a bug where the app would crash while saving an image to the gallery on Android. This only happens on certain devices but I was able to reproduce it by creating 32 images until it crashed. A random UUID gets now appended to the file name to make sure no name clashes happen anymore.

@dwieeb is there anything I can do to provide some testing or how do you test this fix?