### PR TITLE
feat(cli): allow 'export default' style TS config files

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -80,12 +80,14 @@ async function loadExtConfigTS(
     }
 
     const ts = require(tsPath); // eslint-disable-line @typescript-eslint/no-var-requires
+    const extConfigObject = requireTS(ts, extConfigFilePath) as any;
+    const extConfig = extConfigObject.default ?? extConfigObject;
 
     return {
       extConfigType: 'ts',
       extConfigName,
       extConfigFilePath: extConfigFilePath,
-      extConfig: requireTS(ts, extConfigFilePath) as any,
+      extConfig,
     };
   } catch (e) {
     if (!isFatal(e)) {


### PR DESCRIPTION
Allows devs to use:

```typescript
const config = { ... };
export default config;
```

ref: https://github.com/ionic-team/capacitor/pull/3999#pullrequestreview-563747655