### PR TITLE
refactor(android): reduce access of Bridge.Builder to Package Private

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1112,7 +1112,7 @@ public class Bridge {
         this.webViewClient = client;
     }
 
-    public static class Builder {
+    static class Builder {
 
         private Bundle instanceState = null;
         private CapConfig config = null;


### PR DESCRIPTION
Shouldn't need to be public