### PR TITLE
refactor(cli): consolidate paths to config

### DIFF
--- a/cli/src/android/common.ts
+++ b/cli/src/android/common.ts
@@ -73,14 +73,8 @@ export async function editProjectSettingsAndroid(
   const appId = config.app.appId;
   const appName = config.app.appName;
 
-  const manifestPath = resolve(
-    config.android.platformDirAbs,
-    'app/src/main/AndroidManifest.xml',
-  );
-  const buildGradlePath = resolve(
-    config.android.platformDirAbs,
-    'app/build.gradle',
-  );
+  const manifestPath = resolve(config.android.srcDirAbs, 'AndroidManifest.xml');
+  const buildGradlePath = resolve(config.android.appDirAbs, 'build.gradle');
 
   let manifestContent = await readFile(manifestPath, { encoding: 'utf-8' });
 
@@ -92,10 +86,7 @@ export async function editProjectSettingsAndroid(
 
   const domainPath = appId.split('.').join('/');
   // Make the package source path to the new plugin Java file
-  const newJavaPath = resolve(
-    config.android.platformDirAbs,
-    `app/src/main/java/${domainPath}`,
-  );
+  const newJavaPath = resolve(config.android.srcDirAbs, `java/${domainPath}`);
 
   if (!(await pathExists(newJavaPath))) {
     await mkdirp(newJavaPath);
@@ -103,34 +94,23 @@ export async function editProjectSettingsAndroid(
 
   await copy(
     resolve(
-      config.android.platformDirAbs,
-      'app/src/main/java/com/getcapacitor/myapp/MainActivity.java',
+      config.android.srcDirAbs,
+      'java/com/getcapacitor/myapp/MainActivity.java',
     ),
     resolve(newJavaPath, 'MainActivity.java'),
   );
 
   if (appId.split('.')[1] !== 'getcapacitor') {
-    await remove(
-      resolve(
-        config.android.platformDirAbs,
-        'app/src/main/java/com/getcapacitor',
-      ),
-    );
+    await remove(resolve(config.android.srcDirAbs, 'java/com/getcapacitor'));
   }
 
   // Remove our template 'com' folder if their ID doesn't have it
   if (appId.split('.')[0] !== 'com') {
-    await remove(
-      resolve(config.android.platformDirAbs, 'app/src/main/java/com/'),
-    );
+    await remove(resolve(config.android.srcDirAbs, 'java/com/'));
   }
 
   // Update the package in the MainActivity java file
-  const activityPath = resolve(
-    config.android.platformDirAbs,
-    newJavaPath,
-    'MainActivity.java',
-  );
+  const activityPath = resolve(newJavaPath, 'MainActivity.java');
   let activityContent = await readFile(activityPath, { encoding: 'utf-8' });
 
   activityContent = activityContent.replace(
@@ -149,10 +129,7 @@ export async function editProjectSettingsAndroid(
   await writeFile(buildGradlePath, gradleContent, { encoding: 'utf-8' });
 
   // Update the settings in res/values/strings.xml
-  const stringsPath = resolve(
-    config.android.platformDirAbs,
-    'app/src/main/res/values/strings.xml',
-  );
+  const stringsPath = resolve(config.android.resDirAbs, 'values/strings.xml');
   let stringsContent = await readFile(stringsPath, { encoding: 'utf-8' });
   stringsContent = stringsContent.replace(/com.getcapacitor.myapp/g, appId);
   stringsContent = stringsContent.replace(

--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -84,7 +84,7 @@ export async function installGradlePlugins(
   );
 
   const settingsPath = config.android.platformDirAbs;
-  const dependencyPath = join(config.android.platformDirAbs, 'app');
+  const dependencyPath = config.android.appDirAbs;
   const relativeCapcitorAndroidPath = convertToUnixPath(
     relative(settingsPath, capacitorAndroidPath),
   );

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -154,9 +154,12 @@ async function loadAndroidConfig(
   const name = 'android';
   const platformDir = extConfig.android?.path ?? 'android';
   const platformDirAbs = resolve(rootDir, platformDir);
-  const webDir = 'app/src/main/assets/public';
-  const resDir = 'app/src/main/res';
-  const buildOutputDir = 'app/build/outputs/apk/debug';
+  const appDir = 'app';
+  const srcDir = `${appDir}/src/main`;
+  const assetsDir = `${srcDir}/assets`;
+  const webDir = `${assetsDir}/public`;
+  const resDir = `${srcDir}/res`;
+  const buildOutputDir = `${appDir}/build/outputs/apk/debug`;
 
   const templateName = 'android-template';
   const pluginsFolderName = 'capacitor-cordova-android-plugins';
@@ -168,6 +171,12 @@ async function loadAndroidConfig(
     studioPath,
     platformDir,
     platformDirAbs,
+    appDir,
+    appDirAbs: resolve(platformDir, appDir),
+    srcDir,
+    srcDirAbs: resolve(platformDir, srcDir),
+    assetsDir,
+    assetsDirAbs: resolve(platformDir, assetsDir),
     webDir,
     webDirAbs: resolve(platformDir, webDir),
     resDir,
@@ -192,8 +201,9 @@ async function loadIOSConfig(
   const podPath = determineCocoapodPath();
   const platformDir = extConfig.ios?.path ?? 'ios';
   const platformDirAbs = resolve(rootDir, platformDir);
-  const webDir = 'public';
-  const nativeProjectName = 'App';
+  const nativeProjectDir = 'App';
+  const nativeTargetDir = `${nativeProjectDir}/App`;
+  const webDir = `${nativeProjectDir}/public`;
   const templateName = 'ios-template';
   const pluginsFolderName = 'capacitor-cordova-ios-plugins';
 
@@ -203,9 +213,12 @@ async function loadIOSConfig(
     cordovaSwiftVersion: '5.1',
     platformDir,
     platformDirAbs,
+    nativeProjectDir,
+    nativeProjectDirAbs: resolve(platformDir, nativeProjectDir),
+    nativeTargetDir,
+    nativeTargetDirAbs: resolve(platformDir, nativeTargetDir),
     webDir,
-    webDirAbs: resolve(platformDir, nativeProjectName, webDir),
-    nativeProjectName,
+    webDirAbs: resolve(platformDir, webDir),
     assets: {
       templateName,
       pluginsFolderName,

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -214,15 +214,10 @@ export async function autoGenerateConfig(
   cordovaPlugins: Plugin[],
   platform: string,
 ): Promise<void> {
-  const xml2js = await import('xml2js');
   let xmlDir = join(config.android.resDirAbs, 'xml');
   const fileName = 'config.xml';
   if (platform === 'ios') {
-    xmlDir = join(
-      config.ios.platformDirAbs,
-      config.ios.nativeProjectName,
-      config.ios.nativeProjectName,
-    );
+    xmlDir = config.ios.nativeTargetDirAbs;
   }
   await ensureDir(xmlDir);
   const cordovaConfigXMLFile = join(xmlDir, fileName);
@@ -338,12 +333,7 @@ export async function logCordovaManualSteps(
 }
 
 async function logiOSPlist(configElement: any, config: Config, plugin: Plugin) {
-  const plistPath = resolve(
-    config.ios.platformDirAbs,
-    config.ios.nativeProjectName,
-    config.ios.nativeProjectName,
-    'Info.plist',
-  );
+  const plistPath = resolve(config.ios.nativeTargetDirAbs, 'Info.plist');
   const xmlMeta = await readXML(plistPath);
   const data = await readFile(plistPath, { encoding: 'utf-8' });
   const plistData = plist.parse(data) as PlistObject;

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -69,8 +69,14 @@ export interface AppConfig {
 export interface AndroidConfig extends PlatformConfig {
   readonly studioPath: string;
   readonly minVersion: string;
+  readonly appDir: string;
+  readonly appDirAbs: string;
+  readonly srcDir: string;
+  readonly srcDirAbs: string;
   readonly webDir: string;
   readonly webDirAbs: string;
+  readonly assetsDir: string;
+  readonly assetsDirAbs: string;
   readonly resDir: string;
   readonly resDirAbs: string;
   readonly buildOutputDir: string;
@@ -84,7 +90,10 @@ export interface IOSConfig extends PlatformConfig {
   readonly cordovaSwiftVersion: string;
   readonly webDir: string;
   readonly webDirAbs: string;
-  readonly nativeProjectName: string;
+  readonly nativeProjectDir: string;
+  readonly nativeProjectDirAbs: string;
+  readonly nativeTargetDir: string;
+  readonly nativeTargetDirAbs: string;
   readonly assets: PlatformAssetsConfig;
 }
 

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -90,7 +90,7 @@ export async function editProjectSettingsIOS(config: Config): Promise<void> {
   const appId = config.app.appId;
   const appName = config.app.appName;
 
-  const pbxPath = `${config.ios.nativeProjectDirAbs}.xcodeproj/project.pbxproj`;
+  const pbxPath = `${config.ios.nativeTargetDirAbs}.xcodeproj/project.pbxproj`;
   const plistPath = resolve(config.ios.nativeTargetDirAbs, 'Info.plist');
 
   let plistContent = await readFile(plistPath, { encoding: 'utf-8' });

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -12,16 +12,10 @@ import { isInstalled } from '../util/subprocess';
 
 export async function findXcodePath(config: Config): Promise<string | null> {
   try {
-    const files = await readdir(
-      join(config.ios.platformDirAbs, config.ios.nativeProjectName),
-    );
+    const files = await readdir(config.ios.nativeProjectDirAbs);
     const xcodeProject = files.find(file => file.endsWith('.xcworkspace'));
     if (xcodeProject) {
-      return join(
-        config.ios.platformDirAbs,
-        config.ios.nativeProjectName,
-        xcodeProject,
-      );
+      return join(config.ios.nativeProjectDirAbs, xcodeProject);
     }
     return null;
   } catch {
@@ -96,16 +90,8 @@ export async function editProjectSettingsIOS(config: Config): Promise<void> {
   const appId = config.app.appId;
   const appName = config.app.appName;
 
-  const pbxPath = resolve(
-    config.ios.platformDirAbs,
-    config.ios.nativeProjectName,
-    'App.xcodeproj/project.pbxproj',
-  );
-  const plistPath = resolve(
-    config.ios.platformDirAbs,
-    config.ios.nativeProjectName,
-    'App/Info.plist',
-  );
+  const pbxPath = `${config.ios.nativeProjectDirAbs}.xcodeproj/project.pbxproj`;
+  const plistPath = resolve(config.ios.nativeTargetDirAbs, 'Info.plist');
 
   let plistContent = await readFile(plistPath, { encoding: 'utf-8' });
 

--- a/cli/src/ios/run.ts
+++ b/cli/src/ios/run.ts
@@ -42,7 +42,7 @@ export async function runIOS(
 
   await runTask('Running xcodebuild', async () =>
     runCommand('xcrun', ['xcodebuild', ...xcodebuildArgs], {
-      cwd: resolve(config.ios.platformDirAbs, 'App'),
+      cwd: config.ios.nativeProjectDirAbs,
     }),
   );
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -1,5 +1,5 @@
 import { copy, remove, readFile, realpath, writeFile } from '@ionic/utils-fs';
-import { dirname, join, relative, resolve } from 'path';
+import { basename, dirname, join, relative, resolve } from 'path';
 
 import c from '../colors';
 import { checkPlatformVersions, runTask } from '../common';
@@ -81,10 +81,8 @@ async function updatePodfile(
   deployment: boolean,
 ): Promise<void> {
   const dependenciesContent = await generatePodFile(config, plugins);
-  const projectName = config.ios.nativeProjectName;
-  const projectRoot = resolve(config.ios.platformDirAbs, projectName);
-  const podfilePath = join(projectRoot, 'Podfile');
-  const podfileLockPath = join(projectRoot, 'Podfile.lock');
+  const podfilePath = join(config.ios.nativeProjectDirAbs, 'Podfile');
+  const podfileLockPath = join(config.ios.nativeProjectDirAbs, 'Podfile.lock');
   let podfileContent = await readFile(podfilePath, { encoding: 'utf-8' });
   podfileContent = podfileContent.replace(
     /(def capacitor_pods)[\s\S]+?(\nend)/,
@@ -98,14 +96,24 @@ async function updatePodfile(
   if (!deployment) {
     await remove(podfileLockPath);
   }
+
   await runCommand(
     config.ios.podPath,
     ['install', ...(deployment ? ['--deployment'] : [])],
-    { cwd: projectRoot },
+    { cwd: config.ios.nativeProjectDirAbs },
   );
-  await runCommand('xcodebuild', ['-project', 'App.xcodeproj', 'clean'], {
-    cwd: projectRoot,
-  });
+
+  await runCommand(
+    'xcodebuild',
+    [
+      '-project',
+      basename(`${config.ios.nativeTargetDirAbs}.xcodeproj`),
+      'clean',
+    ],
+    {
+      cwd: config.ios.nativeProjectDirAbs,
+    },
+  );
 }
 
 async function generatePodFile(
@@ -124,7 +132,7 @@ async function generatePodFile(
     );
   }
 
-  const podfilePath = join(config.ios.platformDirAbs, 'App');
+  const podfilePath = config.ios.nativeProjectDirAbs;
   const relativeCapacitoriOSPath = convertToUnixPath(
     relative(podfilePath, await realpath(dirname(capacitoriOSPath))),
   );

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -64,23 +64,13 @@ export async function copy(
     if (platformName === config.ios.name) {
       await copyWebDir(config, config.ios.webDirAbs);
       await copyNativeBridge(config.app.rootDir, config.ios.webDirAbs);
-      await copyCapacitorConfig(
-        config,
-        join(
-          config.ios.platformDirAbs,
-          config.ios.nativeProjectName,
-          config.ios.nativeProjectName,
-        ),
-      );
+      await copyCapacitorConfig(config, config.ios.nativeTargetDirAbs);
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
       await handleCordovaPluginsJS(cordovaPlugins, config, platformName);
     } else if (platformName === config.android.name) {
       await copyWebDir(config, config.android.webDirAbs);
       await copyNativeBridge(config.app.rootDir, config.android.webDirAbs);
-      await copyCapacitorConfig(
-        config,
-        join(config.android.platformDirAbs, 'app/src/main/assets'),
-      );
+      await copyCapacitorConfig(config, config.android.assetsDirAbs);
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
       await handleCordovaPluginsJS(cordovaPlugins, config, platformName);
       await writeCordovaAndroidManifest(cordovaPlugins, config, platformName);


### PR DESCRIPTION
We want to rely on the config for file paths as much as possible to reduce hard-coding and open up the CLI to opportunity for configuring these paths in the future.