### PR TITLE
Embedded Capacitor: Pass urlPath to Bridge

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -135,7 +135,8 @@ public class Bridge {
         CordovaInterfaceImpl cordovaInterface,
         PluginManager pluginManager,
         CordovaPreferences preferences,
-        JSONObject config
+        JSONObject config,
+        String urlPath
     ) {
         this.context = context;
         this.webView = webView;
@@ -163,10 +164,10 @@ public class Bridge {
         // Register our core plugins
         this.registerAllPlugins();
 
-        this.loadWebView();
+        this.loadWebView(urlPath);
     }
 
-    private void loadWebView() {
+    private void loadWebView(String urlPath) {
         appUrlConfig = this.config.getString("server.url");
         String[] appAllowNavigationConfig = this.config.getArray("server.allowNavigation");
 
@@ -199,6 +200,9 @@ public class Bridge {
             if (!scheme.equals(Bridge.CAPACITOR_HTTP_SCHEME) && !scheme.equals(CAPACITOR_HTTPS_SCHEME)) {
                 appUrl += "/";
             }
+        }
+        if (urlPath != null) {
+            appUrl += urlPath;
         }
 
         final boolean html5mode = this.config.getBoolean("server.html5mode", true);

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -76,7 +76,7 @@ public class BridgeActivity extends AppCompatActivity {
 
         pluginManager = mockWebView.getPluginManager();
         cordovaInterface.onCordovaInit(pluginManager);
-        bridge = new Bridge(this, webView, initialPlugins, cordovaInterface, pluginManager, preferences, this.config);
+        bridge = new Bridge(this, webView, initialPlugins, cordovaInterface, pluginManager, preferences, this.config, null);
 
         Splash.showOnLaunch(this, bridge.getConfig());
 

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
@@ -45,8 +45,7 @@ public class BridgeFragment extends Fragment {
     private PluginManager pluginManager;
     private CordovaPreferences preferences;
     private MockCordovaWebViewImpl mockWebView;
-    private int activityDepth = 0;
-    private String bridgeStartDir;
+    private String urlPath;
 
     private String lastActivityPlugin;
 
@@ -80,11 +79,15 @@ public class BridgeFragment extends Fragment {
         this.initialPlugins.add(plugin);
     }
 
+    public void setUrlPath(String urlPath) {
+        this.urlPath = urlPath;
+    }
+
     /**
      * Load the WebView and create the Bridge
      */
     protected void load(Bundle savedInstanceState) {
-        Logger.debug("Starting BridgeActivity");
+        Logger.debug("Starting BridgeFragment");
 
         Bundle args = getArguments();
         String startDir = null;
@@ -109,7 +112,7 @@ public class BridgeFragment extends Fragment {
             preferences = new CordovaPreferences();
         }
 
-        bridge = new Bridge(this.getActivity(), webView, initialPlugins, cordovaInterface, pluginManager, preferences, config);
+        bridge = new Bridge(this.getActivity(), webView, initialPlugins, cordovaInterface, pluginManager, preferences, config, urlPath);
 
         if (startDir != null) {
             bridge.setServerAssetPath(startDir);


### PR DESCRIPTION
For Embedded Capacitor, it is often necessary to have multiple Capacitor fragments with different routes.
For example, I have two embedded Capacitor fragments like this:
`http://localhost/feature_1`
`http://localhost/feature_2`

This PR passes the `/feature_1` and `/feature_2` to the target bridges.
It is somewhat similar to the following iOS-issue: https://github.com/ionic-team/capacitor/issues/3106

My intended usage of this PR is as follows (although not the only possible usage):

```Kotlin
import android.os.Bundle
import com.getcapacitor.BridgeFragment

class MyFeatureBridgeFragment : BridgeFragment() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        super.setUrlPath("/feature_1")
    }
}
```

## Why the URL path?

One could argue whether it makes sense to pass only URL paths instead of complete URLs.
However, I still want the host to be independent of the path in order to configure the host for "live reload debugging":
As described in https://github.com/ionic-team/capacitor/discussions/1478, live reload debugging leads to dangerous mis-configurations, but this is a story for another PR.


## Limitations and Further Work

Passing only the URL path might not be enough for all use cases of Embedded Capacitor.
For example, one might have different hosts instead of different URL paths.
Although this practice might be forbidden by app store guidelines, it might still be a valid use case:
`https://remote_host_1.com`
`https://remote_host_2.com`

More generally, I propose a system where the entire Capacitor-configuration can be dynamically modified/overriden by the native code.
In turn, this may or may not lead to the elimination of the native `capacitor.config.json`-files.
Nevertheless, I still submit this PR because I cannot estimate how long it would take to have a new configuration system.
