### PR TITLE
fix(iOS): skip Swift type coercion on Cordova plugin calls

### DIFF
--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -385,7 +385,9 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         dispatchQueue.async { [weak self] in
             //let startTime = CFAbsoluteTimeGetCurrent()
 
-            let pluginCall = CAPPluginCall(callbackId: call.callbackId, options: call.options, success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
+            let pluginCall = CAPPluginCall(callbackId: call.callbackId,
+                                           options: JSTypes.coerceDictionaryToJSObject(call.options) ?? [:],
+                                           success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
                 if result != nil {
                     self?.toJs(result: JSResult(call: call, result: result!.data), save: pluginCall?.isSaved ?? false)
                 } else {

--- a/ios/Capacitor/Capacitor/JS.swift
+++ b/ios/Capacitor/Capacitor/JS.swift
@@ -11,13 +11,13 @@ public class JSDate {
  * A call originating from JavaScript land
  */
 public class JSCall {
-    public var options: JSObject = [:]
+    public var options: [String: Any] = [:]
     public var pluginId: String = ""
     public var method: String = ""
     public var callbackId: String = ""
 
     public init(options: [String: Any], pluginId: String, method: String, callbackId: String) {
-        self.options = JSTypes.coerceDictionaryToJSObject(options) ?? [:]
+        self.options = options
         self.pluginId = pluginId
         self.method = method
         self.callbackId = callbackId


### PR DESCRIPTION
This branch moves the point at which the `JSCall` options are coerced into the preferred swift types. The coercion strips `NSNull` objects, which is an Obj-C placeholder for `nil` in collections. Removing the object(s) changes the indexes of arguments on Cordova calls and breaks existing behavior. The coercion is moved from the `JSCall` wrapper (which is used for both types of plugins) to the point where the `CAPPluginCall` is created for Capacitor plugins.