### PR TITLE
chore(ci): remove swiftlint installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - run: brew install swiftlint
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x


### PR DESCRIPTION
SwiftLint is now installed by default: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md