### PR TITLE
feat(android): support plugin init

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -158,6 +158,8 @@ public class Bridge {
             Splash.showOnLaunch((BridgeActivity) context, this.config);
         }
 
+        this.initPlugins();
+
         // Initialize web view and message handler for it
         this.initWebView();
         this.msgHandler = new MessageHandler(this, webView, pluginManager);
@@ -166,9 +168,7 @@ public class Bridge {
         Intent intent = context.getIntent();
         this.intentUri = intent.getData();
 
-        // Register our core plugins
-        this.registerAllPlugins();
-
+        this.loadPlugins();
         this.loadWebView();
     }
 
@@ -229,6 +229,12 @@ public class Bridge {
         }
         // Get to work
         webView.loadUrl(appUrl);
+    }
+
+    private void loadPlugins() {
+        for (PluginHandle plugin : plugins.values()) {
+            plugin.load(this);
+        }
     }
 
     public boolean launchIntent(Uri url) {
@@ -421,7 +427,7 @@ public class Bridge {
     /**
      * Register our core Plugin APIs
      */
-    private void registerAllPlugins() {
+    private void initPlugins() {
         this.registerPlugin(SplashScreen.class);
         this.registerPlugin(com.getcapacitor.plugin.WebView.class);
 
@@ -471,7 +477,7 @@ public class Bridge {
         Logger.debug("Registering plugin: " + pluginId);
 
         try {
-            this.plugins.put(pluginId, new PluginHandle(this, pluginClass));
+            this.plugins.put(pluginId, new PluginHandle(pluginClass));
         } catch (InvalidPluginException ex) {
             Logger.error(
                 "NativePlugin " +
@@ -561,7 +567,7 @@ public class Bridge {
                     if (call.isSaved()) {
                         saveCall(call);
                     }
-                } catch (PluginLoadException | InvalidPluginMethodException ex) {
+                } catch (InvalidPluginMethodException ex) {
                     Logger.error("Unable to execute plugin method", ex);
                 } catch (Exception ex) {
                     Logger.error("Serious error executing plugin", ex);

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -477,7 +477,9 @@ public class Bridge {
         Logger.debug("Registering plugin: " + pluginId);
 
         try {
-            this.plugins.put(pluginId, new PluginHandle(pluginClass));
+            PluginHandle handle = new PluginHandle(pluginClass);
+            this.plugins.put(pluginId, handle);
+            handle.init(getActivity());
         } catch (InvalidPluginException ex) {
             Logger.error(
                 "NativePlugin " +

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -479,7 +479,7 @@ public class Bridge {
         try {
             PluginHandle handle = new PluginHandle(pluginClass);
             this.plugins.put(pluginId, handle);
-            handle.init(getActivity());
+            handle.init(this);
         } catch (InvalidPluginException ex) {
             Logger.error(
                 "NativePlugin " +

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -109,7 +109,7 @@ public class Plugin {
      * as indexed methods for reflection, and {@link CapacitorPlugin} annotation data).
      * @param pluginHandle
      */
-    public void setPluginHandle(PluginHandle pluginHandle) {
+    void setPluginHandle(PluginHandle pluginHandle) {
         this.handle = pluginHandle;
     }
 
@@ -120,7 +120,7 @@ public class Plugin {
      * such as indexed methods for reflection, and {@link CapacitorPlugin} annotation data).
      * @return
      */
-    public PluginHandle getPluginHandle() {
+    PluginHandle getPluginHandle() {
         return this.handle;
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
@@ -1,5 +1,6 @@
 package com.getcapacitor;
 
+import androidx.appcompat.app.AppCompatActivity;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -16,6 +17,7 @@ class PluginHandle {
     private final Class<? extends Plugin> pluginClass;
 
     private Map<String, PluginMethodHandle> pluginMethods = new HashMap<>();
+    private Method initMethod = null;
 
     private final String pluginId;
 
@@ -86,6 +88,16 @@ class PluginHandle {
         return this.pluginMethods.values();
     }
 
+    public void init(AppCompatActivity activity) {
+        if (initMethod != null) {
+            try {
+                initMethod.invoke(null, activity);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                // ignore
+            }
+        }
+    }
+
     public void load(Bridge bridge) {
         this.instance.setBridge(bridge);
         this.instance.load();
@@ -116,6 +128,10 @@ class PluginHandle {
         Method[] methods = pluginClass.getMethods();
 
         for (Method methodReflect : methods) {
+            if (methodReflect.getName().equals("init")) {
+                initMethod = methodReflect;
+            }
+
             PluginMethod method = methodReflect.getAnnotation(PluginMethod.class);
 
             if (method == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginHandle.java
@@ -88,10 +88,10 @@ class PluginHandle {
         return this.pluginMethods.values();
     }
 
-    public void init(AppCompatActivity activity) {
+    public void init(Bridge bridge) {
         if (initMethod != null) {
             try {
-                initMethod.invoke(null, activity);
+                initMethod.invoke(null, bridge);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 // ignore
             }

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginMethodHandle.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginMethodHandle.java
@@ -2,7 +2,7 @@ package com.getcapacitor;
 
 import java.lang.reflect.Method;
 
-public class PluginMethodHandle {
+class PluginMethodHandle {
 
     // The reflect method reference
     private final Method method;


### PR DESCRIPTION
To support an alternative to https://github.com/ionic-team/capacitor/pull/3914

Plugins can add the following static method which will get called during plugin initialization:

```java
public static void init(Bridge bridge) {
    // do things
}
```

The splash screen plugin's would look like this:

```java
public static void init(Bridge bridge) {
    Splash.showOnLaunch(bridge.getActivity(), bridge.getConfig());
}
```

This is a "breaking change" in that it restricts `PluginHandle` and `PluginMethodHandle` to package-only visibility, not `public`.