### PR TITLE
feat(cli): configurable iOS build scheme

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -262,6 +262,7 @@ async function loadIOSConfig(
   const podPath = determineCocoapodPath();
   const platformDir = extConfig.ios?.path ?? 'ios';
   const platformDirAbs = resolve(rootDir, platformDir);
+  const scheme = extConfig.ios?.scheme ?? 'App';
   const nativeProjectDir = 'App';
   const nativeProjectDirAbs = resolve(platformDirAbs, nativeProjectDir);
   const nativeTargetDir = `${nativeProjectDir}/App`;
@@ -285,6 +286,7 @@ async function loadIOSConfig(
     minVersion: '12.0',
     platformDir,
     platformDirAbs,
+    scheme,
     cordovaPluginsDir,
     cordovaPluginsDirAbs: resolve(platformDirAbs, cordovaPluginsDir),
     nativeProjectDir,

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -176,6 +176,21 @@ export interface CapacitorConfig {
     path?: string;
 
     /**
+     * iOS build scheme to use.
+     *
+     * Usually this matches your app's target in Xcode. You can use the
+     * following command to list schemes:
+     *
+     * ```shell
+     * xcodebuild -workspace ios/App/App.xcworkspace -list
+     * ```
+     *
+     * @since 3.0.0
+     * @default App
+     */
+    scheme?: string;
+
+    /**
      * User agent of Capacitor Web View on iOS.
      *
      * Overrides global `overrideUserAgent` option.

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -96,6 +96,7 @@ export interface IOSConfig extends PlatformConfig {
   readonly cordovaPluginsDirAbs: string;
   readonly minVersion: string;
   readonly podPath: string;
+  readonly scheme: string;
   readonly webDir: Promise<string>;
   readonly webDirAbs: Promise<string>;
   readonly nativeProjectDir: string;

--- a/cli/src/ios/run.ts
+++ b/cli/src/ios/run.ts
@@ -29,7 +29,7 @@ export async function runIOS(
     '-workspace',
     basename(await config.ios.nativeXcodeWorkspaceDirAbs),
     '-scheme',
-    'App',
+    config.ios.scheme,
     '-configuration',
     'Debug',
     '-destination',
@@ -46,7 +46,7 @@ export async function runIOS(
     }),
   );
 
-  const appName = 'App.app';
+  const appName = `${config.ios.scheme}.app`;
   const appPath = resolve(
     derivedDataPath,
     'Build/Products',


### PR DESCRIPTION
This allows custom scheme names to be used when running `npx cap run`.