### PR TITLE
feat(cli): opt-in anonymous usage data

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -50,6 +50,7 @@
     "@ionic/utils-terminal": "^2.3.0",
     "commander": "^6.0.0",
     "debug": "^4.2.0",
+    "env-paths": "^2.2.0",
     "kleur": "^4.1.1",
     "native-run": "^1.2.1",
     "open": "^7.1.0",

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -1,0 +1,88 @@
+import { open, mkdirp } from '@ionic/utils-fs';
+import { fork } from '@ionic/utils-subprocess';
+import Debug from 'debug';
+import { request } from 'https';
+import { resolve } from 'path';
+
+import type { TelemetryMessage } from './telemetry';
+import { ENV_PATHS } from './util/cli';
+
+const debug = Debug('capacitor:ipc');
+
+export interface TelemetryIPCMessage {
+  type: 'telemetry';
+  data: TelemetryMessage;
+}
+
+export type IPCMessage = TelemetryIPCMessage;
+
+/**
+ * Send an IPC message to a forked process.
+ */
+export async function send(msg: IPCMessage): Promise<void> {
+  const dir = ENV_PATHS.log;
+  await mkdirp(dir);
+  const logPath = resolve(dir, 'ipc.log');
+
+  debug(
+    'Sending %O IPC message to forked process (logs: %O)',
+    msg.type,
+    logPath,
+  );
+
+  const fd = await open(logPath, 'a');
+  const p = fork(process.argv[1], ['📡'], { stdio: ['ignore', fd, fd, 'ipc'] });
+
+  p.send(msg);
+  p.disconnect();
+  p.unref();
+}
+
+/**
+ * Receive and handle an IPC message.
+ *
+ * Assume minimal context and keep external dependencies to a minimum.
+ */
+export async function receive(msg: IPCMessage): Promise<void> {
+  debug('Received %O IPC message', msg.type);
+
+  if (msg.type === 'telemetry') {
+    const now = new Date().toISOString();
+    const { data } = msg;
+
+    // This request is only made if telemetry is on.
+    const req = request(
+      {
+        hostname: 'api-staging.ionicjs.com', // TODO
+        port: 443,
+        path: '/events/metrics',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      response => {
+        debug(
+          'Sent telemetry data to events service (status: %O)',
+          response.statusCode,
+        );
+
+        if (response.statusCode !== 204) {
+          response.on('data', chunk => {
+            debug(
+              'Bad response from events service. Request body: %O',
+              chunk.toString(),
+            );
+          });
+        }
+      },
+    );
+
+    const body = {
+      metrics: [data],
+      sent_at: now,
+    };
+
+    req.end(JSON.stringify(body));
+  }
+}

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -53,7 +53,7 @@ export async function receive(msg: IPCMessage): Promise<void> {
     // This request is only made if telemetry is on.
     const req = request(
       {
-        hostname: 'api-staging.ionicjs.com', // TODO
+        hostname: 'api.ionicjs.com',
         port: 443,
         path: '/events/metrics',
         method: 'POST',

--- a/cli/src/ipc.ts
+++ b/cli/src/ipc.ts
@@ -4,14 +4,14 @@ import Debug from 'debug';
 import { request } from 'https';
 import { resolve } from 'path';
 
-import type { TelemetryMessage } from './telemetry';
+import type { Metric } from './telemetry';
 import { ENV_PATHS } from './util/cli';
 
 const debug = Debug('capacitor:ipc');
 
 export interface TelemetryIPCMessage {
   type: 'telemetry';
-  data: TelemetryMessage;
+  data: Metric<string, unknown>;
 }
 
 export type IPCMessage = TelemetryIPCMessage;
@@ -63,7 +63,8 @@ export async function receive(msg: IPCMessage): Promise<void> {
       },
       response => {
         debug(
-          'Sent telemetry data to events service (status: %O)',
+          'Sent %O metric to events service (status: %O)',
+          data.name,
           response.statusCode,
         );
 

--- a/cli/src/sysconfig.ts
+++ b/cli/src/sysconfig.ts
@@ -18,8 +18,10 @@ export interface SystemConfig {
 
   /**
    * Whether telemetry is enabled or not.
+   *
+   * If undefined, a choice has not yet been made.
    */
-  readonly telemetry: boolean;
+  readonly telemetry?: boolean;
 }
 
 export async function readConfig(): Promise<SystemConfig> {
@@ -34,7 +36,6 @@ export async function readConfig(): Promise<SystemConfig> {
 
     const sysconfig: SystemConfig = {
       machine: uuidv4(),
-      telemetry: true,
     };
 
     await writeConfig(sysconfig);

--- a/cli/src/sysconfig.ts
+++ b/cli/src/sysconfig.ts
@@ -1,0 +1,51 @@
+import { readJSON, writeJSON, mkdirp } from '@ionic/utils-fs';
+import Debug from 'debug';
+import { dirname, resolve } from 'path';
+
+import { ENV_PATHS } from './util/cli';
+import { uuidv4 } from './util/uuid';
+
+const debug = Debug('capacitor:sysconfig');
+
+const SYSCONFIG_FILE = 'sysconfig.json';
+const SYSCONFIG_PATH = resolve(ENV_PATHS.config, SYSCONFIG_FILE);
+
+export interface SystemConfig {
+  /**
+   * A UUID that anonymously identifies this computer.
+   */
+  readonly machine: string;
+
+  /**
+   * Whether telemetry is enabled or not.
+   */
+  readonly telemetry: boolean;
+}
+
+export async function readConfig(): Promise<SystemConfig> {
+  debug('Reading from %O', SYSCONFIG_PATH);
+
+  try {
+    return await readJSON(SYSCONFIG_PATH);
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+
+    const sysconfig: SystemConfig = {
+      machine: uuidv4(),
+      telemetry: true,
+    };
+
+    await writeConfig(sysconfig);
+
+    return sysconfig;
+  }
+}
+
+export async function writeConfig(sysconfig: SystemConfig): Promise<void> {
+  debug('Writing to %O', SYSCONFIG_PATH);
+
+  await mkdirp(dirname(SYSCONFIG_PATH));
+  await writeJSON(SYSCONFIG_PATH, sysconfig, { spaces: '\t' });
+}

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -58,12 +58,12 @@ export async function initCommand(
 
     printNextSteps(config);
   } catch (e) {
-    output.write(
-      'Usage: npx cap init appName appId\n' +
-        'Example: npx cap init "My App" "com.example.myapp"\n\n',
-    );
-
     if (!isFatal(e)) {
+      output.write(
+        'Usage: npx cap init appName appId\n' +
+          'Example: npx cap init "My App" "com.example.myapp"\n\n',
+      );
+
       fatal(e.stack ?? e);
     }
 

--- a/cli/src/tasks/telemetry.ts
+++ b/cli/src/tasks/telemetry.ts
@@ -1,0 +1,46 @@
+import c from '../colors';
+import { fatal } from '../errors';
+import { logger, logSuccess, output } from '../log';
+import { readConfig, writeConfig } from '../sysconfig';
+import { THANK_YOU } from '../telemetry';
+
+export async function telemetryCommand(onOrOff?: string): Promise<void> {
+  const sysconfig = await readConfig();
+  const enabled = interpretEnabled(onOrOff);
+
+  if (typeof enabled === 'boolean') {
+    if (sysconfig.telemetry === enabled) {
+      logger.info(`Telemetry is already ${c.strong(enabled ? 'on' : 'off')}`);
+    } else {
+      await writeConfig({ ...sysconfig, telemetry: enabled });
+      logSuccess(
+        `You have ${c.strong(`opted ${enabled ? 'in' : 'out'}`)} ${
+          enabled ? 'for' : 'of'
+        } telemetry on this machine.`,
+      );
+
+      if (enabled) {
+        output.write(THANK_YOU);
+      }
+    }
+  } else {
+    logger.info(`Telemetry is ${c.strong(sysconfig.telemetry ? 'on' : 'off')}`);
+  }
+}
+
+function interpretEnabled(onOrOff?: string): boolean | undefined {
+  switch (onOrOff) {
+    case 'on':
+      return true;
+    case 'off':
+      return false;
+    case undefined:
+      return undefined;
+  }
+
+  fatal(
+    `Argument must be ${c.strong('on')} or ${c.strong(
+      'off',
+    )} (or left unspecified)`,
+  );
+}

--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -4,6 +4,7 @@ import c from './colors';
 import type { Config } from './definitions';
 import { send } from './ipc';
 import { readConfig } from './sysconfig';
+import { isInteractive } from './util/term';
 
 export const THANK_YOU =
   `\nThank you for helping to make Capacitor better! 💖` +
@@ -33,7 +34,7 @@ export interface TelemetryMessage {
 async function sendTelemetryData(data: TelemetryData): Promise<void> {
   const sysconfig = await readConfig();
 
-  if (sysconfig.telemetry) {
+  if (sysconfig.telemetry && isInteractive()) {
     const message: TelemetryMessage = {
       name: 'capacitor_cli_command',
       timestamp: new Date().toISOString(),

--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -93,7 +93,7 @@ export function telemetryAction(
     if (isInteractive()) {
       let sysconfig = await readConfig();
 
-      if (typeof sysconfig.telemetry === 'undefined') {
+      if (!error && typeof sysconfig.telemetry === 'undefined') {
         const confirm = await promptForTelemetry();
         sysconfig = { ...sysconfig, telemetry: confirm };
 

--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -1,0 +1,124 @@
+import { Command } from 'commander';
+
+import c from './colors';
+import type { Config } from './definitions';
+import { send } from './ipc';
+import { readConfig } from './sysconfig';
+
+export const THANK_YOU =
+  `\nThank you for helping to make Capacitor better! 💖` +
+  `\nInformation about the data we collect is available on our website: ${c.strong(
+    'https://capacitorjs.com/telemetry',
+  )}\n`;
+
+export interface TelemetryData {
+  app_id: string;
+  command: string;
+  arguments: string;
+  options: string;
+  duration: number;
+  error: string | null;
+  node_version: string;
+  os: string;
+}
+
+export interface TelemetryMessage {
+  name: string;
+  timestamp: string;
+  session_id: string;
+  source: string;
+  value: TelemetryData;
+}
+
+async function sendTelemetryData(data: TelemetryData): Promise<void> {
+  const sysconfig = await readConfig();
+
+  if (sysconfig.telemetry) {
+    const message: TelemetryMessage = {
+      name: 'capacitor_cli_command',
+      timestamp: new Date().toISOString(),
+      session_id: sysconfig.machine,
+      source: 'capacitor_cli',
+      value: data,
+    };
+
+    await send({ type: 'telemetry', data: message });
+  }
+}
+
+type CommanderAction = (...args: any[]) => void | Promise<void>;
+
+export function telemetryAction(
+  config: Config,
+  action: CommanderAction,
+): CommanderAction {
+  return async (...actionArgs: any[]): Promise<void> => {
+    const start = new Date();
+    // This is how commanderjs works--the command object is either the last
+    // element or second to last if there are additional options (via `.allowUnknownOption()`)
+    const lastArg = actionArgs[actionArgs.length - 1];
+    const cmd: Command =
+      lastArg instanceof Command ? lastArg : actionArgs[actionArgs.length - 2];
+    const command = getFullCommandName(cmd);
+    let error: any;
+
+    try {
+      await action(...actionArgs);
+    } catch (e) {
+      error = e;
+    }
+
+    const end = new Date();
+    const duration = end.getTime() - start.getTime();
+
+    const packages = Object.entries({
+      ...config.app.package.devDependencies,
+      ...config.app.package.dependencies,
+    });
+
+    // Only collect packages in the capacitor org:
+    // https://www.npmjs.com/org/capacitor
+    const capacitorPackages = packages.filter(([k]) =>
+      k.startsWith('@capacitor/'),
+    );
+
+    const versions = capacitorPackages.map(([k, v]) => [
+      `${k.replace(/^@capacitor\//, '').replace(/-/g, '_')}_version`,
+      v,
+    ]);
+
+    const data: TelemetryData = {
+      app_id: '', // TODO
+      command,
+      arguments: cmd.args.join(' '),
+      options: JSON.stringify(cmd.opts()),
+      duration,
+      error: error ? (error.message ? error.message : String(error)) : null,
+      node_version: process.version,
+      os: config.cli.os,
+      ...Object.fromEntries(versions),
+    };
+
+    await sendTelemetryData(data);
+
+    if (error) {
+      throw error;
+    }
+  };
+}
+
+/**
+ * Walk through the command's parent tree and construct a space-separated name.
+ *
+ * Probably overkill because we don't have nested commands, but whatever.
+ */
+function getFullCommandName(cmd: Command): string {
+  const names: string[] = [];
+
+  while (cmd.parent !== null) {
+    names.push(cmd.name());
+    cmd = cmd.parent;
+  }
+
+  return names.reverse().join(' ');
+}

--- a/cli/src/util/cli.ts
+++ b/cli/src/util/cli.ts
@@ -1,5 +1,9 @@
+import envPaths from 'env-paths';
+
 import { isFatal } from '../errors';
 import { logger } from '../log';
+
+export const ENV_PATHS = envPaths('capacitor', { suffix: '' });
 
 export type CommanderAction = (...args: any[]) => void | Promise<void>;
 

--- a/cli/src/util/subprocess.ts
+++ b/cli/src/util/subprocess.ts
@@ -26,9 +26,10 @@ export async function runCommand(
 export async function getCommandOutput(
   command: string,
   args: readonly string[],
+  options: RunCommandOptions = {},
 ): Promise<string | null> {
   try {
-    return (await runCommand(command, args)).trim();
+    return (await runCommand(command, args, options)).trim();
   } catch (e) {
     return null;
   }

--- a/cli/src/util/uuid.ts
+++ b/cli/src/util/uuid.ts
@@ -1,0 +1,8 @@
+export function uuidv4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c == 'x' ? r : (r & 0x3) | 0x8;
+
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
This PR adds telemetry to the Capacitor CLI, which comprises several components:

1. `npx cap telemetry [on|off]` command, which is for managing telemetry on a machine
2. New "sysconfig" for managing a system-level configuration file (for storing telemetry opt-in/out status)
3. Command-level events for gathering anonymous usage data
4. IPC system for sending event data in the background (as to not affect the performance of commands)

TODO
- [x] Prompt for opting into telemetry
- [x] Switch off staging
- [ ] ~Questionnaire during `init` (may be done as part of a separate PR)~

ref: https://github.com/ionic-team/capacitor/issues/4020