### PR TITLE
fix(ios): avoid crash on portrait apps after taking a photo

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -564,10 +564,6 @@ public class CAPBridgeViewController: UIViewController, CAPBridgeDelegate, WKScr
     }
   }
 
-  override open var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-    return UIApplication.shared.statusBarOrientation
-  }
-
   override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     var ret = 0
     if self.supportedOrientations.contains(UIInterfaceOrientation.portrait.rawValue) {


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor/issues/3910

supposedly the `preferredInterfaceOrientationForPresentation` override is not needed, according to the docs

> If you do not implement this method, the system presents the view controller using the current orientation of the status bar.

and that's what our code does, but it crash on portrait only apps after taking a picture. Letting the view controller do its default doesn't crash.

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621438-preferredinterfaceorientationfor