### PR TITLE
fix(android): append missing new lines on cordova injected files

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -149,7 +149,7 @@ public class FileUtils {
             StringBuffer buffer = new StringBuffer();
             String line;
             while ((line = reader.readLine()) != null) {
-                buffer.append(line);
+                buffer.append(line + "\n");
             }
 
             return buffer.toString();


### PR DESCRIPTION
As the `BufferedReader` is reading line per line, we need to append a `\n` in the `StringBuffer`, otherwise the cordova.js and cordova plugins js files get unformatted, causing syntax errors.
This was mistakenly removed in a previous refactor.