### PR TITLE
chore(cli): remove default SplashScreen launchShowDuration value

### DIFF
--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -144,8 +144,7 @@ async function mergeConfig(
       ...oldConfig,
       ...extConfig,
       ...{
-        plugins: extConfig.plugins ??
-          oldConfig.plugins,
+        plugins: extConfig.plugins ?? oldConfig.plugins,
       },
     },
     { spaces: 2 },

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -145,7 +145,7 @@ async function mergeConfig(
       ...extConfig,
       ...{
         plugins: extConfig.plugins ??
-          oldConfig.plugins ?? { SplashScreen: { launchShowDuration: 0 } },
+          oldConfig.plugins,
       },
     },
     { spaces: 2 },

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -143,9 +143,6 @@ async function mergeConfig(
     {
       ...oldConfig,
       ...extConfig,
-      ...{
-        plugins: extConfig.plugins ?? oldConfig.plugins,
-      },
     },
     { spaces: 2 },
   );


### PR DESCRIPTION
Max wanted launchShowDuration value to be 0, but we couldn't do it in the middle of v2 as it was a breaking change, so we added this setting for new apps.

For the new SplashScreen plugin I'm making the default value 0, so the CLI don't need to add the value anymore.
