### PR TITLE
feat(android): add onConfigurationChanged() activity lifecycle hook

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
@@ -959,6 +960,16 @@ public class Bridge {
 
         if (cordovaWebView != null) {
             cordovaWebView.onNewIntent(intent);
+        }
+    }
+
+    /**
+     * Handle an onConfigurationChanged event and notify the plugins
+     * @param newConfig
+     */
+    public void onConfigurationChanged(Configuration newConfig) {
+        for (PluginHandle plugin : plugins.values()) {
+            plugin.getInstance().handleOnConfigurationChanged(newConfig);
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -199,10 +199,12 @@ public class BridgeActivity extends AppCompatActivity {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
         if (this.bridge == null) {
             return;
         }
 
-        this.bridge.onActivityResult(requestCode, resultCode, data);
+        this.bridge.onConfigurationChanged(newConfig);
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -1,6 +1,7 @@
 package com.getcapacitor;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import com.getcapacitor.android.R;
@@ -194,5 +195,14 @@ public class BridgeActivity extends AppCompatActivity {
         }
 
         this.bridge.onBackPressed();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        if (this.bridge == null) {
+            return;
+        }
+
+        this.bridge.onActivityResult(requestCode, resultCode, data);
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
@@ -689,6 +690,12 @@ public class Plugin {
      * @param intent
      */
     protected void handleOnNewIntent(Intent intent) {}
+
+    /**
+     * Handle onConfigurationChanged
+     * @param newConfig
+     */
+    protected void handleOnConfigurationChanged(Configuration newConfig) {}
 
     /**
      * Handle onStart


### PR DESCRIPTION
Called whenever one of the configurations in `android:configChanges` changes.

ref: https://developer.android.com/guide/topics/resources/runtime-changes#HandlingTheChange

resolves https://github.com/ionic-team/capacitor/issues/3535