### PR TITLE
chore(cli): remove cordova-plugin-googlemaps from skip list

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -339,7 +339,7 @@ export function getIncompatibleCordovaPlugins(platform: string) {
   'cordova-plugin-add-swift-support', 'cordova-plugin-ionic-keyboard', 'cordova-plugin-braintree',
   '@ionic-enterprise/filesystem', '@ionic-enterprise/keyboard', '@ionic-enterprise/splashscreen', 'cordova-support-google-services'];
   if (platform === 'ios') {
-    pluginList.push('cordova-plugin-googlemaps', 'cordova-plugin-statusbar', '@ionic-enterprise/statusbar');
+    pluginList.push('cordova-plugin-statusbar', '@ionic-enterprise/statusbar');
   }
   if (platform === 'android') {
     pluginList.push('cordova-plugin-compat');


### PR DESCRIPTION
The plugin is being reworked to be compatible with Capacitor and people can't test it unless we remove it from the skip list.

Related: https://github.com/ionic-team/capacitor/discussions/3431