### PR TITLE
chore(iOS): updating UIColor extension with namespaced protocol

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -99,8 +99,8 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKUID
         bridge = CAPBridge(self, messageHandler, capConfig, specifiedScheme)
 
         if let backgroundColor = (bridge!.config.getValue("ios.backgroundColor") as? String) ?? (bridge!.config.getValue("backgroundColor") as? String) {
-            webView?.backgroundColor = UIColor(fromHex: backgroundColor)
-            webView?.scrollView.backgroundColor = UIColor(fromHex: backgroundColor)
+            webView?.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor)
+            webView?.scrollView.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor)
         } else if #available(iOS 13, *) {
             // Use the system background colors if background is not set by user
             webView?.backgroundColor = UIColor.systemBackground

--- a/ios/Capacitor/Capacitor/CapacitorExtension.swift
+++ b/ios/Capacitor/Capacitor/CapacitorExtension.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public protocol CapacitorExtension {
+    associatedtype T
+    var capacitor: T { get }
+    static var capacitor: T.Type { get }
+}
+
+public extension CapacitorExtension {
+    var capacitor: CapacitorExtensionTypeWrapper<Self> {
+        return CapacitorExtensionTypeWrapper(self)
+    }
+
+    static var capacitor: CapacitorExtensionTypeWrapper<Self>.Type {
+        return CapacitorExtensionTypeWrapper.self
+    }
+}
+
+public struct CapacitorExtensionTypeWrapper<T> {
+    var baseType: T
+    init(_ baseType: T) {
+        self.baseType = baseType
+    }
+}

--- a/ios/Capacitor/Capacitor/Plugins/Browser.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Browser.swift
@@ -31,7 +31,7 @@ public class CAPBrowserPlugin: CAPPlugin, SFSafariViewControllerDelegate {
                 }
 
                 if toolbarColor != nil {
-                    safariVC.preferredBarTintColor = UIColor(fromHex: toolbarColor!)
+                    safariVC.preferredBarTintColor = UIColor.capacitor.color(fromHex: toolbarColor!)
                 }
 
                 self?.bridge?.presentVC(safariVC, animated: true, completion: {

--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -155,7 +155,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
                 return
             }
             if backgroundColor != nil {
-                strongSelf.imageView.backgroundColor = UIColor(fromHex: backgroundColor!)
+                strongSelf.imageView.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor!)
             }
 
             if strongSelf.showSpinner {
@@ -169,7 +169,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
                 }
 
                 if spinnerColor != nil {
-                    strongSelf.spinner.color = UIColor(fromHex: spinnerColor!)
+                    strongSelf.spinner.color = UIColor.capacitor.color(fromHex: spinnerColor!)
                 }
             }
 

--- a/ios/Capacitor/Capacitor/Plugins/Toast.swift
+++ b/ios/Capacitor/Capacitor/Plugins/Toast.swift
@@ -25,7 +25,7 @@ public class CAPToastPlugin: CAPPlugin {
         DispatchQueue.main.async {
             let maxSizeTitle: CGSize = CGSize(width: viewController.view.bounds.size.width-32, height: viewController.view.bounds.size.height)
 
-            let label = UILabel()
+            let label = UILabel() // TODO: Use a custom subclass here and deprecate the 'padding' extension of UILabel
             label.backgroundColor = UIColor.black.withAlphaComponent(0.6)
             label.textColor = UIColor.white
             label.textAlignment = .center

--- a/ios/Capacitor/Capacitor/UIColor.swift
+++ b/ios/Capacitor/Capacitor/UIColor.swift
@@ -1,8 +1,9 @@
-extension UIColor {
+extension UIColor: CapacitorExtension {}
+public extension CapacitorExtensionTypeWrapper where T: UIColor {
     // disable linting for the short variable names, since that's the point of the method
     // swiftlint:disable:next identifier_name
-    convenience init(r: Int, g: Int, b: Int, a: Int = 0xFF) {
-        self.init(
+    static func color(r: Int, g: Int, b: Int, a: Int = 0xFF) -> UIColor {
+        return T(
             red: CGFloat(r) / 255.0,
             green: CGFloat(g) / 255.0,
             blue: CGFloat(b) / 255.0,
@@ -10,8 +11,8 @@ extension UIColor {
         )
     }
 
-    convenience init(argb: UInt32) {
-        self.init(
+    static func color(argb: UInt32) -> UIColor {
+        return T(
             red: CGFloat((argb >> 16) & 0xFF),
             green: CGFloat((argb >> 8) & 0xFF),
             blue: CGFloat(argb & 0xFF),
@@ -19,7 +20,7 @@ extension UIColor {
         )
     }
 
-    convenience init?(fromHex: String) {
+    static func color(fromHex: String) -> UIColor? {
         let hexString = fromHex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(
             of: "#",
             with: ""
@@ -48,7 +49,7 @@ extension UIColor {
         } else {
             return nil
         }
-
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
+        
+        return T(red: red, green: green, blue: blue, alpha: alpha)
     }
 }


### PR DESCRIPTION
The project has several convenience init methods in a `UIColor` extension. By default, the extension is internal and is only available within the capacitor module. That has been fine since the use of the methods has only been from within the module. However, this presents a problem when splitting the plugins out since they cannot access them from their new, external modules.

Simply making the extension `public` is undesirable because that will pollute the global space and will cause conflicts if Capacitor is ever added to a project along with other code that declares similarly named methods. It makes Capacitor a bad citizen of the ecosystem to attach methods to Foundation types for everyone.

So, this branch adds a new protocol and generic type wrapper to isolate these methods with a pseudo namespace and avoid that potential conflict. A consequence is that the protocol conformance cannot add initializers but static methods will work just as well for these use-cases. So, the code `UIColor(fromHex: "FFFFFF")` will become `UIColor.capacitor.color(fromHex: "FFFFFF)`. Instances can have new methods added with the `.capacitor` chaining as well.

The extension to `UILabel` is left alone for the time being with an added comment at its point of use. Using an associated object cannot be done in a generic type but since that functionality is only used in `Toast`, which might get refactored into a new plugin, it would be better served to be a `UILabel` subclass instead of an extension anyway.