### PR TITLE
fix(ios): correctly initialize cordova plugins with webViewEngine

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -53,6 +53,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 
 @interface CDVPlugin : NSObject {}
 
+- (instancetype)initWithWebViewEngine:(WKWebView *)theWebViewEngine;
 @property (nonatomic, weak) UIView* webView;
 @property (nonatomic, weak) WKWebView * webViewEngine;
 @property (nonatomic, strong) NSString * className;

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.m
@@ -35,12 +35,12 @@
 
   id obj = [self.pluginObjects objectForKey:className];
   if (!obj) {
-    obj = [[NSClassFromString(className)alloc] init];
+    obj = [[NSClassFromString(className)alloc] initWithWebViewEngine: self.webView];
     if (!obj) {
       NSString* fullClassName = [NSString stringWithFormat:@"%@.%@",
                                  NSBundle.mainBundle.infoDictionary[@"CFBundleExecutable"],
                                  className];
-      obj = [[NSClassFromString(fullClassName)alloc] init];
+      obj = [[NSClassFromString(fullClassName)alloc] initWithWebViewEngine: self.webView];
     }
 
     if (obj != nil) {


### PR DESCRIPTION
This PR corrects a small mistake where Cordova iOS plugins were initialized with a `webViewEngine` set to `nil` which causes NPE's.
See two screenshots with before and after the changes applied.

<img width="1155" alt="Screenshot 2021-01-10 at 19 43 11" src="https://user-images.githubusercontent.com/838003/104132265-0deed600-5374-11eb-98bd-3efd78af43dd.png">
<img width="1159" alt="Screenshot 2021-01-10 at 19 43 44" src="https://user-images.githubusercontent.com/838003/104132266-10e9c680-5374-11eb-9440-3e85695e3f6b.png">
