### PR TITLE
fix(cli): Properly detect cocoapods on multiple platforms

### DIFF
--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -68,9 +68,9 @@ export function updateChecks(
         () => checkIOSProject(config),
       );
     } else if (platformName === config.android.name) {
-      return [];
+      continue;
     } else if (platformName === config.web.name) {
-      return [];
+      continue;
     } else {
       throw `Platform ${platformName} is not valid.`;
     }


### PR DESCRIPTION
When running `npx cap sync` and not specifying a platform, the cli will attempt to run `pod install` without verifying it exists. This results in an error saying "pod does not exist."

When running `npx cap sync ios` the problem does not exist.