### PR TITLE
fix(cli): use stderr for logs when using --json option

### DIFF
--- a/cli/src/log.ts
+++ b/cli/src/log.ts
@@ -10,7 +10,10 @@ import type { Answers, PromptObject } from 'prompts';
 import c from './colors';
 import { isInteractive } from './util/term';
 
-const options = { colors: c, stream: process.stdout };
+const options = {
+  colors: c,
+  stream: process.argv.includes('--json') ? process.stderr : process.stdout,
+};
 
 export const output = isInteractive()
   ? new TTYOutputStrategy(options)

--- a/cli/src/tasks/config.ts
+++ b/cli/src/tasks/config.ts
@@ -10,7 +10,7 @@ export async function configCommand(
   const evaluatedConfig = await deepAwait(config);
 
   if (json) {
-    output.write(JSON.stringify(evaluatedConfig));
+    process.stdout.write(`${JSON.stringify(evaluatedConfig)}\n`);
   } else {
     output.write(
       `${util.inspect(evaluatedConfig, { depth: Infinity, colors: true })}\n`,

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -64,7 +64,7 @@ export async function runCommand(
 
       // TODO: make hidden commander option (https://github.com/tj/commander.js/issues/1106)
       if (process.argv.includes('--json')) {
-        output.write(JSON.stringify(outputTargets));
+        process.stdout.write(`${JSON.stringify(outputTargets)}\n`);
       } else {
         const rows = outputTargets.map(t => [t.name, t.api, t.id]);
 


### PR DESCRIPTION
This was causing this issue from the Ionic CLI:

```
  ionic:lib:integrations:capacitor Getting config with Capacitor CLI: [ 'config', '--json' ] +0ms
SyntaxError: Unexpected token n JSON at position 0
at JSON.parse (<anonymous>)
```