### PR TITLE
feat(ios): Add CAPFileUtils class with getCleanData function

### DIFF
--- a/ios/Capacitor/Capacitor/CAPFile.swift
+++ b/ios/Capacitor/Capacitor/CAPFile.swift
@@ -72,3 +72,13 @@ private class CAPFileResolverNotImplemented: CAPFileResolver {
         return nil
     }
 }
+
+@objc public class CAPFileUtils: NSObject {
+    public static func getCleanData(_ data: String) -> String {
+        let dataParts = data.split(separator: ",")
+        if let part = dataParts.last {
+            return String(part)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
Removes the data part of a base64 file representation if present, to use it in Clipboard, Filesystem or other plugins that might need it.
Usage is like this `CAPFileUtils.getCleanData(data)`