### PR TITLE
refactor(android): readFile now takes an AssetManager instead of a full Context object

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -95,7 +95,7 @@ public class CapConfig {
      */
     private void loadConfig(Context context) {
         try {
-            String jsonString = readFile(context, "capacitor.config.json");
+            String jsonString = readFile(context.getAssets(), "capacitor.config.json");
             configJSON = new JSONObject(jsonString);
         } catch (IOException ex) {
             Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -5,6 +5,7 @@ import static com.getcapacitor.FileUtils.readFile;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
+import android.content.res.AssetManager;
 import com.getcapacitor.util.JSONUtils;
 import java.io.IOException;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class CapConfig {
             return config;
         }
 
-        config.loadConfig(context);
+        config.loadConfig(context.getAssets());
         config.deserializeConfig(context);
         return config;
     }
@@ -93,9 +94,9 @@ public class CapConfig {
     /**
      * Loads a Capacitor Configuration JSON file into a Capacitor Configuration object.
      */
-    private void loadConfig(Context context) {
+    private void loadConfig(AssetManager assetManager) {
         try {
-            String jsonString = readFile(context.getAssets(), "capacitor.config.json");
+            String jsonString = readFile(assetManager, "capacitor.config.json");
             configJSON = new JSONObject(jsonString);
         } catch (IOException ex) {
             Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -27,6 +27,7 @@ package com.getcapacitor;
 
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
@@ -138,13 +139,13 @@ public class FileUtils {
     /**
      * Read a plaintext file.
      *
-     * @param context Used to get access to the asset manager to open the file.
+     * @param assetManager Used to open the file.
      * @param fileName The path of the file to read.
      * @return The contents of the file path.
      * @throws IOException Thrown if any issues reading the provided file path.
      */
-    static String readFile(Context context, String fileName) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(context.getAssets().open(fileName)))) {
+    static String readFile(AssetManager assetManager, String fileName) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(assetManager.open(fileName)))) {
             StringBuffer buffer = new StringBuffer();
             String line;
             while ((line = reader.readLine()) != null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -21,7 +21,7 @@ public class JSExport {
     public static String getCordovaJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context, "public/cordova.js");
+            fileContent = readFile(context.getAssets(), "public/cordova.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova.js file, Cordova plugins will not work");
         }
@@ -31,7 +31,7 @@ public class JSExport {
     public static String getCordovaPluginsFileJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context, "public/cordova_plugins.js");
+            fileContent = readFile(context.getAssets(), "public/cordova_plugins.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
         }
@@ -87,7 +87,7 @@ public class JSExport {
                     builder.append(getFilesContent(context, path + "/" + file));
                 }
             } else {
-                return readFile(context, path);
+                return readFile(context.getAssets(), path);
             }
         } catch (IOException ex) {
             Logger.error("Unable to read file at path " + path);


### PR DESCRIPTION
A full context is not required for this, only an AssetManager is really needed. This allows the helper to be used when a Context isn't available.