### PR TITLE
fix(iOS): Only open a URL while the application is active

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -311,7 +311,9 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     }
 
     if navUrl.absoluteString.range(of: hostname!) == nil && (navigationAction.targetFrame == nil || (navigationAction.targetFrame?.isMainFrame)!) {
-      UIApplication.shared.open(navUrl, options: [:], completionHandler: nil)
+      if UIApplication.shared.applicationState == .active {
+        UIApplication.shared.open(navUrl, options: [:], completionHandler: nil)
+      }
       decisionHandler(.cancel)
       return
     }


### PR DESCRIPTION
This branch avoids a bug discovered by an enterprise client. In the reproduction case, if a user performs a double tap on a `tel` link, the application will get stuck in the `inactive` state. When opening the URL, the system presents an action sheet so the user can confirm the dial operation. However, if a second `tel` URL is attempted to open while that system-supplied action sheet is on-screen (and the application is `inactive`), the application will not be moved to the `active` state if the user selects `cancel` and dismisses the sheet. The application needs to be deactivated some other way (app switcher, etc) for the normal application life cycle events to be restored.

Under normal operations, the application shouldn't be asking the system to open URLs if it is not active so I'm not aware of any issues with the added check.