### PR TITLE
chore(cli): Remove doctor entry from PluginManifest interface

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -13,7 +13,6 @@ export const enum PluginType {
 export interface PluginManifest {
   ios: {
     src: string;
-    doctor?: any[];
   };
   android: {
     src: string;


### PR DESCRIPTION
While doing reviews I noticed this property that is not used, so better remove it.