### PR TITLE
Unsupported Browser Exception proposal

### DIFF
--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -1,6 +1,28 @@
 import { Capacitor, Plugins } from './global';
 import { WebPlugin } from './web';
 
+export enum ExceptionCodes {
+  UNSUPPORTED_BROWSER = 'UNSUPPORTED_BROWSER',
+}
+
+export class Exception extends Error {
+  readonly code: ExceptionCodes;
+}
+
+/**
+ * Feature unavailable for the current browser (or all browsers).
+ *
+ * This error is thrown when the requested API is not supported in the browser.
+ *
+ * This can happen particularly for the web platform when implementation is
+ * uncertain due to the plethora of browsers available to end users.
+ *
+ * Error code: `UNSUPPORTED_BROWSER`
+ */
+export class UnsupportedBrowserException extends Exception {
+  code = ExceptionCodes.UNSUPPORTED_BROWSER;
+}
+
 const PLUGIN_REGISTRY = new (class {
   protected readonly plugins: {
     [plugin: string]: RegisteredPlugin<unknown>;


### PR DESCRIPTION
For the web platform, many APIs may not work, especially for IE11, for example. We need a consistent way to report that a feature is unsupported. This will be used by official plugins, but all Capacitor plugins are welcome to use it. This is just a proposal to spark discussion.

Stems from a discussion in the Haptics PR: https://github.com/ionic-team/capacitor-plugins/pull/5#issuecomment-667739490

- Usage in plugins: https://github.com/ionic-team/capacitor-plugins/blob/4862a1997c0d1e6e65f4a16a7de976083acbf4d5/screen-reader/src/web.ts#L16-L20
- Usage in apps: https://github.com/ionic-team/capacitor-testapp/blob/84aaab694f05dadebb1666ff130f33130a279ec1/src/pages/ScreenReader.tsx#L38-L49