### PR TITLE
test(iOS): Add tests for `Date` types in JSValue collections

### DIFF
--- a/ios/Capacitor/CapacitorTests/BridgedTypesTests.swift
+++ b/ios/Capacitor/CapacitorTests/BridgedTypesTests.swift
@@ -24,7 +24,7 @@ class BridgedTypesTests: XCTestCase {
     
     override class func setUp() {
         let formatter = ISO8601DateFormatter()
-        // an ISO 8601 string does not necessarily include subsecond precision, so we can't just captured the current date
+        // an ISO 8601 string does not necessarily include subsecond precision, so we can't just capture the current date
         // or else we won't be able to compare the objects since they could differ by milliseconds or nanoseonds. so instead
         // we use a fixed timestamp at a whole hour.
         let date = NSDate(timeIntervalSinceReferenceDate: 632854800)

--- a/ios/Capacitor/CapacitorTests/JSONSerializationWrapper.h
+++ b/ios/Capacitor/CapacitorTests/JSONSerializationWrapper.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @interface JSONSerializationWrapper : NSObject
-@property (nonatomic, strong) NSDictionary* _Nonnull dictionary;
+@property (nonatomic, copy) NSDictionary* _Nonnull dictionary;
 
 - (instancetype _Nullable)initWithDictionary:(NSDictionary* _Nonnull)options;
 - (NSDictionary * _Nullable)unwrappedResult;


### PR DESCRIPTION
Companion to https://github.com/ionic-team/capacitor/pull/4043

This branch adds tests for the Date handling in JSTypes. It also renames the ivars in BridgedTypesTests to make the usage more clear.