### PR TITLE
fix(android): move splash screen trigger before the webview render to prevent flicker (2.x)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -152,6 +152,7 @@ public class Bridge {
     this.config = new CapConfig(getActivity().getAssets(), config);
     Logger.init(this.config);
 
+    // Display splash screen if configured
     if (context instanceof BridgeActivity) {
       Splash.showOnLaunch((BridgeActivity) context, this.config);
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -152,6 +152,10 @@ public class Bridge {
     this.config = new CapConfig(getActivity().getAssets(), config);
     Logger.init(this.config);
 
+    if (context instanceof BridgeActivity) {
+      Splash.showOnLaunch((BridgeActivity) context, this.config);
+    }
+
     // Initialize web view and message handler for it
     this.initWebView();
     this.msgHandler = new MessageHandler(this, webView, pluginManager);

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -82,8 +82,6 @@ public class BridgeActivity extends AppCompatActivity {
     cordovaInterface.onCordovaInit(pluginManager);
     bridge = new Bridge(this, webView, initialPlugins, cordovaInterface, pluginManager, preferences, this.config);
 
-    Splash.showOnLaunch(this, bridge.getConfig());
-
     if (savedInstanceState != null) {
       bridge.restoreInstanceState(savedInstanceState);
     }


### PR DESCRIPTION
Resolves #3601

Fix in 3.x: #3596