### PR TITLE
Added disable drag and drop in a WKWebView.

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -167,6 +167,21 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKUID
         loadWebView()
     }
 
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // https://stackoverflow.com/questions/49911060/how-to-disable-ios-11-and-ios-12-drag-drop-in-wkwebview
+        for subview in webView!.scrollView.subviews {
+            if subview.interactions.count > 1 {
+                for interaction in subview.interactions {
+                    if interaction is UIDragInteraction {
+                        (interaction as! UIDragInteraction).isEnabled = false
+                    }
+                }
+            }
+        }
+    }
+
     func printLoadError() {
         let fullStartPath = URL(fileURLWithPath: assetsFolder).appendingPathComponent(startDir)
 


### PR DESCRIPTION
There is an annoying issue on iPads and WKWebView when long pressing on images or text, it starts a drag and drop operation. This only happens on iPads in our tests so far. While researching the issue, I came across this StackOverflow post:
https://stackoverflow.com/questions/49911060/how-to-disable-ios-11-and-ios-12-drag-drop-in-wkwebview

It explains how to circumvent this issue. I took the basic idea and implemented it for use in Capacitor. As mentioned in the post, since iOS 12 it is being handled differently so I had to add another override method for `viewDidAppear` and added the code to disable the UIDragInteraction there. 

It solves the issue and makes sure that no drag and drop operations are happening inside the WKWebView. However, I am not sure if this should be configurable as some projects might need that feature.

Please kindly review this merge request and give feedback. Thank you!