### PR TITLE
Added asset ignore string to allow dirs beginning with underscore in assets

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -9,6 +9,9 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        aaptOptions {
+            ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:!CVS:!thumbs.db:!picasa.ini:!*~'
+        }
     }
     buildTypes {
         release {

--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -10,7 +10,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
-            ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:!CVS:!thumbs.db:!picasa.ini:!*~'
+            ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
     buildTypes {

--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -11,7 +11,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
-             // Default: https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt/AaptAssets.cpp#61
+             // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }

--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -10,10 +10,8 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
-            /*
-                Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
-                Default: https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt/AaptAssets.cpp#61
-            */
+             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
+             // Default: https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt/AaptAssets.cpp#61
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }

--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -10,6 +10,10 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
+            /*
+                Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
+                Default: https://android.googlesource.com/platform/frameworks/base/+/master/tools/aapt/AaptAssets.cpp#61
+            */
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }


### PR DESCRIPTION
@dwieeb to answer your question from the other PR I made..

The presence of these items in the list means they *will* be ignored. (The default string includes the `<dir>_` pattern that ignores the directories, thus we override it here to omit that and allow them). The exclamation point here means not to print a warning about it (vs. meaning negation like in other code)

Source: https://android.googlesource.com/platform/frameworks/base/+/6d2c0e5/tools/aapt2/Files.h#88