### PR TITLE
refactor(cli): shuffle imports to reduce startup time

### DIFF
--- a/cli/bin/capacitor
+++ b/cli/bin/capacitor
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
-var semver = require('semver');
+var satisfies = require('semver/functions/satisfies');
 var packageJson = require('../package.json');
 var currentNodeVersion = process.version.replace('v', '');
 var requiresNodeVersion = packageJson.engines.node;
 
-if (!semver.satisfies(currentNodeVersion, requiresNodeVersion)) {
+if (!satisfies(currentNodeVersion, requiresNodeVersion)) {
   console.error('ERROR: Capacitor CLI requires Node ' + requiresNodeVersion);
   process.exit(1);
 }

--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -3,8 +3,10 @@ import { homedir } from 'os';
 import { join } from 'path';
 
 import c from '../colors';
-import { copyTemplate, runCommand, runTask } from '../common';
+import { runTask } from '../common';
 import type { Config } from '../definitions';
+import { runCommand } from '../util/subprocess';
+import { copyTemplate } from '../util/template';
 
 export async function addAndroid(config: Config): Promise<void> {
   await runTask(

--- a/cli/src/android/doctor.ts
+++ b/cli/src/android/doctor.ts
@@ -3,8 +3,10 @@ import { accessSync } from 'fs';
 import { join } from 'path';
 
 import c from '../colors';
-import { check, logFatal, logSuccess, readXML } from '../common';
+import { check } from '../common';
 import type { Config } from '../definitions';
+import { logFatal, logSuccess } from '../log';
+import { readXML } from '../util/xml';
 
 export async function doctorAndroid(config: Config): Promise<void> {
   try {

--- a/cli/src/android/run.ts
+++ b/cli/src/android/run.ts
@@ -2,15 +2,11 @@ import Debug from 'debug';
 import { resolve } from 'path';
 
 import c from '../colors';
-import {
-  getPlatformTargets,
-  promptForPlatformTarget,
-  runCommand,
-  runNativeRun,
-  runTask,
-} from '../common';
+import { promptForPlatformTarget, runTask } from '../common';
 import type { Config } from '../definitions';
 import type { RunCommandOptions } from '../tasks/run';
+import { runNativeRun, getPlatformTargets } from '../util/native-run';
+import { runCommand } from '../util/subprocess';
 
 const debug = Debug('capacitor:android:run');
 

--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -2,18 +2,14 @@ import { copy, remove, pathExists, readFile, writeFile } from '@ionic/utils-fs';
 import { dirname, join, relative, resolve } from 'path';
 
 import c from '../colors';
-import {
-  checkPlatformVersions,
-  logFatal,
-  resolveNode,
-  runTask,
-} from '../common';
+import { checkPlatformVersions, runTask } from '../common';
 import {
   checkPluginDependencies,
   handleCordovaPluginsJS,
   writeCordovaAndroidManifest,
 } from '../cordova';
 import type { Config } from '../definitions';
+import { logFatal } from '../log';
 import type { Plugin } from '../plugin';
 import {
   PluginType,
@@ -26,6 +22,7 @@ import {
   printPlugins,
 } from '../plugin';
 import { convertToUnixPath } from '../util/fs';
+import { resolveNode } from '../util/node';
 
 import { getAndroidPlugins } from './common';
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -3,7 +3,6 @@ import Debug from 'debug';
 import { dirname, join, resolve } from 'path';
 
 import c from './colors';
-import { logFatal, resolveNode, runCommand } from './common';
 import type {
   AndroidConfig,
   AppConfig,
@@ -14,8 +13,9 @@ import type {
   WebConfig,
 } from './definitions';
 import { OS } from './definitions';
+import { logFatal } from './log';
 import { tryFn } from './util/fn';
-import { requireTS } from './util/node';
+import { resolveNode, requireTS } from './util/node';
 
 const debug = Debug('capacitor:config');
 
@@ -250,6 +250,8 @@ async function determineAndroidStudioPath(os: OS): Promise<string> {
     case OS.Mac:
       return '/Applications/Android Studio.app';
     case OS.Windows: {
+      const { runCommand } = await import('./util/subprocess');
+
       let p = 'C:\\Program Files\\Android\\Android Studio\\bin\\studio64.exe';
 
       try {

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -13,18 +13,9 @@ import prompts from 'prompts';
 
 import { getAndroidPlugins } from './android/common';
 import c from './colors';
-import {
-  buildXmlElement,
-  logFatal,
-  logPrompt,
-  parseXML,
-  readXML,
-  resolveNode,
-  writeXML,
-} from './common';
 import type { Config } from './definitions';
 import { getIOSPlugins } from './ios/common';
-import { logger } from './log';
+import { logger, logFatal, logPrompt } from './log';
 import type { Plugin } from './plugin';
 import {
   PluginType,
@@ -37,6 +28,8 @@ import {
   printPlugins,
 } from './plugin';
 import { copy as copyTask } from './tasks/copy';
+import { resolveNode } from './util/node';
+import { buildXmlElement, parseXML, readXML, writeXML } from './util/xml';
 
 /**
  * Build the root cordova_plugins.js file referencing each Plugin JS file.
@@ -221,6 +214,7 @@ export async function autoGenerateConfig(
   cordovaPlugins: Plugin[],
   platform: string,
 ): Promise<void> {
+  const xml2js = await import('xml2js');
   let xmlDir = join(config.android.resDirAbs, 'xml');
   const fileName = 'config.xml';
   if (platform === 'ios') {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,21 +1,8 @@
 import program from 'commander';
 
 import c from './colors';
-import { logFatal } from './common';
 import { loadConfig } from './config';
-import { output } from './log';
-import { addCommand } from './tasks/add';
-import { copyCommand } from './tasks/copy';
-import { createCommand } from './tasks/create';
-import { doctorCommand } from './tasks/doctor';
-import { initCommand } from './tasks/init';
-import { listCommand } from './tasks/list';
-import { newPluginCommand } from './tasks/new-plugin';
-import { openCommand } from './tasks/open';
-import { runCommand } from './tasks/run';
-import { serveCommand } from './tasks/serve';
-import { syncCommand } from './tasks/sync';
-import { updateCommand } from './tasks/update';
+import { output, logFatal } from './log';
 import { emoji as _e } from './util/emoji';
 
 process.on('unhandledRejection', error => {
@@ -30,8 +17,9 @@ export async function run(): Promise<void> {
   program
     .command('create [directory] [name] [id]', { hidden: true })
     .description('Creates a new Capacitor project')
-    .action(() => {
-      return createCommand();
+    .action(async () => {
+      const { createCommand } = await import('./tasks/create');
+      await createCommand();
     });
 
   program
@@ -41,15 +29,17 @@ export async function run(): Promise<void> {
       '--web-dir <value>',
       'Optional: Directory of your projects built web assets',
     )
-    .action((appName, appId, { webDir }) => {
-      return initCommand(config, appName, appId, webDir);
+    .action(async (appName, appId, { webDir }) => {
+      const { initCommand } = await import('./tasks/init');
+      await initCommand(config, appName, appId, webDir);
     });
 
   program
     .command('serve', { hidden: true })
     .description('Serves a Capacitor Progressive Web App in the browser')
-    .action(() => {
-      return serveCommand();
+    .action(async () => {
+      const { serveCommand } = await import('./tasks/serve');
+      await serveCommand();
     });
 
   program
@@ -59,8 +49,9 @@ export async function run(): Promise<void> {
       '--deployment',
       "Optional: if provided, Podfile.lock won't be deleted and pod install will use --deployment option",
     )
-    .action((platform, { deployment }) => {
-      return syncCommand(config, platform, deployment);
+    .action(async (platform, { deployment }) => {
+      const { syncCommand } = await import('./tasks/sync');
+      await syncCommand(config, platform, deployment);
     });
 
   program
@@ -74,15 +65,17 @@ export async function run(): Promise<void> {
       '--deployment',
       "Optional: if provided, Podfile.lock won't be deleted and pod install will use --deployment option",
     )
-    .action((platform, { deployment }) => {
-      return updateCommand(config, platform, deployment);
+    .action(async (platform, { deployment }) => {
+      const { updateCommand } = await import('./tasks/update');
+      await updateCommand(config, platform, deployment);
     });
 
   program
     .command('copy [platform]')
     .description('copies the web app build into the native app')
-    .action(platform => {
-      return copyCommand(config, platform);
+    .action(async platform => {
+      const { copyCommand } = await import('./tasks/copy');
+      await copyCommand(config, platform);
     });
 
   program
@@ -92,46 +85,52 @@ export async function run(): Promise<void> {
     )
     .option('--list', 'list targets, then quit')
     .option('--target <id>', 'use a specific target')
-    .action((platform, { list, target }) => {
-      return runCommand(config, platform, { list, target });
+    .action(async (platform, { list, target }) => {
+      const { runCommand } = await import('./tasks/run');
+      await runCommand(config, platform, { list, target });
     });
 
   program
     .command('open [platform]')
     .description('opens the native project workspace (Xcode for iOS)')
-    .action(platform => {
-      return openCommand(config, platform);
+    .action(async platform => {
+      const { openCommand } = await import('./tasks/open');
+      await openCommand(config, platform);
     });
 
   program
     .command('add [platform]')
     .description('add a native platform project')
-    .action(platform => {
-      return addCommand(config, platform);
+    .action(async platform => {
+      const { addCommand } = await import('./tasks/add');
+      await addCommand(config, platform);
     });
 
   program
     .command('ls [platform]')
     .description('list installed Cordova and Capacitor plugins')
-    .action(platform => {
-      return listCommand(config, platform);
+    .action(async platform => {
+      const { listCommand } = await import('./tasks/list');
+      await listCommand(config, platform);
     });
 
   program
     .command('doctor [platform]')
     .description('checks the current setup for common errors')
-    .action(platform => {
-      return doctorCommand(config, platform);
+    .action(async platform => {
+      const { doctorCommand } = await import('./tasks/doctor');
+      await doctorCommand(config, platform);
     });
 
   program
     .command('plugin:generate', { hidden: true })
     .description('start a new Capacitor plugin')
-    .action(() => {
-      return newPluginCommand();
+    .action(async () => {
+      const { newPluginCommand } = await import('./tasks/new-plugin');
+      await newPluginCommand();
     });
 
-  program.arguments('[command]').action(cmd => {
+  program.arguments('[command]').action(async cmd => {
     if (typeof cmd === 'undefined') {
       output.write(
         `\n  ${_e('⚡️', '--')}  ${c.strong(

--- a/cli/src/ios/add.ts
+++ b/cli/src/ios/add.ts
@@ -1,6 +1,7 @@
 import c from '../colors';
-import { copyTemplate, runTask } from '../common';
+import { runTask } from '../common';
 import type { Config } from '../definitions';
+import { copyTemplate } from '../util/template';
 
 export async function addIOS(config: Config): Promise<void> {
   await runTask(

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -2,16 +2,13 @@ import { readdir, readFile, writeFile } from '@ionic/utils-fs';
 import { join, resolve } from 'path';
 
 import c from '../colors';
-import {
-  isInstalled,
-  checkCapacitorPlatform,
-  getProjectPlatformDirectory,
-} from '../common';
+import { checkCapacitorPlatform, getProjectPlatformDirectory } from '../common';
 import { getIncompatibleCordovaPlugins } from '../cordova';
 import type { Config } from '../definitions';
 import { OS } from '../definitions';
 import type { Plugin } from '../plugin';
 import { PluginType, getPluginPlatform } from '../plugin';
+import { isInstalled } from '../util/subprocess';
 
 export async function findXcodePath(config: Config): Promise<string | null> {
   try {

--- a/cli/src/ios/doctor.ts
+++ b/cli/src/ios/doctor.ts
@@ -1,11 +1,7 @@
-import {
-  check,
-  checkWebDir,
-  isInstalled,
-  logFatal,
-  logSuccess,
-} from '../common';
+import { check, checkWebDir } from '../common';
 import type { Config } from '../definitions';
+import { logFatal, logSuccess } from '../log';
+import { isInstalled } from '../util/subprocess';
 
 import { checkCocoaPods, checkIOSProject } from './common';
 

--- a/cli/src/ios/open.ts
+++ b/cli/src/ios/open.ts
@@ -1,8 +1,9 @@
 import open from 'open';
 
 import c from '../colors';
-import { wait, logFatal } from '../common';
+import { wait } from '../common';
 import type { Config } from '../definitions';
+import { logFatal } from '../log';
 
 import { findXcodePath } from './common';
 

--- a/cli/src/ios/run.ts
+++ b/cli/src/ios/run.ts
@@ -2,15 +2,11 @@ import Debug from 'debug';
 import { resolve } from 'path';
 
 import c from '../colors';
-import {
-  getPlatformTargets,
-  promptForPlatformTarget,
-  runCommand,
-  runNativeRun,
-  runTask,
-} from '../common';
+import { promptForPlatformTarget, runTask } from '../common';
 import type { Config } from '../definitions';
 import type { RunCommandOptions } from '../tasks/run';
+import { runNativeRun, getPlatformTargets } from '../util/native-run';
+import { runCommand } from '../util/subprocess';
 
 const debug = Debug('capacitor:ios:run');
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -2,19 +2,14 @@ import { copy, remove, readFile, realpath, writeFile } from '@ionic/utils-fs';
 import { dirname, join, relative, resolve } from 'path';
 
 import c from '../colors';
-import {
-  checkPlatformVersions,
-  logFatal,
-  resolveNode,
-  runCommand,
-  runTask,
-} from '../common';
+import { checkPlatformVersions, runTask } from '../common';
 import {
   checkPluginDependencies,
   handleCordovaPluginsJS,
   logCordovaManualSteps,
 } from '../cordova';
 import type { Config } from '../definitions';
+import { logFatal } from '../log';
 import type { Plugin } from '../plugin';
 import {
   PluginType,
@@ -26,6 +21,8 @@ import {
   printPlugins,
 } from '../plugin';
 import { convertToUnixPath } from '../util/fs';
+import { resolveNode } from '../util/node';
+import { runCommand } from '../util/subprocess';
 
 import { getIOSPlugins } from './common';
 

--- a/cli/src/log.ts
+++ b/cli/src/log.ts
@@ -5,11 +5,12 @@ import {
   TTYOutputStrategy,
   createDefaultLogger,
 } from '@ionic/cli-framework-output';
+import type { Answers, PromptObject } from 'prompts';
 
-import colors from './colors';
+import c from './colors';
 import { isInteractive } from './util/term';
 
-const options = { colors, stream: process.stdout };
+const options = { colors: c, stream: process.stdout };
 
 export const output = isInteractive()
   ? new TTYOutputStrategy(options)
@@ -20,10 +21,35 @@ export const logger = createDefaultLogger({
   formatterOptions: {
     titleize: false,
     tags: new Map<LoggerLevelWeight, string>([
-      [LOGGER_LEVELS.DEBUG, colors.log.DEBUG('[debug]')],
-      [LOGGER_LEVELS.INFO, colors.log.INFO('[info]')],
-      [LOGGER_LEVELS.WARN, colors.log.WARN('[warn]')],
-      [LOGGER_LEVELS.ERROR, colors.log.ERROR('[error]')],
+      [LOGGER_LEVELS.DEBUG, c.log.DEBUG('[debug]')],
+      [LOGGER_LEVELS.INFO, c.log.INFO('[info]')],
+      [LOGGER_LEVELS.WARN, c.log.WARN('[warn]')],
+      [LOGGER_LEVELS.ERROR, c.log.ERROR('[error]')],
     ]),
   },
 });
+
+export async function logPrompt<T extends string>(
+  msg: string,
+  promptObject: PromptObject<T>,
+): Promise<Answers<T>> {
+  const { wordWrap } = await import('@ionic/cli-framework-output');
+  const { prompt } = await import('prompts');
+
+  logger.log({
+    msg: `${c.input('[?]')} ${wordWrap(msg, { indentation: 4 })}`,
+    logger,
+    format: false,
+  });
+
+  return prompt(promptObject, { onCancel: () => process.exit(1) });
+}
+
+export function logSuccess(msg: string): void {
+  logger.msg(`${c.success('[success]')} ${msg}`);
+}
+
+export function logFatal(msg: string): never {
+  logger.error(msg);
+  return process.exit(1);
+}

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -1,9 +1,11 @@
+import { readJSON } from '@ionic/utils-fs';
 import { dirname, join } from 'path';
 
 import c from './colors';
-import { logFatal, readJSON, readXML, resolveNode } from './common';
 import type { Config } from './definitions';
-import { logger } from './log';
+import { logger, logFatal } from './log';
+import { resolveNode } from './util/node';
+import { readXML } from './util/xml';
 
 export const enum PluginType {
   Core,

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -11,7 +11,6 @@ import {
   checkAppConfig,
   checkPackage,
   checkWebDir,
-  logFatal,
   resolvePlatform,
   runPlatformHook,
   runTask,
@@ -28,7 +27,7 @@ import {
   checkIOSPackage,
   checkCocoaPods,
 } from '../ios/common';
-import { logger } from '../log';
+import { logger, logFatal } from '../log';
 
 import { sync } from './sync';
 

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -1,11 +1,9 @@
-import { copy as fsCopy, pathExists, remove, writeJSON } from '@ionic/utils-fs';
-import { basename, join, relative, resolve } from 'path';
+import { copy as fsCopy, remove, writeJSON } from '@ionic/utils-fs';
+import { basename, join, relative } from 'path';
 
 import c from '../colors';
 import {
   checkWebDir,
-  logFatal,
-  resolveNode,
   resolvePlatform,
   runPlatformHook,
   runTask,
@@ -18,7 +16,8 @@ import {
   writeCordovaAndroidManifest,
 } from '../cordova';
 import type { Config } from '../definitions';
-import { logger } from '../log';
+import { logger, logFatal } from '../log';
+import { resolveNode } from '../util/node';
 import { allSerial } from '../util/promise';
 import { copyWeb } from '../web/copy';
 

--- a/cli/src/tasks/create.ts
+++ b/cli/src/tasks/create.ts
@@ -1,5 +1,5 @@
 import c from '../colors';
-import { logFatal } from '../common';
+import { logFatal } from '../log';
 
 export async function createCommand(): Promise<void> {
   logFatal(

--- a/cli/src/tasks/doctor.ts
+++ b/cli/src/tasks/doctor.ts
@@ -1,15 +1,14 @@
+import { readJSON } from '@ionic/utils-fs';
+
 import { doctorAndroid } from '../android/doctor';
 import c from '../colors';
-import {
-  readJSON,
-  resolveNode,
-  getCommandOutput,
-  selectPlatforms,
-} from '../common';
+import { selectPlatforms } from '../common';
 import type { Config } from '../definitions';
 import { doctorIOS } from '../ios/doctor';
 import { output } from '../log';
 import { emoji as _e } from '../util/emoji';
+import { resolveNode } from '../util/node';
+import { getCommandOutput } from '../util/subprocess';
 
 export async function doctorCommand(
   config: Config,

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -1,17 +1,10 @@
+import { writeJSON } from '@ionic/utils-fs';
+
 import c from '../colors';
-import {
-  check,
-  checkAppId,
-  checkAppName,
-  logFatal,
-  mergeConfig,
-  runTask,
-  logSuccess,
-  logPrompt,
-} from '../common';
+import { check, checkAppId, checkAppName, runTask } from '../common';
 import { getCordovaPreferences } from '../cordova';
-import type { Config } from '../definitions';
-import { output } from '../log';
+import type { Config, ExternalConfig } from '../definitions';
+import { output, logFatal, logSuccess, logPrompt } from '../log';
 import { checkInteractive, isInteractive } from '../util/term';
 
 export async function initCommand(
@@ -137,4 +130,24 @@ async function getWebDir(config: Config, webDir?: string) {
     return answers.webDir;
   }
   return webDir;
+}
+
+async function mergeConfig(
+  config: Config,
+  extConfig: ExternalConfig,
+): Promise<void> {
+  const oldConfig = { ...config.app.extConfig };
+
+  await writeJSON(
+    config.app.extConfigFilePath,
+    {
+      ...oldConfig,
+      ...extConfig,
+      ...{
+        plugins: extConfig.plugins ??
+          oldConfig.plugins ?? { SplashScreen: { launchShowDuration: 0 } },
+      },
+    },
+    { spaces: 2 },
+  );
 }

--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -1,5 +1,5 @@
 import c from '../colors';
-import { logFatal } from '../common';
+import { logFatal } from '../log';
 
 export async function newPluginCommand(): Promise<void> {
   logFatal(

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -1,7 +1,6 @@
 import { openAndroid } from '../android/open';
 import c from '../colors';
 import {
-  logFatal,
   resolvePlatform,
   runPlatformHook,
   runTask,
@@ -11,7 +10,7 @@ import {
 } from '../common';
 import type { Config } from '../definitions';
 import { openIOS } from '../ios/open';
-import { logger } from '../log';
+import { logger, logFatal } from '../log';
 
 export async function openCommand(
   config: Config,

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -8,13 +8,12 @@ import {
   runPlatformHook,
   selectPlatforms,
   promptForPlatform,
-  logFatal,
-  getPlatformTargets,
   getPlatformTargetName,
 } from '../common';
 import type { Config } from '../definitions';
 import { runIOS } from '../ios/run';
-import { logger, output } from '../log';
+import { logger, output, logFatal } from '../log';
+import { getPlatformTargets } from '../util/native-run';
 
 import { copy } from './copy';
 

--- a/cli/src/tasks/serve.ts
+++ b/cli/src/tasks/serve.ts
@@ -1,5 +1,5 @@
 import c from '../colors';
-import { logFatal } from '../common';
+import { logFatal } from '../log';
 
 export async function serveCommand(): Promise<void> {
   logFatal(

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -3,12 +3,11 @@ import {
   check,
   checkPackage,
   checkWebDir,
-  logFatal,
   selectPlatforms,
   isValidPlatform,
 } from '../common';
 import type { Config } from '../definitions';
-import { logger } from '../log';
+import { logger, logFatal } from '../log';
 import { allSerial } from '../util/promise';
 
 import { copy, copyCommand } from './copy';

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -4,7 +4,6 @@ import type { CheckFunction } from '../common';
 import {
   check,
   checkPackage,
-  logFatal,
   resolvePlatform,
   runPlatformHook,
   runTask,
@@ -14,7 +13,7 @@ import {
 import type { Config } from '../definitions';
 import { checkCocoaPods, checkIOSProject } from '../ios/common';
 import { updateIOS } from '../ios/update';
-import { logger } from '../log';
+import { logger, logFatal } from '../log';
 import { allSerial } from '../util/promise';
 
 export async function updateCommand(

--- a/cli/src/util/native-run.ts
+++ b/cli/src/util/native-run.ts
@@ -1,0 +1,39 @@
+import { dirname } from 'path';
+
+import c from '../colors';
+import type { PlatformTarget } from '../common';
+import { logFatal } from '../log';
+
+import { resolveNode } from './node';
+import type { RunCommandOptions } from './subprocess';
+import { runCommand } from './subprocess';
+
+export async function runNativeRun(
+  args: readonly string[],
+  options: RunCommandOptions = {},
+): Promise<string> {
+  const p = resolveNode(
+    __dirname,
+    '..',
+    dirname('native-run/package'),
+    'bin/native-run',
+  );
+
+  if (!p) {
+    logFatal(`${c.input('native-run')} not found.`);
+  }
+
+  return await runCommand(p, args, options);
+}
+
+export async function getPlatformTargets(
+  platformName: string,
+): Promise<PlatformTarget[]> {
+  const output = await runNativeRun([platformName, '--list', '--json']);
+  const parsedOutput = JSON.parse(output);
+
+  return [
+    ...parsedOutput.devices.map((t: any) => ({ ...t, virtual: false })),
+    ...parsedOutput.virtualDevices.map((t: any) => ({ ...t, virtual: true })),
+  ];
+}

--- a/cli/src/util/node.ts
+++ b/cli/src/util/node.ts
@@ -48,3 +48,14 @@ export const requireTS = (ts: typeof typescript, p: string): unknown => {
 
   return m;
 };
+
+export function resolveNode(
+  root: string,
+  ...pathSegments: string[]
+): string | null {
+  try {
+    return require.resolve(pathSegments.join('/'), { paths: [root] });
+  } catch (e) {
+    return null;
+  }
+}

--- a/cli/src/util/subprocess.ts
+++ b/cli/src/util/subprocess.ts
@@ -1,0 +1,45 @@
+import { Subprocess, SubprocessError, which } from '@ionic/utils-subprocess';
+
+export interface RunCommandOptions {
+  cwd?: string;
+}
+
+export async function runCommand(
+  command: string,
+  args: readonly string[],
+  options: RunCommandOptions = {},
+): Promise<string> {
+  const p = new Subprocess(command, args, options);
+
+  try {
+    return await p.output();
+  } catch (e) {
+    if (e instanceof SubprocessError) {
+      // old behavior of just throwing the stdout/stderr strings
+      throw e.output ? e.output : e.code;
+    }
+
+    throw e;
+  }
+}
+
+export async function getCommandOutput(
+  command: string,
+  args: readonly string[],
+): Promise<string | null> {
+  try {
+    return (await runCommand(command, args)).trim();
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function isInstalled(command: string): Promise<boolean> {
+  try {
+    await which(command);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}

--- a/cli/src/util/template.ts
+++ b/cli/src/util/template.ts
@@ -1,0 +1,16 @@
+import { copy, move, pathExists } from '@ionic/utils-fs';
+import { join } from 'path';
+
+export async function copyTemplate(src: string, dst: string): Promise<void> {
+  await copy(src, dst);
+  await renameGitignore(dst);
+}
+
+async function renameGitignore(dst: string): Promise<void> {
+  // npm renames .gitignore to something else, so our templates
+  // have .gitignore as gitignore, we need to rename it here.
+  const gitignorePath = join(dst, 'gitignore');
+  if (await pathExists(gitignorePath)) {
+    await move(gitignorePath, join(dst, '.gitignore'));
+  }
+}

--- a/cli/src/util/xml.ts
+++ b/cli/src/util/xml.ts
@@ -1,0 +1,48 @@
+import { readFile } from '@ionic/utils-fs';
+import xml2js from 'xml2js';
+
+export async function readXML(path: string): Promise<any> {
+  try {
+    const xmlStr = await readFile(path, { encoding: 'utf-8' });
+    try {
+      return await xml2js.parseStringPromise(xmlStr);
+    } catch (e) {
+      throw `Error parsing: ${path}, ${e.stack ?? e}`;
+    }
+  } catch (e) {
+    throw `Unable to read: ${path}`;
+  }
+}
+
+export function parseXML(xmlStr: string): any {
+  let xmlObj;
+  xml2js.parseString(xmlStr, (err: any, result: any) => {
+    if (!err) {
+      xmlObj = result;
+    }
+  });
+  return xmlObj;
+}
+
+export async function writeXML(object: any): Promise<any> {
+  return new Promise(resolve => {
+    const builder = new xml2js.Builder({
+      headless: true,
+      explicitRoot: false,
+      rootName: 'deleteme',
+    });
+    let xml = builder.buildObject(object);
+    xml = xml.replace('<deleteme>', '').replace('</deleteme>', '');
+    resolve(xml);
+  });
+}
+
+export function buildXmlElement(configElement: any, rootName: string): string {
+  const builder = new xml2js.Builder({
+    headless: true,
+    explicitRoot: false,
+    rootName: rootName,
+  });
+
+  return builder.buildObject(configElement);
+}

--- a/cli/src/web/copy.ts
+++ b/cli/src/web/copy.ts
@@ -2,8 +2,10 @@ import { copy } from '@ionic/utils-fs';
 import { join } from 'path';
 
 import c from '../colors';
-import { logFatal, resolveNode, runTask } from '../common';
+import { runTask } from '../common';
 import type { Config } from '../definitions';
+import { logFatal } from '../log';
+import { resolveNode } from '../util/node';
 
 export async function copyWeb(config: Config): Promise<void> {
   if (config.app.bundledWebRuntime) {

--- a/cli/test/util.ts
+++ b/cli/test/util.ts
@@ -10,9 +10,9 @@ import { join, resolve } from 'path';
 import type { DirCallback } from 'tmp';
 import tmp from 'tmp';
 
-import { runCommand } from '../src/common';
 import { loadConfig } from '../src/config';
 import type { Config } from '../src/definitions';
+import { runCommand } from '../src/util/subprocess';
 
 const cwd = process.cwd();
 


### PR DESCRIPTION
Using the following code after config is loaded in the `run()` function of `cli/src/index.ts`:

```js
console.log(Object.keys(require.cache).length);
```

as well as `time npx cap --version` to test startup time.

**Benchmarks**

These are the numbers I'm getting on my machine (MacBook Pro (16-inch, 2019) / 2.4 GHz 8-Core Intel Core i9 / 32 GB 2667 MHz DDR4):

`main`
- 280 modules in cache
- 0.42s startup
- package: 141 files (500.7 kB, 829.7 kB unpacked)

`cli-bundle` (https://github.com/ionic-team/capacitor/pull/3797)
- 241 modules in cache
- 0.40s startup
- package: 102 files (497.3 kB, 807.7 kB unpacked)

`import-refactor` (this PR)
- 100 modules in cache
- 0.32s startup 
- package: 145 files (501.1 kB, 832.9 kB unpacked)

**Results**

This has ~100ms faster startup than `cli-bundle` while maintaining the simple build process and useful dist stack traces and while adding little to no maintenance overhead. To reduce the number of files published we can implement https://github.com/ionic-team/capacitor/issues/3290 (wouldn't reduce the packaged size much, but would offer additional benefits).

alternative to https://github.com/ionic-team/capacitor/pull/3797