### PR TITLE
chore(cli): rename STUDIO_PATH to CAPACITOR_ANDROID_STUDIO_PATH

### DIFF
--- a/cli/src/android/open.ts
+++ b/cli/src/android/open.ts
@@ -30,7 +30,7 @@ export async function openAndroid(config: Config): Promise<void> {
           androidStudioPath,
         )}\n` +
         `You can configure this with the ${c.input(
-          'STUDIO_PATH',
+          'CAPACITOR_ANDROID_STUDIO_PATH',
         )} environment variable.`,
     );
   }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -287,8 +287,8 @@ function determineOS(os: NodeJS.Platform): OS {
 }
 
 async function determineAndroidStudioPath(os: OS): Promise<string> {
-  if (process.env.STUDIO_PATH) {
-    return process.env.STUDIO_PATH;
+  if (process.env.CAPACITOR_ANDROID_STUDIO_PATH) {
+    return process.env.CAPACITOR_ANDROID_STUDIO_PATH;
   }
 
   switch (os) {


### PR DESCRIPTION
To be more consistent with the other environment variable: `CAPACITOR_COCOAPODS_PATH`. 