### PR TITLE
fix(android): load local assets when using wildcard on allowNavigation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -173,7 +173,7 @@ public class Bridge {
   }
 
   private void loadWebView() {
-    appUrlConfig = this.config.getString("server.url");
+    appUrlConfig = this.getServerUrl();
     String[] appAllowNavigationConfig = this.config.getArray("server.allowNavigation");
 
     ArrayList<String> authorities = new ArrayList<String>();
@@ -182,7 +182,7 @@ public class Bridge {
     }
     this.appAllowNavigationMask = HostMask.Parser.parse(appAllowNavigationConfig);
 
-    String authority = this.config.getString("server.hostname", "localhost");
+    String authority = this.getHost();
     authorities.add(authority);
 
     String scheme = this.getScheme();
@@ -339,6 +339,22 @@ public class Bridge {
    */
   public String getScheme() {
       return this.config.getString("server.androidScheme", CAPACITOR_HTTP_SCHEME);
+  }
+
+  /**
+   * Get host name that is used to serve content
+   * @return
+   */
+  public String getHost() {
+    return this.config.getString("server.hostname", "localhost");
+  }
+
+  /**
+   * Get the server url that is used to serve content
+   * @return
+   */
+  public String getServerUrl() {
+    return this.config.getString("server.url");
   }
 
   public CapConfig getConfig() {

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -172,7 +172,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(loadingUrl) || loadingUrl.getHost().contains(bridge.getHost()) || (bridge.getServerUrl() == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
+    if (isLocalFile(loadingUrl) || loadingUrl.getHost().equalsIgnoreCase(bridge.getHost()) || (bridge.getServerUrl() == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
       Logger.debug("Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -172,7 +172,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(loadingUrl) || (bridge.getConfig().getString("server.url") == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
+    if (isLocalFile(loadingUrl) || loadingUrl.getHost().contains(bridge.getHost()) || (bridge.getServerUrl() == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
       Logger.debug("Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {


### PR DESCRIPTION
if using 
```
"server": {
  "allowNavigation": [
    "*"
  ]
}
```
The app fails to load the local content



closes https://github.com/ionic-team/capacitor/issues/3809