### PR TITLE
chore(iOS): Clean up from bridge API changes

### DIFF
--- a/ios-template/App/App/AppDelegate.swift
+++ b/ios-template/App/App/AppDelegate.swift
@@ -36,14 +36,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call
-        return CAPBridge.handleOpenUrl(url, options)
+        return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         // Called when the app was launched with an activity, including Universal Links.
         // Feel free to add additional processing here, but if you want the App API to support
         // tracking app url opens, make sure to keep this call
-        return CAPBridge.handleContinueActivity(userActivity, restorationHandler)
+        return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -53,18 +53,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
 
         if statusBarRect.contains(touchPoint) {
-            NotificationCenter.default.post(CAPBridge.statusBarTappedNotification)
+            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
         }
     }
 
     #if USE_PUSH
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
     }
 
     #endif

--- a/ios/Capacitor/Capacitor/CAPApplicationDelegateProxy.swift
+++ b/ios/Capacitor/Capacitor/CAPApplicationDelegateProxy.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc(CAPApplicationDelegateProxy)
 public class ApplicationDelegateProxy: NSObject, UIApplicationDelegate {
-    static let shared = ApplicationDelegateProxy()
+    public static let shared = ApplicationDelegateProxy()
 
     private(set) var lastURL: URL?
 


### PR DESCRIPTION
This branch is follow-on work to #3678 to fix a bug and remove deprecation warnings.

- Fixes a bug where the ApplicationDelegateProxy singleton was not correctly exposed as public.
- Update the iOS template to use the new methods/definitions to avoid deprecation warnings.