### PR TITLE
fix(android): always inject js script

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -75,7 +75,7 @@ class JSInjector {
         } else if (html.contains("</head>")) {
             html = html.replace("</head>", js + "\n" + "</head>");
         } else {
-            Logger.error("Unable to inject Capacitor, Plugins won't work");
+            html = js + "\n" + html;
         }
         return new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
While unlikely, it's still possible to have an html file without a head element. Instead of not working at all, fallback to adding the script before all of the html.