### PR TITLE
fix(cordova): add CDVPlugin+Resources category for better plugin support

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
+++ b/ios/CapacitorCordova/CapacitorCordova.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		2F856C00203DEB320047344A /* CDVViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F856BFE203DEB320047344A /* CDVViewController.m */; };
 		2F8AC283217F3A20008C2C33 /* CDVURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F8AC281217F3A20008C2C33 /* CDVURLProtocol.m */; };
 		2F8AC284217F3A20008C2C33 /* CDVURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F8AC282217F3A20008C2C33 /* CDVURLProtocol.h */; };
+		2F92AB5224D9ABA000954A4A /* CDVPlugin+Resources.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F92AB5024D9ABA000954A4A /* CDVPlugin+Resources.m */; };
+		2F92AB5324D9ABA000954A4A /* CDVPlugin+Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F92AB5124D9ABA000954A4A /* CDVPlugin+Resources.h */; };
 		2FAD9772203C77B9000D30F8 /* CDVConfigParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FAD9770203C77B8000D30F8 /* CDVConfigParser.h */; };
 		2FAD9773203C77B9000D30F8 /* CDVConfigParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FAD9771203C77B9000D30F8 /* CDVConfigParser.m */; };
 		2FE19E2A20473160002A4E89 /* AppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FE19E2820473160002A4E89 /* AppDelegate.h */; };
@@ -52,6 +54,8 @@
 		2F856BFE203DEB320047344A /* CDVViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVViewController.m; sourceTree = "<group>"; };
 		2F8AC281217F3A20008C2C33 /* CDVURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVURLProtocol.m; sourceTree = "<group>"; };
 		2F8AC282217F3A20008C2C33 /* CDVURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVURLProtocol.h; sourceTree = "<group>"; };
+		2F92AB5024D9ABA000954A4A /* CDVPlugin+Resources.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CDVPlugin+Resources.m"; sourceTree = "<group>"; };
+		2F92AB5124D9ABA000954A4A /* CDVPlugin+Resources.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CDVPlugin+Resources.h"; sourceTree = "<group>"; };
 		2FAD9770203C77B8000D30F8 /* CDVConfigParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVConfigParser.h; sourceTree = "<group>"; };
 		2FAD9771203C77B9000D30F8 /* CDVConfigParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVConfigParser.m; sourceTree = "<group>"; };
 		2FE19E2820473160002A4E89 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -106,6 +110,8 @@
 		2F5C86E81FE94861004B09C7 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				2F92AB5124D9ABA000954A4A /* CDVPlugin+Resources.h */,
+				2F92AB5024D9ABA000954A4A /* CDVPlugin+Resources.m */,
 				2F8AC282217F3A20008C2C33 /* CDVURLProtocol.h */,
 				2F8AC281217F3A20008C2C33 /* CDVURLProtocol.m */,
 				2F4F657B2091F1FD00EAA994 /* NSDictionary+CordovaPreferences.h */,
@@ -147,6 +153,7 @@
 				2F5C87271FE98418004B09C7 /* CDVPlugin.h in Headers */,
 				2F856BFF203DEB320047344A /* CDVViewController.h in Headers */,
 				2F5C87231FE98418004B09C7 /* CDVCommandDelegateImpl.h in Headers */,
+				2F92AB5324D9ABA000954A4A /* CDVPlugin+Resources.h in Headers */,
 				2F8AC284217F3A20008C2C33 /* CDVURLProtocol.h in Headers */,
 				2F5C87241FE98418004B09C7 /* CDVInvokedUrlCommand.h in Headers */,
 				2FE19E2A20473160002A4E89 /* AppDelegate.h in Headers */,
@@ -226,6 +233,7 @@
 				2F5C871D1FE98418004B09C7 /* CDVPluginResult.m in Sources */,
 				2F4F657C2091F1FD00EAA994 /* NSDictionary+CordovaPreferences.m in Sources */,
 				2F5C87211FE98418004B09C7 /* CDVPlugin.m in Sources */,
+				2F92AB5224D9ABA000954A4A /* CDVPlugin+Resources.m in Sources */,
 				2FAD9773203C77B9000D30F8 /* CDVConfigParser.m in Sources */,
 				2F856C00203DEB320047344A /* CDVViewController.m in Sources */,
 				2F5C87201FE98418004B09C7 /* CDVInvokedUrlCommand.m in Sources */,

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin+Resources.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin+Resources.h
@@ -1,0 +1,39 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "CDVPlugin.h"
+
+@interface CDVPlugin (CDVPluginResources)
+
+/*
+ This will return the localized string for a key in a .bundle that is named the same as your class
+ For example, if your plugin class was called Foo, and you have a Spanish localized strings file, it will
+ try to load the desired key from Foo.bundle/es.lproj/Localizable.strings
+ */
+- (NSString*)pluginLocalizedString:(NSString*)key;
+
+/*
+ This will return the image for a name in a .bundle that is named the same as your class
+ For example, if your plugin class was called Foo, and you have an image called "bar",
+ it will try to load the image from Foo.bundle/bar.png (and appropriately named retina versions)
+ */
+- (UIImage*)pluginImageResource:(NSString*)name;
+
+@end

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin+Resources.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin+Resources.m
@@ -1,0 +1,38 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVPlugin+Resources.h"
+
+@implementation CDVPlugin (CDVPluginResources)
+
+- (NSString*)pluginLocalizedString:(NSString*)key
+{
+    NSBundle* bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:NSStringFromClass([self class]) ofType:@"bundle"]];
+
+    return [bundle localizedStringForKey:(key) value:nil table:nil];
+}
+
+- (UIImage*)pluginImageResource:(NSString*)name
+{
+    NSString* resourceIdentifier = [NSString stringWithFormat:@"%@.bundle/%@", NSStringFromClass([self class]), name];
+
+    return [UIImage imageNamed:resourceIdentifier];
+}
+
+@end


### PR DESCRIPTION
Some plugins use `pluginImageResource` or `pluginLocalizedString` methods and import `CDVPlugin+Resources.h` files, which were not present at the moment.

This PR add those files for better plugin support.

closes https://github.com/ionic-team/capacitor/issues/3379