### PR TITLE
fix(cli): run sync instead of copy during run

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -81,7 +81,7 @@ export async function run(): Promise<void> {
   program
     .command(`run [platform]`)
     .description(
-      `runs ${c.input('copy')}, then builds and deploys the native app`,
+      `runs ${c.input('sync')}, then builds and deploys the native app`,
     )
     .option('--list', 'list targets, then quit')
     .option('--target <id>', 'use a specific target')

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -15,7 +15,7 @@ import { runIOS } from '../ios/run';
 import { logger, output, logFatal } from '../log';
 import { getPlatformTargets } from '../util/native-run';
 
-import { copy } from './copy';
+import { sync } from './sync';
 
 export interface RunCommandOptions {
   list?: boolean;
@@ -71,7 +71,7 @@ export async function runCommand(
     }
 
     try {
-      await copy(config, platformName);
+      await sync(config, platformName, false);
       await run(config, platformName, options);
     } catch (e) {
       logFatal(e.stack ?? e);


### PR DESCRIPTION
Even though it takes longer (especially on iOS), I think this is the safer option for `capacitor run`.