### PR TITLE
fix(cli): run an actual debug build for iOS

### DIFF
--- a/cli/src/ios/run.ts
+++ b/cli/src/ios/run.ts
@@ -31,7 +31,7 @@ export async function runIOS(
     '-scheme',
     'App',
     '-configuration',
-    'debug',
+    'Debug',
     '-destination',
     `id=${target.id}`,
     '-derivedDataPath',
@@ -50,7 +50,7 @@ export async function runIOS(
   const appPath = resolve(
     derivedDataPath,
     'Build/Products',
-    target.virtual ? 'Release-iphonesimulator' : 'Release-iphoneos',
+    target.virtual ? 'Debug-iphonesimulator' : 'Debug-iphoneos',
     appName,
   );
 


### PR DESCRIPTION
The CLI had a typo on the `-configuration` parameter.