### PR TITLE
chore(scripts): add version hook for syncing peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "capacitor",
   "private": true,
   "scripts": {
+    "sync-peer-dependencies": "node scripts/sync-peer-dependencies.mjs",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
     "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- autocorrect --format",
-    "prettier": "prettier \"**/*.{css,html,java,js,ts}\"",
+    "prettier": "prettier \"**/*.{css,html,java,js,mjs,ts}\"",
     "eslint": "eslint . --ext ts",
     "swiftlint": "node-swiftlint",
-    "postinstall": "lerna bootstrap"
+    "postinstall": "lerna bootstrap",
+    "version": "npm run sync-peer-dependencies"
   },
   "husky": {
     "hooks": {

--- a/scripts/lib/cli.mjs
+++ b/scripts/lib/cli.mjs
@@ -1,0 +1,6 @@
+export const execute = fn => {
+  fn().catch(e => {
+    process.stderr.write(e.stack ?? e);
+    process.exit(1);
+  });
+};

--- a/scripts/lib/fn.mjs
+++ b/scripts/lib/fn.mjs
@@ -1,0 +1,2 @@
+export const identity = v => v;
+export const pipe = (...fns) => v => fns.reduce((r, fn) => fn(r), v);

--- a/scripts/lib/fs.mjs
+++ b/scripts/lib/fs.mjs
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+import * as util from 'util';
+
+export const readFile = util.promisify(fs.readFile);
+export const readJSON = async p => JSON.parse(await readFile(p));
+export const writeFile = util.promisify(fs.writeFile);
+export const writeJSON = async (p, contents, space = 2) =>
+  writeFile(p, JSON.stringify(contents, undefined, space) + '\n');

--- a/scripts/lib/lerna.mjs
+++ b/scripts/lib/lerna.mjs
@@ -1,0 +1,14 @@
+import { root } from './repo.mjs';
+import * as cp from './subprocess.mjs';
+
+const stdio = 'inherit';
+const cwd = root;
+
+const execLerna = async command =>
+  await cp.exec(`npx lerna ${command}`, { cwd });
+const runLerna = async (args = []) =>
+  await cp.run('npx', ['lerna', ...args], { cwd, stdio });
+
+export const ls = async () => JSON.parse((await execLerna('ls --json')).stdout);
+export const exec = async (args = []) => await runLerna(['exec', ...args]);
+export const bootstrap = async (args = []) => runLerna(['bootstrap', ...args]);

--- a/scripts/lib/repo.mjs
+++ b/scripts/lib/repo.mjs
@@ -1,0 +1,9 @@
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+import { pipe } from './fn.mjs';
+
+export const root = pipe(
+  fileURLToPath,
+  ...Array(3).fill(dirname),
+)(import.meta.url);

--- a/scripts/lib/subprocess.mjs
+++ b/scripts/lib/subprocess.mjs
@@ -1,0 +1,21 @@
+import * as cp from 'child_process';
+import * as util from 'util';
+
+export const exec = util.promisify(cp.exec);
+export const spawn = cp.spawn;
+export const run = (cmd, args, options) => wait(spawn(cmd, args, options));
+export const wait = async p => {
+  return new Promise((resolve, reject) => {
+    p.on('error', reject);
+
+    p.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(`bad subprocess exit (code=${code}, signal=${signal})`),
+        );
+      }
+    });
+  });
+};

--- a/scripts/lib/version.mjs
+++ b/scripts/lib/version.mjs
@@ -1,0 +1,15 @@
+import { readJSON, writeJSON } from './fs.mjs';
+
+export const setPackageJsonDependencies = async (
+  path,
+  packages,
+  key = 'dependencies',
+) => {
+  const pkg = await readJSON(path);
+
+  for (const [dep, version] of Object.entries(packages)) {
+    pkg[key][dep] = version;
+  }
+
+  await writeJSON(path, pkg);
+};

--- a/scripts/sync-peer-dependencies.mjs
+++ b/scripts/sync-peer-dependencies.mjs
@@ -1,0 +1,28 @@
+import { resolve } from 'path';
+import semver from 'semver';
+
+import { execute } from './lib/cli.mjs';
+import { ls } from './lib/lerna.mjs';
+import { setPackageJsonDependencies } from './lib/version.mjs';
+
+execute(async () => {
+  const CORE_DEPENDENTS = ['@capacitor/android', '@capacitor/ios'];
+  const pkgs = await ls();
+
+  const corePkg = pkgs.find(p => p.name === '@capacitor/core');
+  const { major, minor, prerelease } = semver.parse(corePkg.version);
+
+  const range = `~${major}.${minor}.0${
+    prerelease.length > 0 ? `-${prerelease.join('.')}` : ''
+  }`;
+
+  for (const pkg of pkgs.filter(p => CORE_DEPENDENTS.includes(p.name))) {
+    const p = resolve(pkg.location, 'package.json');
+
+    await setPackageJsonDependencies(
+      p,
+      { '@capacitor/core': range },
+      'peerDependencies',
+    );
+  }
+});


### PR DESCRIPTION
This will automatically keep the version range of `@capacitor/core` in `peerDependencies` up to date as part of the lerna versioning process.