### PR TITLE
chore(android-template): Remove init code from MainActivity

### DIFF
--- a/android-template/app/src/main/java/com/getcapacitor/myapp/MainActivity.java
+++ b/android-template/app/src/main/java/com/getcapacitor/myapp/MainActivity.java
@@ -2,6 +2,4 @@ package com.getcapacitor.myapp;
 
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {
-
-}
+public class MainActivity extends BridgeActivity {}

--- a/android-template/app/src/main/java/com/getcapacitor/myapp/MainActivity.java
+++ b/android-template/app/src/main/java/com/getcapacitor/myapp/MainActivity.java
@@ -1,25 +1,7 @@
 package com.getcapacitor.myapp;
 
-import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
-import com.getcapacitor.Plugin;
-import java.util.ArrayList;
 
 public class MainActivity extends BridgeActivity {
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // Initializes the Bridge
-        this.init(
-                savedInstanceState,
-                new ArrayList<Class<? extends Plugin>>() {
-                    {
-                        // Additional plugins you've installed go here
-                        // Ex: add(TotallyAwesomePlugin.class);
-                    }
-                }
-            );
-    }
 }


### PR DESCRIPTION
Since we prefer users to use the automatic plugin detection, better remove the init code from the template.