### PR TITLE
Deprecate redundant PluginCall methods

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -460,7 +460,7 @@ public class Plugin {
             for (String perm : missing) {
                 builder.append(perm + "\n");
             }
-            savedLastCall.error(builder.toString());
+            savedLastCall.reject(builder.toString());
             savedLastCall = null;
         }
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -66,7 +66,7 @@ public class PluginCall {
      */
     @Deprecated
     public void success() {
-        this.success(new JSObject());
+        this.resolve(new JSObject());
     }
 
     public void resolve(JSObject data) {

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -51,16 +51,20 @@ public class PluginCall {
     }
 
     /**
-     * @deprecated Use `resolve()`.
+     * @deprecated
+     * Use {@link #resolve(JSObject data)}
      */
+    @Deprecated
     public void success(JSObject data) {
         PluginResult result = new PluginResult(data);
         this.msgHandler.sendResponseMessage(this, result, null);
     }
 
     /**
-     * @deprecated Use `resolve()`.
+     * @deprecated
+     * Use {@link #resolve()}
      */
+    @Deprecated
     public void success() {
         this.success(new JSObject());
     }
@@ -87,22 +91,28 @@ public class PluginCall {
     }
 
     /**
-     * @deprecated Use `reject()`.
+     * @deprecated
+     * Use {@link #reject(String msg, Exception ex)}
      */
+    @Deprecated
     public void error(String msg, Exception ex) {
         reject(msg, null, ex);
     }
 
     /**
-     * @deprecated Use `reject()`.
+     * @deprecated
+     * Use {@link #reject(String msg, String code, Exception ex)}
      */
+    @Deprecated
     public void error(String msg, String code, Exception ex) {
         reject(msg, code, ex);
     }
 
     /**
-     * @deprecated Use `reject()`.
+     * @deprecated
+     * Use {@link #reject(String msg)}
      */
+    @Deprecated
     public void error(String msg) {
         reject(msg, null, null);
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -86,11 +86,28 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, null, errorResult);
     }
 
+    /**
+     * @deprecated Use `reject()`.
+     */
     public void error(String msg, Exception ex) {
-        error(msg, null, ex);
+        reject(msg, null, ex);
     }
 
+    /**
+     * @deprecated Use `reject()`.
+     */
     public void error(String msg, String code, Exception ex) {
+        reject(msg, code, ex);
+    }
+
+    /**
+     * @deprecated Use `reject()`.
+     */
+    public void error(String msg) {
+        reject(msg, null, null);
+    }
+
+    public void reject(String msg, String code, Exception ex) {
         PluginResult errorResult = new PluginResult();
 
         if (ex != null) {
@@ -107,28 +124,24 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, null, errorResult);
     }
 
-    public void error(String msg) {
-        error(msg, null);
-    }
-
     public void reject(String msg, Exception ex) {
-        error(msg, ex);
+        reject(msg, null, ex);
     }
 
     public void reject(String msg, String code) {
-        error(msg, code, null);
+        reject(msg, code, null);
     }
 
     public void reject(String msg) {
-        error(msg, null);
+        reject(msg, null, null);
     }
 
     public void unimplemented() {
-        error(UNIMPLEMENTED, null);
+        reject(UNIMPLEMENTED, null, null);
     }
 
     public void unavailable() {
-        error(UNAVAILABLE, null);
+        reject(UNAVAILABLE, null, null);
     }
 
     public String getPluginId() {

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -50,11 +50,17 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, successResult, null);
     }
 
+    /**
+     * @deprecated Use `resolve()`.
+     */
     public void success(JSObject data) {
         PluginResult result = new PluginResult(data);
         this.msgHandler.sendResponseMessage(this, result, null);
     }
 
+    /**
+     * @deprecated Use `resolve()`.
+     */
     public void success() {
         this.success(new JSObject());
     }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -62,12 +62,12 @@ public typealias PluginEventListener = CAPPluginCall
         return self.options.index(forKey: key) != nil
     }
 
-    @available(*, deprecated, message: "Use `resolve()`")
+    @available(*, deprecated, renamed: "resolve")
     func success() {
         successHandler(CAPPluginCallResult([:]), self)
     }
 
-    @available(*, deprecated, message: "Use `resolve()`")
+    @available(*, deprecated, renamed: "resolve")
     func success(_ data: PluginResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }
@@ -80,7 +80,7 @@ public typealias PluginEventListener = CAPPluginCall
         successHandler(CAPPluginCallResult(data), self)
     }
 
-    @available(*, deprecated, message: "Use `reject()`")
+    @available(*, deprecated, renamed: "reject")
     func error(_ message: String, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
         errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
     }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -80,6 +80,7 @@ public typealias PluginEventListener = CAPPluginCall
         successHandler(CAPPluginCallResult(data), self)
     }
 
+    @available(*, deprecated, message: "Use `reject()`")
     func error(_ message: String, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
         errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
     }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -62,7 +62,7 @@ public typealias PluginEventListener = CAPPluginCall
         return self.options.index(forKey: key) != nil
     }
 
-    @available(*, deprecated, renamed: "resolve")
+    @available(*, deprecated, renamed: "resolve()")
     func success() {
         successHandler(CAPPluginCallResult([:]), self)
     }

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -62,10 +62,12 @@ public typealias PluginEventListener = CAPPluginCall
         return self.options.index(forKey: key) != nil
     }
 
+    @available(*, deprecated, message: "Use `resolve()`")
     func success() {
         successHandler(CAPPluginCallResult(), self)
     }
 
+    @available(*, deprecated, message: "Use `resolve()`")
     func success(_ data: PluginResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }

--- a/plugin-template/android/CLASS_NAMEPlugin.java
+++ b/plugin-template/android/CLASS_NAMEPlugin.java
@@ -16,6 +16,6 @@ public class CLASS_NAMEPlugin extends Plugin {
 
         JSObject ret = new JSObject();
         ret.put("value", implementation.echo(value));
-        call.success(ret);
+        call.resolve(ret);
     }
 }

--- a/plugin-template/ios/Plugin/CLASS_NAMEPlugin.swift
+++ b/plugin-template/ios/Plugin/CLASS_NAMEPlugin.swift
@@ -12,7 +12,7 @@ public class CLASS_NAMEPlugin: CAPPlugin {
 
     @objc func echo(_ call: CAPPluginCall) {
         let value = call.getString("value") ?? ""
-        call.success([
+        call.resolve([
             "value": implementation.echo(value)
         ])
     }


### PR DESCRIPTION
- `success()` is now deprecated (use `resolve()`)
- `error()` is now deprecated (use `reject()`)