### PR TITLE
chore(iOS): updating bridge protocol

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -70,13 +70,13 @@ import WebKit
  */
 extension CAPBridgeProtocol {
     // variadic parameters cannot be exposed to Obj-C
-    func modulePrint(_ plugin: CAPPlugin, _ items: Any...) {
+    public func modulePrint(_ plugin: CAPPlugin, _ items: Any...) {
         let output = items.map { String(describing: $0) }.joined(separator: " ")
         print(message: output, for: plugin)
     }
 
     // default arguments are not permitted in protocol declarations
-    func alert(_ title: String, _ message: String, _ buttonTitle: String = "OK") {
+    public func alert(_ title: String, _ message: String, _ buttonTitle: String = "OK") {
         showAlertWith(title: title, message: message, buttonTitle: buttonTitle)
     }
 

--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -33,6 +33,9 @@ import WebKit
     @available(iOS 12.0, *)
     @available(*, deprecated, renamed: "userInterfaceStyle")
     func getUserInterfaceStyle() -> UIUserInterfaceStyle
+    
+    @available(*, deprecated, message: "will be moved to config")
+    func getLocalUrl() -> String
 
     // MARK: Call Management
     func getSavedCall(_ callbackId: String) -> CAPPluginCall?

--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -55,9 +55,6 @@ import WebKit
     func triggerDocumentJSEvent(eventName: String)
     func triggerDocumentJSEvent(eventName: String, data: String)
 
-    // MARK: - Logging
-    func print(message: String, for plugin: CAPPlugin)
-
     // MARK: View Presentation
     func showAlertWith(title: String, message: String, buttonTitle: String)
     func presentVC(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
@@ -73,9 +70,10 @@ import WebKit
  */
 extension CAPBridgeProtocol {
     // variadic parameters cannot be exposed to Obj-C
+    @available(*, deprecated, message: "Use CAPLog directly")
     public func modulePrint(_ plugin: CAPPlugin, _ items: Any...) {
         let output = items.map { String(describing: $0) }.joined(separator: " ")
-        print(message: output, for: plugin)
+        CAPLog.print("⚡️ ", plugin.pluginId, "-", output)
     }
 
     // default arguments are not permitted in protocol declarations

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -537,12 +537,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         }
     }
 
-    // MARK: - CAPBridgeProtocol: Logging
-
-    public func print(message: String, for plugin: CAPPlugin) {
-        CAPLog.print("⚡️ ", plugin.pluginId, "-", message)
-    }
-
     // MARK: - CAPBridgeProtocol: View Presentation
 
     @objc public func showAlertWith(title: String, message: String, buttonTitle: String) {

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -136,7 +136,11 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
     public func getUserInterfaceStyle() -> UIUserInterfaceStyle {
         return userInterfaceStyle
     }
-
+    
+    public func getLocalUrl() -> String {
+        return localUrl!
+    }
+    
     @nonobjc public func setStatusBarAnimation(_ animation: UIStatusBarAnimation) {
         statusBarAnimation = animation
     }
@@ -531,10 +535,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                 }
             }
         }
-    }
-
-    public func getLocalUrl() -> String {
-        return localUrl!
     }
 
     // MARK: - CAPBridgeProtocol: Logging


### PR DESCRIPTION
Follow-on branch to #3678, fixing some minor issues in the bridge protocol

- Added `public` access level to extension methods that mistakenly inherited `internal`
- Deprecated `modulePrint` and removed new `print` method from the bridge
- Exposed and deprecated `getLocalUrl` method which will be superseded by a config property in #3759