### PR TITLE
fix(android): Provide a file name when an image is saved to the gallery to prevent app crash

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -341,8 +341,10 @@ public class Camera extends Plugin {
     boolean saveToGallery = call.getBoolean("saveToGallery", CameraSettings.DEFAULT_SAVE_IMAGE_TO_GALLERY);
     if (saveToGallery && (imageEditedFileSavePath != null || imageFileSavePath != null)) {
       try {
-        String fileToSave = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
-        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSave, "", "");
+        String fileToSavePath = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
+        File file = new File(fileToSavePath);
+        String fileName = file.getName();
+        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSavePath, fileName, "");
       } catch (FileNotFoundException e) {
         Logger.error(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
       }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Camera.java
@@ -342,9 +342,8 @@ public class Camera extends Plugin {
     if (saveToGallery && (imageEditedFileSavePath != null || imageFileSavePath != null)) {
       try {
         String fileToSavePath = imageEditedFileSavePath != null ? imageEditedFileSavePath : imageFileSavePath;
-        File file = new File(fileToSavePath);
-        String fileName = file.getName();
-        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSavePath, fileName, "");
+        File fileToSave = new File(fileToSavePath);
+        MediaStore.Images.Media.insertImage(getActivity().getContentResolver(), fileToSavePath, fileToSave.getName(), "");
       } catch (FileNotFoundException e) {
         Logger.error(getLogTag(), IMAGE_GALLERY_SAVE_ERROR, e);
       }


### PR DESCRIPTION
Hi guys

I ran into an app crash with my ionic app after creating 32 images and save them into the gallery (`saveToGallery: true` in `CameraOptions`) on Android 10. I could reproduce it on a Pixel 3a Emulator running Android 10 and several other physical devices running Android 10. 

This fix extracts the file name from the file path. This file name should be unique since it is generated from the timeStamp of when the picture was taken (thanks @jcesarmobile).

As you can see [here](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/provider/MediaStore.java#L1733) the name of the image is set to "Image" when no name argument was passed. I think this is where the problem starts and after that numbers get appended internally and somehow stop working after 32 images 😅 .

I've also made tests on a Sony device running Android 9. I found out that the saved image in the gallery has somehow no meta data and it's displayed at the bottom of the gallery. There are also several Stack Overflow threads (e.g. [here](https://stackoverflow.com/questions/46874964/android-images-are-stored-at-the-end-of-the-gallery)) which describe this exact problem. I know this would be a different fix but does anybody know how this should be done in a right way?