### PR TITLE
chore: bump targetSdkVersion and compileSdkVersion to 30

### DIFF
--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 21
-    compileSdkVersion = 29
-    targetSdkVersion = 29
+    compileSdkVersion = 30
+    targetSdkVersion = 30
     androidxAppCompatVersion = '1.1.0'
     androidxCoreVersion =  '1.2.0'
     androidxMaterialVersion =  '1.1.0-rc02'

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -24,10 +24,10 @@ tasks.withType(Javadoc).all { enabled = false }
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 29
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 30
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 29
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -1,6 +1,7 @@
 package com.getcapacitor;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
@@ -357,6 +358,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         }
     }
 
+    @SuppressLint("QueryPermissionsNeeded")
     private boolean showImageCapturePicker(final ValueCallback<Uri[]> filePathCallback) {
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (takePictureIntent.resolveActivity(bridge.getActivity().getPackageManager()) == null) {
@@ -390,6 +392,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         return true;
     }
 
+    @SuppressLint("QueryPermissionsNeeded")
     private boolean showVideoCapturePicker(final ValueCallback<Uri[]> filePathCallback) {
         Intent takeVideoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
         if (takeVideoIntent.resolveActivity(bridge.getActivity().getPackageManager()) == null) {

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 29
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 30
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
-        targetSdkVersion targetSdkVersion = project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 29
+        targetSdkVersion targetSdkVersion = project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 30
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
in variables.gradle, capacitor and capacitor-cordova-android-plugins

Added QueryPermissionsNeeded lint suppress because that it used for input file and getUserMedia, but most users won't use it, so adding intent queries on Capacitor's manifest wouldn't be a good idea.

But we would need to document somewhere that for Android 11, users need to add those queries if using input file and/or getUserMedia (not sure where would be the better place for that)
