### PR TITLE
fix(Android): Use plugin's getPermissionStates() to support overriding

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -788,7 +788,7 @@ public class Bridge {
                 if (validatePermissions(plugin.getInstance(), savedPermissionCall, permissions, grantResults)) {
                     // handle request permissions call
                     if (savedPermissionCall.getMethodName().equals("requestPermissions")) {
-                        savedPermissionCall.resolve(getPermissionStates(plugin.getInstance()));
+                        savedPermissionCall.resolve(plugin.getInstance().getPermissionStates());
                     } else {
                         // handle permission requests by other methods on the plugin
                         plugin.getInstance().onRequestPermissionsResult(savedPermissionCall, requestCode, permissions, grantResults);

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -493,7 +493,7 @@ public class Plugin {
      */
     @PluginMethod
     public void checkPermissions(PluginCall pluginCall) {
-        JSObject permissionsResult = bridge.getPermissionStates(this);
+        JSObject permissionsResult = getPermissionStates();
 
         if (permissionsResult.length() == 0) {
             // if no permissions are defined on the plugin, resolve undefined


### PR DESCRIPTION
Ensures that the `getPermissionStates` method is called against the Plugin in case a plugin author has override it to manipulate the states.

Alternative to: https://github.com/ionic-team/capacitor/pull/3911