### PR TITLE
feat(android): Add handlePermissions function for plugins to call

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -560,6 +560,13 @@ public class Plugin {
             return;
         }
 
+        this.handlePermissions(permissions, grantResults);
+
+        savedCall.resolve(getPermissionStates());
+        savedCall.release(bridge);
+    }
+
+    public void handlePermissions(String[] permissions, int[] grantResults) {
         SharedPreferences prefs = getContext().getSharedPreferences(PERMISSION_PREFS, Activity.MODE_PRIVATE);
 
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
@@ -588,9 +595,6 @@ public class Plugin {
                 editor.apply();
             }
         }
-
-        savedCall.resolve(getPermissionStates());
-        savedCall.release(bridge);
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -566,6 +566,13 @@ public class Plugin {
         savedCall.release(bridge);
     }
 
+    /**
+     * Plugin overriding onRequestPermissionsResult should call this method to
+     * handle the permission status correctly
+     *
+     * @param permissions
+     * @param grantResults
+     */
     public void handlePermissions(String[] permissions, int[] grantResults) {
         SharedPreferences prefs = getContext().getSharedPreferences(PERMISSION_PREFS, Activity.MODE_PRIVATE);
 


### PR DESCRIPTION
At the moment `onRequestPermissionsResult` handles the prompt/prompt-with-rationale/denied logic, but since most plugins will overwrite it, that functionality get lost and `checkPermissions` always returns prompt because of that.

By adding a new `handlePermissions` function in Plugin class that handles that logic, users can call it on their `onRequestPermissionsResult` override.