### PR TITLE
refactor(cli): use exceptions for fatal errors, not process.exit()

### DIFF
--- a/cli/src/android/doctor.ts
+++ b/cli/src/android/doctor.ts
@@ -5,7 +5,8 @@ import { join } from 'path';
 import c from '../colors';
 import { check } from '../common';
 import type { Config } from '../definitions';
-import { logFatal, logSuccess } from '../log';
+import { fatal, isFatal } from '../errors';
+import { logSuccess } from '../log';
 import { readXML } from '../util/xml';
 
 export async function doctorAndroid(config: Config): Promise<void> {
@@ -17,7 +18,11 @@ export async function doctorAndroid(config: Config): Promise<void> {
     ]);
     logSuccess('Android looking great! 👌');
   } catch (e) {
-    logFatal(e.stack ?? e);
+    if (!isFatal(e)) {
+      fatal(e.stack ?? e);
+    }
+
+    throw e;
   }
 }
 

--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -18,7 +18,7 @@ import {
   writeCordovaAndroidManifest,
 } from '../cordova';
 import type { Config } from '../definitions';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 import type { Plugin } from '../plugin';
 import {
   PluginType,
@@ -143,7 +143,7 @@ async function findAndroidPluginClassesInPlugin(
           );
 
           if (!packageMatch) {
-            logFatal(
+            fatal(
               `Package could not be parsed from Android plugin.\n` +
                 `Location: ${c.strong(srcFile)}`,
             );
@@ -177,7 +177,7 @@ export async function installGradlePlugins(
     'package.json',
   );
   if (!capacitorAndroidPackagePath) {
-    logFatal(
+    fatal(
       `Unable to find node_modules/@capacitor/android\n` +
         `Are you sure ${c.strong('@capacitor/android')} is installed?`,
     );

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -3,7 +3,8 @@ import { dirname, join } from 'path';
 
 import c from './colors';
 import type { Config, PackageJson } from './definitions';
-import { output, logger, logFatal } from './log';
+import { fatal } from './errors';
+import { output, logger } from './log';
 import { resolveNode } from './util/node';
 
 export type CheckFunction = () => Promise<string | null>;
@@ -221,7 +222,7 @@ export async function requireCapacitorPackage(
   const pkg = await getCapacitorPackage(config, name);
 
   if (!pkg) {
-    logFatal(
+    fatal(
       `Unable to find node_modules/@capacitor/${name}.\n` +
         `Are you sure ${c.strong(`@capacitor/${name}`)} is installed?`,
     );
@@ -279,15 +280,15 @@ export async function selectPlatforms(
     const platformName = selectedPlatformName.toLowerCase().trim();
 
     if (!(await isValidPlatform(platformName))) {
-      logFatal(`Invalid platform: ${c.input(platformName)}`);
+      fatal(`Invalid platform: ${c.input(platformName)}`);
     } else if (!(await getProjectPlatformDirectory(config, platformName))) {
       if (platformName === 'web') {
-        logFatal(
+        fatal(
           `Could not find the web platform directory.\n` +
             `Make sure ${c.strong(config.app.webDir)} exists.`,
         );
       }
-      logFatal(
+      fatal(
         `${c.strong(platformName)} platform has not been added yet.\n` +
           `Use ${c.input(
             `npx cap add ${platformName}`,
@@ -350,7 +351,7 @@ export async function promptForPlatform(
   if (!(await isValidPlatform(platformName))) {
     const knownPlatforms = await getKnownPlatforms();
 
-    logFatal(
+    fatal(
       `Invalid platform: ${c.input(platformName)}.\n` +
         `Valid platforms include: ${knownPlatforms.join(', ')}`,
     );
@@ -401,7 +402,7 @@ export async function promptForPlatformTarget(
   const target = targets.find(t => t.id === targetID);
 
   if (!target) {
-    logFatal(
+    fatal(
       `Invalid target ID: ${c.input(targetID)}.\n` +
         `Valid targets are: ${targets.map(t => t.id).join(', ')}`,
     );

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -13,7 +13,7 @@ import type {
   WebConfig,
 } from './definitions';
 import { OS } from './definitions';
-import { logFatal } from './log';
+import { fatal, isFatal } from './errors';
 import { tryFn } from './util/fn';
 import { resolveNode, requireTS } from './util/node';
 import { lazy } from './util/promise';
@@ -69,7 +69,7 @@ async function loadExtConfigTS(
     const tsPath = resolveNode(rootDir, 'typescript');
 
     if (!tsPath) {
-      logFatal(
+      fatal(
         'Could not find installation of TypeScript.\n' +
           `To use ${c.strong(
             extConfigName,
@@ -88,7 +88,11 @@ async function loadExtConfigTS(
       extConfig: requireTS(ts, extConfigFilePath) as any,
     };
   } catch (e) {
-    logFatal(`Parsing ${c.strong(extConfigName)} failed.\n\n${e.stack ?? e}`);
+    if (!isFatal(e)) {
+      fatal(`Parsing ${c.strong(extConfigName)} failed.\n\n${e.stack ?? e}`);
+    }
+
+    throw e;
   }
 }
 
@@ -105,7 +109,7 @@ async function loadExtConfigJS(
       extConfig: require(extConfigFilePath),
     };
   } catch (e) {
-    logFatal(`Parsing ${c.strong(extConfigName)} failed.\n\n${e.stack ?? e}`);
+    fatal(`Parsing ${c.strong(extConfigName)} failed.\n\n${e.stack ?? e}`);
   }
 }
 

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -14,8 +14,9 @@ import prompts from 'prompts';
 import { getAndroidPlugins } from './android/common';
 import c from './colors';
 import type { Config } from './definitions';
+import { fatal } from './errors';
 import { getIOSPlugins } from './ios/common';
-import { logger, logFatal, logPrompt } from './log';
+import { logger, logPrompt } from './log';
 import type { Plugin } from './plugin';
 import {
   PluginType,
@@ -182,7 +183,7 @@ export async function copyCordovaJS(
     'cordova.js',
   );
   if (!cordovaPath) {
-    logFatal(
+    fatal(
       `Unable to find node_modules/@capacitor/core/cordova.js.\n` +
         `Are you sure ${c.strong('@capacitor/core')} is installed?`,
     );

--- a/cli/src/errors.ts
+++ b/cli/src/errors.ts
@@ -1,0 +1,19 @@
+export abstract class BaseException<T> extends Error {
+  constructor(readonly message: string, readonly code: T) {
+    super(message);
+  }
+}
+
+export class FatalException extends BaseException<'FATAL'> {
+  constructor(readonly message: string, readonly exitCode = 1) {
+    super(message, 'FATAL');
+  }
+}
+
+export function fatal(message: string): never {
+  throw new FatalException(message);
+}
+
+export function isFatal(e: any): e is FatalException {
+  return e && e instanceof FatalException;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,10 @@ import program from 'commander';
 
 import c from './colors';
 import { loadConfig } from './config';
-import { output, logFatal } from './log';
+import type { Config } from './definitions';
+import { fatal, isFatal } from './errors';
+import { logger, output } from './log';
+import { wrapAction } from './util/cli';
 import { emoji as _e } from './util/emoji';
 
 process.on('unhandledRejection', error => {
@@ -10,26 +13,38 @@ process.on('unhandledRejection', error => {
 });
 
 export async function run(): Promise<void> {
-  const config = await loadConfig();
+  try {
+    const config = await loadConfig();
+    runProgram(config);
+  } catch (e) {
+    process.exitCode = isFatal(e) ? e.exitCode : 1;
+    logger.error(e.message ? e.message : String(e));
+  }
+}
 
+export function runProgram(config: Config): void {
   program.version(config.cli.package.version);
 
   program
     .command('config', { hidden: true })
     .description(`print evaluated Capacitor config`)
     .option('--json', 'Print in JSON format')
-    .action(async ({ json }) => {
-      const { configCommand } = await import('./tasks/config');
-      await configCommand(config, json);
-    });
+    .action(
+      wrapAction(async ({ json }) => {
+        const { configCommand } = await import('./tasks/config');
+        await configCommand(config, json);
+      }),
+    );
 
   program
     .command('create [directory] [name] [id]', { hidden: true })
     .description('Creates a new Capacitor project')
-    .action(async () => {
-      const { createCommand } = await import('./tasks/create');
-      await createCommand();
-    });
+    .action(
+      wrapAction(async () => {
+        const { createCommand } = await import('./tasks/create');
+        await createCommand();
+      }),
+    );
 
   program
     .command('init [appName] [appId]')
@@ -38,18 +53,22 @@ export async function run(): Promise<void> {
       '--web-dir <value>',
       'Optional: Directory of your projects built web assets',
     )
-    .action(async (appName, appId, { webDir }) => {
-      const { initCommand } = await import('./tasks/init');
-      await initCommand(config, appName, appId, webDir);
-    });
+    .action(
+      wrapAction(async (appName, appId, { webDir }) => {
+        const { initCommand } = await import('./tasks/init');
+        await initCommand(config, appName, appId, webDir);
+      }),
+    );
 
   program
     .command('serve', { hidden: true })
     .description('Serves a Capacitor Progressive Web App in the browser')
-    .action(async () => {
-      const { serveCommand } = await import('./tasks/serve');
-      await serveCommand();
-    });
+    .action(
+      wrapAction(async () => {
+        const { serveCommand } = await import('./tasks/serve');
+        await serveCommand();
+      }),
+    );
 
   program
     .command('sync [platform]')
@@ -58,10 +77,12 @@ export async function run(): Promise<void> {
       '--deployment',
       "Optional: if provided, Podfile.lock won't be deleted and pod install will use --deployment option",
     )
-    .action(async (platform, { deployment }) => {
-      const { syncCommand } = await import('./tasks/sync');
-      await syncCommand(config, platform, deployment);
-    });
+    .action(
+      wrapAction(async (platform, { deployment }) => {
+        const { syncCommand } = await import('./tasks/sync');
+        await syncCommand(config, platform, deployment);
+      }),
+    );
 
   program
     .command('update [platform]')
@@ -74,18 +95,22 @@ export async function run(): Promise<void> {
       '--deployment',
       "Optional: if provided, Podfile.lock won't be deleted and pod install will use --deployment option",
     )
-    .action(async (platform, { deployment }) => {
-      const { updateCommand } = await import('./tasks/update');
-      await updateCommand(config, platform, deployment);
-    });
+    .action(
+      wrapAction(async (platform, { deployment }) => {
+        const { updateCommand } = await import('./tasks/update');
+        await updateCommand(config, platform, deployment);
+      }),
+    );
 
   program
     .command('copy [platform]')
     .description('copies the web app build into the native app')
-    .action(async platform => {
-      const { copyCommand } = await import('./tasks/copy');
-      await copyCommand(config, platform);
-    });
+    .action(
+      wrapAction(async platform => {
+        const { copyCommand } = await import('./tasks/copy');
+        await copyCommand(config, platform);
+      }),
+    );
 
   program
     .command(`run [platform]`)
@@ -97,63 +122,77 @@ export async function run(): Promise<void> {
     .allowUnknownOption(true)
     .option('--target <id>', 'use a specific target')
     .option('--no-sync', `do not run ${c.input('sync')}`)
-    .action(async (platform, { list, target, sync }) => {
-      const { runCommand } = await import('./tasks/run');
-      await runCommand(config, platform, { list, target, sync });
-    });
+    .action(
+      wrapAction(async (platform, { list, target, sync }) => {
+        const { runCommand } = await import('./tasks/run');
+        await runCommand(config, platform, { list, target, sync });
+      }),
+    );
 
   program
     .command('open [platform]')
     .description('opens the native project workspace (Xcode for iOS)')
-    .action(async platform => {
-      const { openCommand } = await import('./tasks/open');
-      await openCommand(config, platform);
-    });
+    .action(
+      wrapAction(async platform => {
+        const { openCommand } = await import('./tasks/open');
+        await openCommand(config, platform);
+      }),
+    );
 
   program
     .command('add [platform]')
     .description('add a native platform project')
-    .action(async platform => {
-      const { addCommand } = await import('./tasks/add');
-      await addCommand(config, platform);
-    });
+    .action(
+      wrapAction(async platform => {
+        const { addCommand } = await import('./tasks/add');
+        await addCommand(config, platform);
+      }),
+    );
 
   program
     .command('ls [platform]')
     .description('list installed Cordova and Capacitor plugins')
-    .action(async platform => {
-      const { listCommand } = await import('./tasks/list');
-      await listCommand(config, platform);
-    });
+    .action(
+      wrapAction(async platform => {
+        const { listCommand } = await import('./tasks/list');
+        await listCommand(config, platform);
+      }),
+    );
 
   program
     .command('doctor [platform]')
     .description('checks the current setup for common errors')
-    .action(async platform => {
-      const { doctorCommand } = await import('./tasks/doctor');
-      await doctorCommand(config, platform);
-    });
+    .action(
+      wrapAction(async platform => {
+        const { doctorCommand } = await import('./tasks/doctor');
+        await doctorCommand(config, platform);
+      }),
+    );
 
   program
     .command('plugin:generate', { hidden: true })
     .description('start a new Capacitor plugin')
-    .action(async () => {
-      const { newPluginCommand } = await import('./tasks/new-plugin');
-      await newPluginCommand();
-    });
+    .action(
+      wrapAction(async () => {
+        const { newPluginCommand } = await import('./tasks/new-plugin');
+        await newPluginCommand();
+      }),
+    );
 
-  program.arguments('[command]').action(async cmd => {
-    if (typeof cmd === 'undefined') {
-      output.write(
-        `\n  ${_e('⚡️', '--')}  ${c.strong(
-          'Capacitor - Cross-Platform apps with JavaScript and the Web',
-        )}  ${_e('⚡️', '--')}\n\n`,
-      );
-      program.outputHelp();
-    } else {
-      logFatal(`Unknown command: ${c.input(cmd)}`);
-    }
-  });
+  program.arguments('[command]').action(
+    wrapAction(async cmd => {
+      if (typeof cmd === 'undefined') {
+        output.write(
+          `\n  ${_e('⚡️', '--')}  ${c.strong(
+            'Capacitor - Cross-Platform apps with JavaScript and the Web',
+          )}  ${_e('⚡️', '--')}\n\n`,
+        );
+        program.outputHelp();
+      } else {
+        fatal(`Unknown command: ${c.input(cmd)}`);
+      }
+    }),
+  );
 
   program.parse(process.argv);
 }

--- a/cli/src/ios/doctor.ts
+++ b/cli/src/ios/doctor.ts
@@ -1,6 +1,7 @@
 import { check, checkWebDir } from '../common';
 import type { Config } from '../definitions';
-import { logFatal, logSuccess } from '../log';
+import { fatal } from '../errors';
+import { logSuccess } from '../log';
 import { isInstalled } from '../util/subprocess';
 
 import { checkCocoaPods, checkIOSProject } from './common';
@@ -26,7 +27,7 @@ export async function doctorIOS(config: Config): Promise<void> {
     ]);
     logSuccess('iOS looking great! 👌');
   } catch (e) {
-    logFatal(e.stack ?? e);
+    fatal(e.stack ?? e);
   }
 }
 

--- a/cli/src/ios/open.ts
+++ b/cli/src/ios/open.ts
@@ -3,7 +3,7 @@ import open from 'open';
 import c from '../colors';
 import { wait } from '../common';
 import type { Config } from '../definitions';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 
 import { findXcodePath } from './common';
 
@@ -11,7 +11,7 @@ export async function openIOS(config: Config): Promise<void> {
   const xcodeProject = await findXcodePath(config);
 
   if (!xcodeProject) {
-    logFatal(
+    fatal(
       'Xcode workspace does not exist.\n' +
         `Run ${c.input('npx cap add ios')} to bootstrap a new iOS project.`,
     );

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -9,7 +9,7 @@ import {
   logCordovaManualSteps,
 } from '../cordova';
 import type { Config } from '../definitions';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 import type { Plugin } from '../plugin';
 import {
   PluginType,
@@ -127,7 +127,7 @@ async function generatePodFile(
     'package.json',
   );
   if (!capacitoriOSPath) {
-    logFatal(
+    fatal(
       `Unable to find node_modules/@capacitor/ios.\n` +
         `Are you sure ${c.strong('@capacitor/ios')} is installed?`,
     );

--- a/cli/src/log.ts
+++ b/cli/src/log.ts
@@ -48,8 +48,3 @@ export async function logPrompt<T extends string>(
 export function logSuccess(msg: string): void {
   logger.msg(`${c.success('[success]')} ${msg}`);
 }
-
-export function logFatal(msg: string): never {
-  logger.error(msg);
-  return process.exit(1);
-}

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -3,7 +3,8 @@ import { dirname, join } from 'path';
 
 import c from './colors';
 import type { Config } from './definitions';
-import { logger, logFatal } from './log';
+import { fatal } from './errors';
+import { logger } from './log';
 import { resolveNode } from './util/node';
 import { readXML } from './util/xml';
 
@@ -75,7 +76,7 @@ export async function resolvePlugin(
   try {
     const packagePath = resolveNode(config.app.rootDir, name, 'package.json');
     if (!packagePath) {
-      logFatal(
+      fatal(
         `Unable to find node_modules/${name}.\n` +
           `Are you sure ${c.strong(name)} is installed?`,
       );

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -21,13 +21,14 @@ import {
 } from '../common';
 import type { Config } from '../definitions';
 import { OS } from '../definitions';
+import { fatal, isFatal } from '../errors';
 import { addIOS } from '../ios/add';
 import {
   editProjectSettingsIOS,
   checkIOSPackage,
   checkCocoaPods,
 } from '../ios/common';
-import { logger, logFatal } from '../log';
+import { logger } from '../log';
 
 import { sync } from './sync';
 
@@ -69,7 +70,7 @@ export async function addCommand(
     );
 
     if (existingPlatformDir) {
-      logFatal(
+      fatal(
         `${c.input(platformName)} platform already exists.\n` +
           `To re-add this platform, first remove ${existingPlatformDir}, then run this command again.\n` +
           `${c.strong(
@@ -103,7 +104,11 @@ export async function addCommand(
         );
       }
     } catch (e) {
-      logFatal(e.stack ?? e);
+      if (!isFatal(e)) {
+        fatal(e.stack ?? e);
+      }
+
+      throw e;
     }
   }
 }

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -16,6 +16,7 @@ import {
   writeCordovaAndroidManifest,
 } from '../cordova';
 import type { Config } from '../definitions';
+import { isFatal } from '../errors';
 import { logger } from '../log';
 import { allSerial } from '../util/promise';
 import { copyWeb } from '../web/copy';
@@ -45,6 +46,10 @@ export async function copyCommand(
         platforms.map(platformName => () => copy(config, platformName)),
       );
     } catch (e) {
+      if (isFatal(e)) {
+        throw e;
+      }
+
       logger.error(e.stack ?? e);
     }
   }

--- a/cli/src/tasks/create.ts
+++ b/cli/src/tasks/create.ts
@@ -1,8 +1,8 @@
 import c from '../colors';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 
 export async function createCommand(): Promise<void> {
-  logFatal(
+  fatal(
     `The create command has been removed.\n` +
       `Use ${c.input('npm init @capacitor/app')}`,
   );

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -4,7 +4,8 @@ import c from '../colors';
 import { check, checkAppId, checkAppName, runTask } from '../common';
 import { getCordovaPreferences } from '../cordova';
 import type { Config, ExternalConfig } from '../definitions';
-import { output, logFatal, logSuccess, logPrompt } from '../log';
+import { fatal, isFatal } from '../errors';
+import { output, logSuccess, logPrompt } from '../log';
 import { checkInteractive, isInteractive } from '../util/term';
 
 export async function initCommand(
@@ -19,7 +20,7 @@ export async function initCommand(
     }
 
     if (config.app.extConfigType !== 'json') {
-      logFatal(
+      fatal(
         `Cannot run ${c.input(
           'init',
         )} for a project using a non-JSON configuration file.\n` +
@@ -61,7 +62,12 @@ export async function initCommand(
       'Usage: npx cap init appName appId\n' +
         'Example: npx cap init "My App" "com.example.myapp"\n\n',
     );
-    logFatal(e.stack ?? e);
+
+    if (!isFatal(e)) {
+      fatal(e.stack ?? e);
+    }
+
+    throw e;
   }
 }
 

--- a/cli/src/tasks/list.ts
+++ b/cli/src/tasks/list.ts
@@ -2,6 +2,7 @@ import { getAndroidPlugins } from '../android/common';
 import c from '../colors';
 import { selectPlatforms } from '../common';
 import type { Config } from '../definitions';
+import { isFatal } from '../errors';
 import { getIOSPlugins } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
@@ -25,6 +26,10 @@ export async function listCommand(
       platforms.map(platformName => () => list(config, platformName)),
     );
   } catch (e) {
+    if (isFatal(e)) {
+      throw e;
+    }
+
     logger.error(e.stack ?? e);
   }
 }

--- a/cli/src/tasks/new-plugin.ts
+++ b/cli/src/tasks/new-plugin.ts
@@ -1,8 +1,8 @@
 import c from '../colors';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 
 export async function newPluginCommand(): Promise<void> {
-  logFatal(
+  fatal(
     `The plugin:generate command has been removed.\n` +
       `Use ${c.input('npm init @capacitor/plugin')}`,
   );

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -9,8 +9,9 @@ import {
   promptForPlatform,
 } from '../common';
 import type { Config } from '../definitions';
+import { fatal, isFatal } from '../errors';
 import { openIOS } from '../ios/open';
-import { logger, logFatal } from '../log';
+import { logger } from '../log';
 
 export async function openCommand(
   config: Config,
@@ -44,7 +45,11 @@ export async function openCommand(
     try {
       await open(config, platformName);
     } catch (e) {
-      logFatal(e.stack ?? e);
+      if (!isFatal(e)) {
+        fatal(e.stack ?? e);
+      }
+
+      throw e;
     }
   }
 }

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -11,8 +11,9 @@ import {
   getPlatformTargetName,
 } from '../common';
 import type { Config } from '../definitions';
+import { fatal, isFatal } from '../errors';
 import { runIOS } from '../ios/run';
-import { logger, output, logFatal } from '../log';
+import { logger, output } from '../log';
 import { getPlatformTargets } from '../util/native-run';
 
 import { sync } from './sync';
@@ -85,7 +86,11 @@ export async function runCommand(
 
       await run(config, platformName, options);
     } catch (e) {
-      logFatal(e.stack ?? e);
+      if (!isFatal(e)) {
+        fatal(e.stack ?? e);
+      }
+
+      throw e;
     }
   }
 }

--- a/cli/src/tasks/serve.ts
+++ b/cli/src/tasks/serve.ts
@@ -1,8 +1,8 @@
 import c from '../colors';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 
 export async function serveCommand(): Promise<void> {
-  logFatal(
+  fatal(
     `The serve command has been removed.\n` +
       `Use a third-party tool for serving single page apps, such as ${c.strong(
         'serve',

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -7,7 +7,8 @@ import {
   isValidPlatform,
 } from '../common';
 import type { Config } from '../definitions';
-import { logger, logFatal } from '../log';
+import { fatal, isFatal } from '../errors';
+import { logger } from '../log';
 import { allSerial } from '../util/promise';
 
 import { copy, copyCommand } from './copy';
@@ -53,7 +54,11 @@ export async function syncCommand(
       const diff = (now - then) / 1000;
       logger.info(`Sync finished in ${diff}s`);
     } catch (e) {
-      logFatal(e.stack ?? e);
+      if (!isFatal(e)) {
+        fatal(e.stack ?? e);
+      }
+
+      throw e;
     }
   }
 }

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -11,9 +11,10 @@ import {
   isValidPlatform,
 } from '../common';
 import type { Config } from '../definitions';
+import { fatal, isFatal } from '../errors';
 import { checkCocoaPods, checkIOSProject } from '../ios/common';
 import { updateIOS } from '../ios/update';
-import { logger, logFatal } from '../log';
+import { logger } from '../log';
 import { allSerial } from '../util/promise';
 
 export async function updateCommand(
@@ -50,7 +51,11 @@ export async function updateCommand(
       const diff = (now - then) / 1000;
       logger.info(`Update finished in ${diff}s`);
     } catch (e) {
-      logFatal(e.stack ?? e);
+      if (!isFatal(e)) {
+        fatal(e.stack ?? e);
+      }
+
+      throw e;
     }
   }
 }

--- a/cli/src/util/cli.ts
+++ b/cli/src/util/cli.ts
@@ -1,0 +1,19 @@
+import { isFatal } from '../errors';
+import { logger } from '../log';
+
+export type CommanderAction = (...args: any[]) => void | Promise<void>;
+
+export function wrapAction(action: CommanderAction): CommanderAction {
+  return async (...args: any[]) => {
+    try {
+      await action(...args);
+    } catch (e) {
+      if (isFatal(e)) {
+        process.exitCode = e.exitCode;
+        logger.error(e.message);
+      } else {
+        throw e;
+      }
+    }
+  };
+}

--- a/cli/src/util/native-run.ts
+++ b/cli/src/util/native-run.ts
@@ -2,7 +2,7 @@ import { dirname } from 'path';
 
 import c from '../colors';
 import type { PlatformTarget } from '../common';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 
 import { resolveNode } from './node';
 import type { RunCommandOptions } from './subprocess';
@@ -19,7 +19,7 @@ export async function runNativeRun(
   );
 
   if (!p) {
-    logFatal(`${c.input('native-run')} not found.`);
+    fatal(`${c.input('native-run')} not found.`);
   }
 
   return await runCommand(p, args, options);

--- a/cli/src/web/copy.ts
+++ b/cli/src/web/copy.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import c from '../colors';
 import { runTask } from '../common';
 import type { Config } from '../definitions';
-import { logFatal } from '../log';
+import { fatal } from '../errors';
 import { resolveNode } from '../util/node';
 
 export async function copyWeb(config: Config): Promise<void> {
@@ -16,7 +16,7 @@ export async function copyWeb(config: Config): Promise<void> {
       'capacitor.js',
     );
     if (!runtimePath) {
-      logFatal(
+      fatal(
         `Unable to find node_modules/@capacitor/core/dist/capacitor.js.\n` +
           `Are you sure ${c.strong('@capacitor/core')} is installed?`,
       );


### PR DESCRIPTION
Using `process.exit()` is discouraged in NodeJS because it forcibly terminates the process. To set the exit code of the process, the `process.exitCode` property should be used. 

This PR switches the usage of `logFatal()` to a new `fatal()` function, which throws a `FatalException`. Some try/catch flows needed to be adjusted. All commands are now wrapped via `wrapAction` which catches these exceptions and prints their message in the exact same way as before.

This is a precursor for some telemetry work where we want the process to proceed even if the command fails.

relates to https://github.com/ionic-team/capacitor/issues/4020