### PR TITLE
feat(cli): add config command

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,15 @@ export async function run(): Promise<void> {
   program.version(config.cli.package.version);
 
   program
+    .command('config', { hidden: true })
+    .description(`print evaluated Capacitor config`)
+    .option('--json', 'Print in JSON format')
+    .action(async ({ json }) => {
+      const { configCommand } = await import('./tasks/config');
+      await configCommand(config, json);
+    });
+
+  program
     .command('create [directory] [name] [id]', { hidden: true })
     .description('Creates a new Capacitor project')
     .action(async () => {

--- a/cli/src/tasks/config.ts
+++ b/cli/src/tasks/config.ts
@@ -1,0 +1,17 @@
+import util from 'util';
+
+import type { Config } from '../definitions';
+import { output } from '../log';
+
+export async function configCommand(
+  config: Config,
+  json: boolean,
+): Promise<void> {
+  if (json) {
+    output.write(JSON.stringify(config));
+  } else {
+    output.write(
+      `${util.inspect(config, { depth: Infinity, colors: true })}\n`,
+    );
+  }
+}


### PR DESCRIPTION
This is a hidden command that outputs the CLI config (including the `extConfig` from reading `capacitor.config.json` or evaluating dynamic config files).

This will be used in the Ionic CLI to know where each platform's generated `capacitor.config.json` is.