### PR TITLE
refactor: use androidx.coordinatorlayout, not all of android.material

### DIFF
--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -4,7 +4,7 @@ ext {
     targetSdkVersion = 30
     androidxAppCompatVersion = '1.2.0'
     androidxCoreVersion = '1.3.2'
-    androidxMaterialVersion = '1.3.0-rc01'
+    androidxCoordinatorLayoutVersion = '1.1.0'
     junitVersion = '4.13.1'
     androidxJunitVersion = '1.1.2'
     androidxEspressoCoreVersion = '3.3.0'

--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -3,8 +3,8 @@ ext {
     compileSdkVersion = 30
     targetSdkVersion = 30
     androidxAppCompatVersion = '1.2.0'
-    androidxCoreVersion = '1.3.2'
     androidxCoordinatorLayoutVersion = '1.1.0'
+    androidxCoreVersion = '1.3.2'
     junitVersion = '4.13.1'
     androidxJunitVersion = '1.1.2'
     androidxEspressoCoreVersion = '3.3.0'

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -1,7 +1,7 @@
 ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.1.0'
+    androidxCoordinatorLayoutVersion = project.hasProperty('androidxCoordinatorLayoutVersion') ? rootProject.ext.androidxCoordinatorLayoutVersion : '1.1.0'
     androidxCoreVersion = project.hasProperty('androidxCoreVersion') ? rootProject.ext.androidxCoreVersion : '1.2.0'
-    androidxMaterialVersion = project.hasProperty('androidxMaterialVersion') ? rootProject.ext.androidxMaterialVersion : '1.1.0-rc02'
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.12'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.1'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.2.0'
@@ -61,7 +61,7 @@ dependencies {
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation 'androidx.activity:activity:1.2.0-rc01'
     implementation 'androidx.fragment:fragment:1.3.0-rc01'
-    implementation "com.google.android.material:material:$androidxMaterialVersion"
+    implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
…x.coordinatorlayout

we are including the whole android material dependency but it's not used anymore.
On the other hand, it includes a dependency to `androidx.coordinatorlayout`, which is used.

So this PR removes `com.google.android.material` dependency and adds `androidx.coordinatorlayout`