### PR TITLE
fix(android): fixed breaking change to `handleOnActivityResult`

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -928,7 +928,13 @@ public class Bridge {
             plugin.getInstance().saveCall(pluginCallForLastActivity);
         }
 
-        plugin.getInstance().handleOnActivityResult(pluginCallForLastActivity, requestCode, resultCode, data);
+        CapacitorPlugin pluginAnnotation = plugin.getPluginClass().getAnnotation(CapacitorPlugin.class);
+        if (pluginAnnotation != null) {
+            // Use new callback with new @CapacitorPlugin plugins
+            plugin.getInstance().handleOnActivityResult(pluginCallForLastActivity, requestCode, resultCode, data);
+        } else {
+            plugin.getInstance().handleOnActivityResult(requestCode, resultCode, data);
+        }
 
         // Clear the plugin call we may have re-hydrated on app launch
         pluginCallForLastActivity = null;

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -673,6 +673,18 @@ public class Plugin {
     protected void handleOnActivityResult(PluginCall lastPluginCall, int requestCode, int resultCode, Intent data) {}
 
     /**
+     * Handle activity result, should be overridden by each plugin
+     * @deprecated use {@link #handleOnActivityResult(PluginCall, int, int, Intent)} in
+     * conjunction with @CapacitorPlugin
+     *
+     * @param requestCode
+     * @param resultCode
+     * @param data
+     */
+    @Deprecated
+    protected void handleOnActivityResult(int requestCode, int resultCode, Intent data) {}
+
+    /**
      * Handle onNewIntent
      * @param intent
      */


### PR DESCRIPTION
These changes were a breaking change but this should keep existing plugins functional with deprecation instead