### PR TITLE
fix(android): builder and config refactoring

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -150,7 +150,7 @@ public class Bridge {
         handlerThread.start();
         taskHandler = new Handler(handlerThread.getLooper());
 
-        this.config = config != null ? config : CapConfig.fromFile(getActivity());
+        this.config = config != null ? config : CapConfig.loadDefault(getActivity());
         Logger.init(this.config);
 
         // Initialize web view and message handler for it
@@ -1112,7 +1112,7 @@ public class Bridge {
         this.webViewClient = client;
     }
 
-    public static class Builder {
+    static class Builder {
 
         private Bundle instanceState = null;
         private CapConfig config = null;
@@ -1121,11 +1121,10 @@ public class Bridge {
         private Context context = null;
         private WebView webView = null;
 
-        protected Builder setActivity(AppCompatActivity activity) {
+        Builder(AppCompatActivity activity) {
             this.activity = activity;
             this.context = activity.getApplicationContext();
             this.webView = activity.findViewById(R.id.webview);
-            return this;
         }
 
         public Builder setInstanceState(Bundle instanceState) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1117,14 +1117,10 @@ public class Bridge {
         private Bundle instanceState = null;
         private CapConfig config = null;
         private List<Class<? extends Plugin>> plugins = new ArrayList<>();
-        private AppCompatActivity activity = null;
-        private Context context = null;
-        private WebView webView = null;
+        private final AppCompatActivity activity;
 
         Builder(AppCompatActivity activity) {
             this.activity = activity;
-            this.context = activity.getApplicationContext();
-            this.webView = activity.findViewById(R.id.webview);
         }
 
         public Builder setInstanceState(Bundle instanceState) {
@@ -1158,15 +1154,18 @@ public class Bridge {
         public Bridge create() {
             // Cordova initialization
             ConfigXmlParser parser = new ConfigXmlParser();
-            parser.parse(context);
+            parser.parse(activity.getApplicationContext());
             CordovaPreferences preferences = parser.getPreferences();
             preferences.setPreferencesBundle(activity.getIntent().getExtras());
             List<PluginEntry> pluginEntries = parser.getPluginEntries();
+
             MockCordovaInterfaceImpl cordovaInterface = new MockCordovaInterfaceImpl(activity);
             if (instanceState != null) {
                 cordovaInterface.restoreInstanceState(instanceState);
             }
-            MockCordovaWebViewImpl mockWebView = new MockCordovaWebViewImpl(context);
+
+            WebView webView = activity.findViewById(R.id.webview);
+            MockCordovaWebViewImpl mockWebView = new MockCordovaWebViewImpl(activity.getApplicationContext());
             mockWebView.init(cordovaInterface, pluginEntries, preferences, webView);
             PluginManager pluginManager = mockWebView.getPluginManager();
             cordovaInterface.onCordovaInit(pluginManager);

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -16,7 +16,7 @@ public class BridgeActivity extends AppCompatActivity {
 
     private int activityDepth = 0;
     private List<Class<? extends Plugin>> initialPlugins = new ArrayList<>();
-    private final Bridge.Builder bridgeBuilder = new Bridge.Builder();
+    private final Bridge.Builder bridgeBuilder = new Bridge.Builder(this);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,7 +70,7 @@ public class BridgeActivity extends AppCompatActivity {
 
         Logger.debug("Starting BridgeActivity");
 
-        bridge = bridgeBuilder.setActivity(this).addPlugins(initialPlugins).setConfig(config).create();
+        bridge = bridgeBuilder.addPlugins(initialPlugins).setConfig(config).create();
 
         this.keepRunning = bridge.shouldKeepRunning();
         this.onNewIntent(getIntent());

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeFragment.java
@@ -69,8 +69,7 @@ public class BridgeFragment extends Fragment {
         }
 
         bridge =
-            new Bridge.Builder()
-                .setActivity((AppCompatActivity) getActivity())
+            new Bridge.Builder((AppCompatActivity) getActivity())
                 .setInstanceState(savedInstanceState)
                 .setPlugins(initialPlugins)
                 .setConfig(config)

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -5,6 +5,7 @@ import static com.getcapacitor.FileUtils.readFile;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
+import android.content.res.AssetManager;
 import com.getcapacitor.util.JSONUtils;
 import java.io.IOException;
 import java.util.HashMap;
@@ -46,12 +47,33 @@ public class CapConfig {
     private CapConfig() {}
 
     /**
-     * Constructs a Capacitor Configuration from config.json file.
+     * Get an instance of the Config file object.
+     * @deprecated use {@link #loadDefault(Context)} to load an instance of the Config object
+     * from the capacitor.config.json file, or use the {@link CapConfig.Builder} to construct
+     * a CapConfig for embedded use.
      *
-     * @param context The context.
-     * @return A loaded config file, if successful.
+     * @param assetManager The AssetManager used to load the config file
+     * @param config JSON describing a configuration to use
      */
-    static CapConfig fromFile(Context context) {
+    @Deprecated
+    public CapConfig(AssetManager assetManager, JSONObject config) {
+        if (config != null) {
+            this.configJSON = config;
+        } else {
+            // Load the capacitor.config.json
+            loadConfig(assetManager);
+        }
+
+        deserializeConfig(null);
+    }
+
+    /**
+     * Constructs a Capacitor Configuration from the capacitor.config.json file.
+     *
+     * @param context The context
+     * @return A loaded config file, if successful
+     */
+    public static CapConfig loadDefault(Context context) {
         CapConfig config = new CapConfig();
 
         if (context == null) {
@@ -59,7 +81,7 @@ public class CapConfig {
             return config;
         }
 
-        config.loadConfig(context);
+        config.loadConfig(context.getAssets());
         config.deserializeConfig(context);
         return config;
     }
@@ -93,9 +115,9 @@ public class CapConfig {
     /**
      * Loads a Capacitor Configuration JSON file into a Capacitor Configuration object.
      */
-    private void loadConfig(Context context) {
+    private void loadConfig(AssetManager assetManager) {
         try {
-            String jsonString = readFile(context, "capacitor.config.json");
+            String jsonString = readFile(assetManager, "capacitor.config.json");
             configJSON = new JSONObject(jsonString);
         } catch (IOException ex) {
             Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);
@@ -130,7 +152,7 @@ public class CapConfig {
             );
         captureInput = JSONUtils.getBoolean(configJSON, "android.captureInput", captureInput);
         hideLogs = JSONUtils.getBoolean(configJSON, "android.hideLogs", JSONUtils.getBoolean(configJSON, "hideLogs", hideLogs));
-        webContentsDebuggingEnabled = (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+        webContentsDebuggingEnabled = context != null && (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
         webContentsDebuggingEnabled = JSONUtils.getBoolean(configJSON, "android.webContentsDebuggingEnabled", webContentsDebuggingEnabled);
 
         // Plugins
@@ -323,6 +345,8 @@ public class CapConfig {
      */
     public static class Builder {
 
+        private Context context;
+
         // Server Config Values
         private boolean html5mode = true;
         private String serverUrl;
@@ -336,11 +360,20 @@ public class CapConfig {
         private String backgroundColor;
         private boolean allowMixedContent = false;
         private boolean captureInput = false;
-        private boolean webContentsDebuggingEnabled = false;
+        private Boolean webContentsDebuggingEnabled = null;
         private boolean hideLogs = false;
 
         // Plugins Config Object
         private Map<String, PluginConfig> pluginsConfiguration = new HashMap<>();
+
+        /**
+         * Constructs a new CapConfig Builder.
+         *
+         * @param context The context
+         */
+        public Builder(Context context) {
+            this.context = context;
+        }
 
         /**
          * Builds a Capacitor Config from the builder.
@@ -348,6 +381,10 @@ public class CapConfig {
          * @return A new Capacitor Config
          */
         public CapConfig create() {
+            if (webContentsDebuggingEnabled == null) {
+                webContentsDebuggingEnabled = (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+            }
+
             return new CapConfig(this);
         }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -18,7 +18,7 @@ public class CapacitorWebView extends WebView {
 
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        CapConfig config = CapConfig.fromFile(getContext());
+        CapConfig config = CapConfig.loadDefault(getContext());
         boolean captureInput = config.isInputCaptured();
         if (captureInput) {
             if (capInputConnection == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -27,6 +27,7 @@ package com.getcapacitor;
 
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
@@ -138,13 +139,13 @@ public class FileUtils {
     /**
      * Read a plaintext file.
      *
-     * @param context Used to get access to the asset manager to open the file.
+     * @param assetManager Used to open the file.
      * @param fileName The path of the file to read.
      * @return The contents of the file path.
      * @throws IOException Thrown if any issues reading the provided file path.
      */
-    static String readFile(Context context, String fileName) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(fileName)))) {
+    static String readFile(AssetManager assetManager, String fileName) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(assetManager.open(fileName)))) {
             StringBuffer buffer = new StringBuffer();
             String line;
             while ((line = reader.readLine()) != null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -21,7 +21,7 @@ public class JSExport {
     public static String getCordovaJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context, "public/cordova.js");
+            fileContent = readFile(context.getAssets(), "public/cordova.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova.js file, Cordova plugins will not work");
         }
@@ -31,7 +31,7 @@ public class JSExport {
     public static String getCordovaPluginsFileJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context, "public/cordova_plugins.js");
+            fileContent = readFile(context.getAssets(), "public/cordova_plugins.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
         }
@@ -87,7 +87,7 @@ public class JSExport {
                     builder.append(getFilesContent(context, path + "/" + file));
                 }
             } else {
-                return readFile(context, path);
+                return readFile(context.getAssets(), path);
             }
         } catch (IOException ex) {
             Logger.error("Unable to read file at path " + path);

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -1,15 +1,21 @@
 package com.getcapacitor;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
+import android.app.Activity;
+import android.content.pm.ApplicationInfo;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ConfigBuildingTest {
 
     final String TEST_PLUGIN_NAME = "TestPlugin";
+
+    Activity context = Mockito.mock(Activity.class);
 
     JSONObject pluginConfig = new JSONObject();
     JSONObject testPluginObject = new JSONObject();
@@ -37,7 +43,7 @@ public class ConfigBuildingTest {
             pluginConfig.put(TEST_PLUGIN_NAME, testPluginObject);
 
             config =
-                new CapConfig.Builder()
+                new CapConfig.Builder(context)
                     .setAllowMixedContent(true)
                     .setAllowNavigation(new String[] { "http://www.google.com" })
                     .setAndroidScheme("test")

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigReadingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigReadingTest.java
@@ -44,7 +44,7 @@ public class ConfigReadingTest {
         try {
             when(assetManager.open("capacitor.config.json")).thenReturn(getTestInputStream(BAD_TEST));
 
-            CapConfig config = CapConfig.fromFile(context);
+            CapConfig config = CapConfig.loadDefault(context);
             assertEquals("not a real domain", config.getServerUrl());
             assertNull(config.getBackgroundColor());
             assertFalse(config.isLogsHidden());
@@ -58,7 +58,7 @@ public class ConfigReadingTest {
         try {
             when(assetManager.open("capacitor.config.json")).thenReturn(getTestInputStream(FLAT_TEST));
 
-            CapConfig config = CapConfig.fromFile(context);
+            CapConfig config = CapConfig.loadDefault(context);
             assertEquals("level 1 override", config.getOverriddenUserAgentString());
             assertEquals("level 1 append", config.getAppendedUserAgentString());
             assertEquals("#ffffff", config.getBackgroundColor());
@@ -74,7 +74,7 @@ public class ConfigReadingTest {
         try {
             when(assetManager.open("capacitor.config.json")).thenReturn(getTestInputStream(HIERARCHY_TEST));
 
-            CapConfig config = CapConfig.fromFile(context);
+            CapConfig config = CapConfig.loadDefault(context);
             assertEquals("level 2 override", config.getOverriddenUserAgentString());
             assertEquals("level 2 append", config.getAppendedUserAgentString());
             assertEquals("#000000", config.getBackgroundColor());
@@ -92,7 +92,7 @@ public class ConfigReadingTest {
             when(assetManager.open("capacitor.config.json")).thenReturn(getTestInputStream(NONJSON_TEST));
 
             try (MockedStatic<Logger> logger = mockStatic(Logger.class)) {
-                CapConfig config = CapConfig.fromFile(context);
+                CapConfig config = CapConfig.loadDefault(context);
                 logger.verify(times(1), () -> Logger.error(eq(errText), any()));
             }
         } catch (IOException e) {
@@ -105,7 +105,7 @@ public class ConfigReadingTest {
         try {
             when(assetManager.open("capacitor.config.json")).thenReturn(getTestInputStream(SERVER_TEST));
 
-            CapConfig config = CapConfig.fromFile(context);
+            CapConfig config = CapConfig.loadDefault(context);
             assertEquals("myhost", config.getHostname());
             assertEquals("http://192.168.100.1:2057", config.getServerUrl());
             assertEquals("override", config.getAndroidScheme());


### PR DESCRIPTION
- Restored old `CapConfig` constructor and deprecated instead (prevents breakage when used in broadcast receivers)
- Refactored `Bridge.Builder` and `CapConfig.Builder` to have a constructor for required items
- Reduced visibility of `Bridge.Builder` to package only
- `FileUtils.readFile()` requires AssetManager instead of a full `Config` object
