### PR TITLE
chore: cleanup capacitor manifest

### DIFF
--- a/android/capacitor/src/main/AndroidManifest.xml
+++ b/android/capacitor/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.getcapacitor.android">
-    <uses-feature android:name="android.hardware.camera"
-        android:required="false" />
-
-    <application>
-
-
-    </application>
 </manifest>


### PR DESCRIPTION
application is empty now, so no need to keep it

camera feature is no longer used