### PR TITLE
chore: drop cordovaSwiftVersion config option

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -244,7 +244,6 @@ async function loadIOSConfig(
   return {
     name,
     minVersion: '12.0',
-    cordovaSwiftVersion: '5.1',
     platformDir,
     platformDirAbs,
     cordovaPluginsDir,

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -230,14 +230,6 @@ export interface CapacitorConfig {
     scrollEnabled?: boolean;
 
     /**
-     * Configure the Swift version to be used in Cordova plugins.
-     *
-     * @since 1.0.0
-     * @default 5.1
-     */
-    cordovaSwiftVersion?: string;
-
-    /**
      * Configure the minimum iOS version supported.
      *
      * @since 1.0.0

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -96,7 +96,6 @@ export interface IOSConfig extends PlatformConfig {
   readonly cordovaPluginsDirAbs: string;
   readonly minVersion: string;
   readonly podPath: string;
-  readonly cordovaSwiftVersion: string;
   readonly webDir: string;
   readonly webDirAbs: string;
   readonly nativeProjectDir: string;

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -350,7 +350,7 @@ async function generateCordovaPodspec(
     s.ios.deployment_target  = '${config.ios.minVersion}'
     s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) COCOAPODS=1 WK_WEB_VIEW_ONLY=1' }
     s.dependency 'CapacitorCordova'${getLinkerFlags(config)}
-    s.swift_version  = '${config.ios.cordovaSwiftVersion}'
+    s.swift_version  = '5.1'
     ${frameworksString}
   end`;
   await writeFile(


### PR DESCRIPTION
`cordovaSwiftVersion` was added because in the old days each Swift version was incompatible with the previous ones and a lot of plugins were not updated to latest available Swift version.

At the moment, Xcode 12 only supports Swift 4.2 and Swift 5, and Swift 4.2 code should still compile if set a Swift 5. And even if it didn't, the plugin authors will probably update the plugin at some point, if it reached 4.2 it's probably still maintained.

Old Cordova plugins that use Swift 2/3 won't work on Capacitor apps anymore, but that's not because of Capacitor, but because of Xcode not being able to use older versions (won't work on Cordova apps neither), so the `cordovaSwiftVersion` doesn't make much sense anymore.