### PR TITLE
feat(cli): Add configurable pod path

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -189,6 +189,7 @@ async function loadIOSConfig(
   cliConfig: CLIConfig,
 ): Promise<IOSConfig> {
   const name = 'ios';
+  const podPath = determineCocoapodPath();
   const platformDir = extConfig.ios?.path ?? 'ios';
   const platformDirAbs = resolve(rootDir, platformDir);
   const webDir = 'public';
@@ -211,6 +212,7 @@ async function loadIOSConfig(
       templateDir: resolve(cliConfig.assetsDir, templateName),
       pluginsDir: resolve(cliConfig.assetsDir, pluginsFolderName),
     },
+    podPath,
   };
 }
 
@@ -278,4 +280,12 @@ async function determineAndroidStudioPath(os: OS): Promise<string> {
   }
 
   return '';
+}
+
+function determineCocoapodPath(): string {
+  if (process.env.CAPACITOR_COCOAPODS_PATH) {
+    return process.env.CAPACITOR_COCOAPODS_PATH;
+  }
+
+  return 'pod';
 }

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -80,6 +80,7 @@ export interface AndroidConfig extends PlatformConfig {
 
 export interface IOSConfig extends PlatformConfig {
   readonly minVersion: string;
+  readonly podPath: string;
   readonly cordovaSwiftVersion: string;
   readonly webDir: string;
   readonly webDirAbs: string;

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -37,7 +37,7 @@ export async function checkIOSPackage(config: Config): Promise<string | null> {
 }
 
 export async function checkCocoaPods(config: Config): Promise<string | null> {
-  if (!(await isInstalled('pod')) && config.cli.os === OS.Mac) {
+  if (!(await isInstalled(config.ios.podPath)) && config.cli.os === OS.Mac) {
     return (
       `CocoaPods is not installed.\n` +
       `See this install guide: ${c.strong(

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -69,7 +69,9 @@ export async function installCocoaPodsPlugins(
   deployment: boolean,
 ): Promise<void> {
   await runTask(
-    `Updating iOS native dependencies with ${c.input(`${config.ios.podPath} install`)}`,
+    `Updating iOS native dependencies with ${c.input(
+      `${config.ios.podPath} install`,
+    )}`,
     () => {
       return updatePodfile(config, plugins, deployment);
     },

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -69,7 +69,7 @@ export async function installCocoaPodsPlugins(
   deployment: boolean,
 ): Promise<void> {
   await runTask(
-    `Updating iOS native dependencies with ${c.input('pod install')}`,
+    `Updating iOS native dependencies with ${c.input(`${config.ios.podPath} install`)}`,
     () => {
       return updatePodfile(config, plugins, deployment);
     },
@@ -100,7 +100,7 @@ async function updatePodfile(
     await remove(podfileLockPath);
   }
   await runCommand(
-    'pod',
+    config.ios.podPath,
     ['install', ...(deployment ? ['--deployment'] : [])],
     { cwd: projectRoot },
   );


### PR DESCRIPTION
Fixes https://github.com/ionic-team/capacitor/issues/3603

A new environment variable `CAPACITOR_COCOAPODS_PATH` can be set to specify a specific pod installation