### PR TITLE
truncate strings before logging them in CAPLog avoid crashing the iOS…

### DIFF
--- a/ios/Capacitor/Capacitor/CAPLog.swift
+++ b/ios/Capacitor/Capacitor/CAPLog.swift
@@ -1,13 +1,18 @@
 public class CAPLog {
 
     public static let config = CAPConfig()
-
+ 
     public static func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {
         if !self.hideLogs() {
             for (itemIndex, item) in items.enumerated() {
-                Swift.print(item, terminator: itemIndex == items.count - 1 ? terminator : separator)
+                Swift.print(loggableString(forItem: item), terminator: itemIndex == items.count - 1 ? terminator : separator)
             }
         }
+    }
+    
+    private static func loggableString(forItem item: Any, maxLenght: Int = 2048) -> String {
+        let string = "\(item)"
+        return String(string.prefix(maxLenght))
     }
 
     public static func hideLogs() -> Bool {
@@ -17,3 +22,4 @@ public class CAPLog {
         return false
     }
 }
+


### PR DESCRIPTION
fixes https://github.com/ionic-team/capacitor/issues/3824