### PR TITLE
chore: Make native resolve return undefined

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -92,7 +92,9 @@ public class MessageHandler {
                 Logger.debug("Sending plugin error: " + data.toString());
             } else {
                 data.put("success", true);
-                data.put("data", successResult);
+                if (successResult != null) {
+                    data.put("data", successResult);
+                }
             }
 
             boolean isValidCallbackId = !call.getCallbackId().equals(PluginCall.CALLBACK_ID_DANGLING);

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -65,7 +65,7 @@ public class PluginCall {
     }
 
     public void resolve() {
-        this.success(new JSObject());
+        this.msgHandler.sendResponseMessage(this, null, null);
     }
 
     public void errorCallback(String msg) {

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -50,17 +50,11 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, successResult, null);
     }
 
-    /**
-     * @deprecated Use `resolve()`.
-     */
     public void success(JSObject data) {
         PluginResult result = new PluginResult(data);
         this.msgHandler.sendResponseMessage(this, result, null);
     }
 
-    /**
-     * @deprecated Use `resolve()`.
-     */
     public void success() {
         this.success(new JSObject());
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -50,11 +50,17 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, successResult, null);
     }
 
+    /**
+     * @deprecated Use `resolve()`.
+     */
     public void success(JSObject data) {
         PluginResult result = new PluginResult(data);
         this.msgHandler.sendResponseMessage(this, result, null);
     }
 
+    /**
+     * @deprecated Use `resolve()`.
+     */
     public void success() {
         this.success(new JSObject());
     }

--- a/ios/Capacitor/Capacitor/CAPBridge.swift
+++ b/ios/Capacitor/Capacitor/CAPBridge.swift
@@ -432,7 +432,7 @@ enum BridgeError: Error {
 
             let pluginCall = CAPPluginCall(callbackId: call.callbackId, options: call.options, success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
                 if result != nil {
-                    self?.toJs(result: JSResult(call: call, result: result!.data ?? [:]), save: pluginCall?.isSaved ?? false)
+                    self?.toJs(result: JSResult(call: call, result: result!.data), save: pluginCall?.isSaved ?? false)
                 } else {
                     self?.toJs(result: JSResult(call: call, result: [:]), save: pluginCall?.isSaved ?? false)
                 }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -63,7 +63,7 @@ public typealias PluginEventListener = CAPPluginCall
     }
 
     func success() {
-        successHandler(CAPPluginCallResult(), self)
+        successHandler(CAPPluginCallResult([:]), self)
     }
 
     func success(_ data: PluginResultData = [:]) {

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -62,10 +62,12 @@ public typealias PluginEventListener = CAPPluginCall
         return self.options.index(forKey: key) != nil
     }
 
+    @available(*, deprecated, message: "Use `resolve()`")
     func success() {
         successHandler(CAPPluginCallResult([:]), self)
     }
 
+    @available(*, deprecated, message: "Use `resolve()`")
     func success(_ data: PluginResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -62,12 +62,10 @@ public typealias PluginEventListener = CAPPluginCall
         return self.options.index(forKey: key) != nil
     }
 
-    @available(*, deprecated, message: "Use `resolve()`")
     func success() {
         successHandler(CAPPluginCallResult([:]), self)
     }
 
-    @available(*, deprecated, message: "Use `resolve()`")
     func success(_ data: PluginResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }

--- a/ios/Capacitor/Capacitor/JS.swift
+++ b/ios/Capacitor/Capacitor/JS.swift
@@ -45,32 +45,36 @@ public typealias JSResultBody = [String: Any]
  */
 public class JSResult {
     public var call: JSCall
-    public var result: JSResultBody
+    public var result: JSResultBody?
 
-    public init(call: JSCall, result: JSResultBody) {
+    public init(call: JSCall, result: JSResultBody?) {
         self.call = call
         self.result = result
     }
 
     public func toJson() throws -> String {
-        do {
-            if JSONSerialization.isValidJSONObject(result) {
-                let theJSONData = try JSONSerialization.data(withJSONObject: result, options: [])
+        if let result = result {
+            do {
+                if JSONSerialization.isValidJSONObject(result) {
+                    let theJSONData = try JSONSerialization.data(withJSONObject: result, options: [])
 
-                return String(data: theJSONData,
-                              encoding: .utf8)!
-            } else {
-                CAPLog.print("[Capacitor Plugin Error] - \(call.pluginId) - \(call.method) - Unable to serialize plugin response as JSON." +
-                    "Ensure that all data passed to success callback from module method is JSON serializable!")
-                throw JSProcessingError.jsonSerializeError(call: call)
+                    return String(data: theJSONData,
+                                  encoding: .utf8)!
+                } else {
+                    CAPLog.print("[Capacitor Plugin Error] - \(call.pluginId) - \(call.method) - Unable to serialize plugin response as JSON." +
+                        "Ensure that all data passed to success callback from module method is JSON serializable!")
+                    throw JSProcessingError.jsonSerializeError(call: call)
+                }
+            } catch let error as JSProcessingError {
+                throw error
+            } catch {
+                CAPLog.print("Unable to serialize plugin response as JSON: \(error.localizedDescription)")
             }
-        } catch let error as JSProcessingError {
-            throw error
-        } catch {
-            CAPLog.print("Unable to serialize plugin response as JSON: \(error.localizedDescription)")
-        }
 
-        return "{}"
+            return "{}"
+        } else {
+            return "undefined"
+        }
     }
 }
 


### PR DESCRIPTION
When calling `call.resolve()` it will return `undefined` instead of `{}`
`call.success()` will keep returning `{}`