### PR TITLE
fix: wildcard in allowNavigation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/util/HostMask.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/HostMask.java
@@ -48,7 +48,7 @@ public interface HostMask {
             List<String> hostParts = Util.splitAndReverse(host);
             int hostSize = hostParts.size();
             int maskSize = maskParts.size();
-            if(hostSize != maskSize) {
+            if(maskSize > 1 && hostSize != maskSize) {
                 return false;
             }
 

--- a/android/capacitor/src/test/java/com/getcapacitor/util/HostMaskTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/util/HostMaskTest.java
@@ -17,8 +17,8 @@ public class HostMaskTest {
 
     @Test
     public void testAny() {
-        HostMask mask = HostMask.Any.parse("*", "*.example.org", "example.org");
-        assertTrue(mask.matches("org"));
+        HostMask mask = HostMask.Any.parse("*.example.org", "example.org");
+        assertFalse(mask.matches("org"));
         assertTrue(mask.matches("example.org"));
         assertTrue(mask.matches("www.example.org"));
         assertFalse(mask.matches("imap.mail.example.org"));
@@ -27,6 +27,17 @@ public class HostMaskTest {
         assertFalse(mask.matches(null));
     }
 
+    @Test
+    public void testAnyWildcard() {
+        HostMask mask = HostMask.Any.parse("*");
+        assertTrue(mask.matches("org"));
+        assertTrue(mask.matches("example.org"));
+        assertTrue(mask.matches("www.example.org"));
+        assertTrue(mask.matches("imap.mail.example.org"));
+        assertTrue(mask.matches("another.org"));
+        assertTrue(mask.matches("www.another.org"));
+        assertFalse(mask.matches(null));
+    }
 
     @Test
     public void testSimple() {
@@ -46,7 +57,7 @@ public class HostMaskTest {
     @Test
     public void testSimpleExample2() {
         HostMask mask = HostMask.Simple.parse("*");
-        assertFalse("Single star does not match with 2nd level domain", mask.matches("example.org"));
+        assertTrue("Single star matches everything", mask.matches("example.org"));
     }
 
     @Test

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -424,6 +424,10 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
   }
 
   func matchHost(host: String, pattern: String) -> Bool {
+    if pattern == "*" {
+      return true
+    }
+
     var host = host.split(separator: ".")
     var pattern = pattern.split(separator: ".")
 


### PR DESCRIPTION
Having 
```
"server": {
  "allowNavigation": [
    "*"
  ]
}
```
in `capacitor.config.json` should allow all internal navigation, but it doesn't at the moment.
This PR address it.
