### PR TITLE
fix(android): Don't return 404 on empty files

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -356,7 +356,7 @@ public class WebViewLocalServer {
   private int getStatusCode(InputStream stream, int defaultCode) {
     int finalStatusCode = defaultCode;
     try {
-      if (stream.available() == 0) {
+      if (stream.available() == -1) {
         finalStatusCode = 404;
       }
     } catch (IOException e) {
@@ -492,7 +492,7 @@ public class WebViewLocalServer {
     @Override
     public int available() throws IOException {
       InputStream is = getInputStream();
-      return (is != null) ? is.available() : 0;
+      return (is != null) ? is.available() : -1;
     }
 
     @Override


### PR DESCRIPTION
If file is empty stream.available() returns 0, so make available return -1 when the stream is null to distinguish between empty and not found

closes https://github.com/ionic-team/capacitor/issues/3312