### PR TITLE
fix: fix isPluginAvailable() for web and native

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -4,6 +4,11 @@ import static com.getcapacitor.FileUtils.readFile;
 
 import android.content.Context;
 import android.text.TextUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,38 +45,33 @@ public class JSExport {
 
     public static String getPluginJS(Collection<PluginHandle> plugins) {
         List<String> lines = new ArrayList<>();
-
-        lines.add("// Begin: Capacitor Plugin JS");
+        JSONArray pluginArray = new JSONArray();
 
         for (PluginHandle plugin : plugins) {
-            lines.add(
-                "(function(w) {\n" +
-                "var a = (w.Capacitor = w.Capacitor || {});\n" +
-                "var p = (a.Plugins = a.Plugins || {});\n" +
-                "var t = (p['" +
-                plugin.getId() +
-                "'] = {});\n" +
-                "t.addListener = function(eventName, callback) {\n" +
-                "  return w.Capacitor.addListener('" +
-                plugin.getId() +
-                "', eventName, callback);\n" +
-                "}"
-            );
-
+            String id = plugin.getId();
+            JSONObject pluginObj = new JSONObject();
             Collection<PluginMethodHandle> methods = plugin.getMethods();
+            try {
+                JSONArray methodArray = new JSONArray();
+                pluginObj.put("name", id);
 
-            for (PluginMethodHandle method : methods) {
-                if (method.getName().equals("addListener") || method.getName().equals("removeListener")) {
-                    // Don't export add/remove listener, we do that automatically above as they are "special snowflakes"
-                    continue;
+                for (PluginMethodHandle method : methods) {
+                    JSONObject methodObj = new JSONObject();
+                    methodObj.put("name", method.getName());
+                    if (!method.getReturnType().equals(PluginMethod.RETURN_NONE)) {
+                        methodObj.put("rtype", method.getReturnType());
+                    }
+                    methodArray.put(methodObj);
                 }
 
-                lines.add(generateMethodJS(plugin, method));
+                pluginObj.put("methods", methodArray);
+            } catch (JSONException e) {
+              // ignore
             }
-            lines.add("})(window);\n");
+            pluginArray.put(pluginObj);
         }
 
-        return TextUtils.join("\n", lines);
+        return "window.Capacitor.PluginHeaders = " + pluginArray.toString() + ";";
     }
 
     public static String getCordovaPluginJS(Context context) {
@@ -93,59 +93,5 @@ public class JSExport {
             Logger.error("Unable to read file at path " + path);
         }
         return builder.toString();
-    }
-
-    private static String generateMethodJS(PluginHandle plugin, PluginMethodHandle method) {
-        List<String> lines = new ArrayList<>();
-
-        List<String> args = new ArrayList<>();
-        // Add the catch all param that will take a full javascript object to pass to the plugin
-        args.add(CATCHALL_OPTIONS_PARAM);
-
-        String returnType = method.getReturnType();
-        if (returnType.equals(PluginMethod.RETURN_CALLBACK)) {
-            args.add(CALLBACK_PARAM);
-        }
-
-        // Create the method function declaration
-        lines.add("t['" + method.getName() + "'] = function(" + TextUtils.join(", ", args) + ") {");
-
-        switch (returnType) {
-            case PluginMethod.RETURN_NONE:
-                lines.add(
-                    "return w.Capacitor.nativeCallback('" +
-                    plugin.getId() +
-                    "', '" +
-                    method.getName() +
-                    "', " +
-                    CATCHALL_OPTIONS_PARAM +
-                    ")"
-                );
-                break;
-            case PluginMethod.RETURN_PROMISE:
-                lines.add(
-                    "return w.Capacitor.nativePromise('" + plugin.getId() + "', '" + method.getName() + "', " + CATCHALL_OPTIONS_PARAM + ")"
-                );
-                break;
-            case PluginMethod.RETURN_CALLBACK:
-                lines.add(
-                    "return w.Capacitor.nativeCallback('" +
-                    plugin.getId() +
-                    "', '" +
-                    method.getName() +
-                    "', " +
-                    CATCHALL_OPTIONS_PARAM +
-                    ", " +
-                    CALLBACK_PARAM +
-                    ")"
-                );
-                break;
-            default:
-            // TODO: Do something here?
-        }
-
-        lines.add("}");
-
-        return TextUtils.join("\n", lines);
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -4,15 +4,13 @@ import static com.getcapacitor.FileUtils.readFile;
 
 import android.content.Context;
 import android.text.TextUtils;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class JSExport {
 
@@ -52,16 +50,16 @@ public class JSExport {
         for (PluginHandle plugin : plugins) {
             lines.add(
                 "(function(w) {\n" +
-                    "var a = (w.Capacitor = w.Capacitor || {});\n" +
-                    "var p = (a.Plugins = a.Plugins || {});\n" +
-                    "var t = (p['" +
-                    plugin.getId() +
-                    "'] = {});\n" +
-                    "t.addListener = function(eventName, callback) {\n" +
-                    "  return w.Capacitor.addListener('" +
-                    plugin.getId() +
-                    "', eventName, callback);\n" +
-                    "}"
+                "var a = (w.Capacitor = w.Capacitor || {});\n" +
+                "var p = (a.Plugins = a.Plugins || {});\n" +
+                "var t = (p['" +
+                plugin.getId() +
+                "'] = {});\n" +
+                "t.addListener = function(eventName, callback) {\n" +
+                "  return w.Capacitor.addListener('" +
+                plugin.getId() +
+                "', eventName, callback);\n" +
+                "}"
             );
             String id = plugin.getId();
             JSONObject pluginObj = new JSONObject();
@@ -135,12 +133,12 @@ public class JSExport {
             case PluginMethod.RETURN_NONE:
                 lines.add(
                     "return w.Capacitor.nativeCallback('" +
-                        plugin.getId() +
-                        "', '" +
-                        method.getName() +
-                        "', " +
-                        CATCHALL_OPTIONS_PARAM +
-                        ")"
+                    plugin.getId() +
+                    "', '" +
+                    method.getName() +
+                    "', " +
+                    CATCHALL_OPTIONS_PARAM +
+                    ")"
                 );
                 break;
             case PluginMethod.RETURN_PROMISE:
@@ -151,18 +149,18 @@ public class JSExport {
             case PluginMethod.RETURN_CALLBACK:
                 lines.add(
                     "return w.Capacitor.nativeCallback('" +
-                        plugin.getId() +
-                        "', '" +
-                        method.getName() +
-                        "', " +
-                        CATCHALL_OPTIONS_PARAM +
-                        ", " +
-                        CALLBACK_PARAM +
-                        ")"
+                    plugin.getId() +
+                    "', '" +
+                    method.getName() +
+                    "', " +
+                    CATCHALL_OPTIONS_PARAM +
+                    ", " +
+                    CALLBACK_PARAM +
+                    ")"
                 );
                 break;
             default:
-                // TODO: Do something here?
+            // TODO: Do something here?
         }
 
         lines.add("}");

--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -20,10 +20,6 @@ class JSInjector {
     private String cordovaPluginsFileJS;
     private String localUrlJS;
 
-    public JSInjector(String globalJS, String pluginJS) {
-        this(globalJS, pluginJS, ""/* cordovaJS */, ""/* cordovaPluginsJS */, ""/* cordovaPluginsFileJS */, ""/* localUrlJS */);
-    }
-
     public JSInjector(
         String globalJS,
         String pluginJS,

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -5,6 +5,16 @@ import type {
   PluginResultError,
 } from './definitions';
 
+export interface PluginHeaderMethod {
+  readonly name: string;
+  readonly rtype?: 'promise' | 'callback';
+}
+
+export interface PluginHeader {
+  readonly name: string;
+  readonly methods: readonly PluginHeaderMethod[];
+}
+
 /**
  * Has all instance properties that are available and used
  * by the native layer. The "Capacitor" interface it extends
@@ -22,6 +32,8 @@ export interface CapacitorInstance extends CapacitorGlobal {
       [prop: string]: any;
     };
   };
+
+  PluginHeaders: readonly PluginHeader[];
 
   /**
    * Low-level API to send data to the native layer.

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -33,7 +33,7 @@ export interface CapacitorInstance extends CapacitorGlobal {
     };
   };
 
-  PluginHeaders: readonly PluginHeader[];
+  PluginHeaders?: readonly PluginHeader[];
 
   /**
    * Low-level API to send data to the native layer.

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -2,6 +2,7 @@ import { getPlatformId, initBridge } from './bridge';
 import type { CapacitorGlobal, PluginImplementations } from './definitions';
 import type {
   CapacitorInstance,
+  PluginHeader,
   WindowCapacitor,
 } from './definitions-internal';
 import { initEvents } from './events';
@@ -28,14 +29,21 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
   const isPluginAvailable = (pluginName: string): boolean => {
     const plugin = registeredPlugins.get(pluginName);
 
-    if (!plugin) {
-      return false;
+    if (plugin && getPlatform() in plugin.implementations) {
+      // JS implementation available for the current platform.
+      return true;
     }
 
-    const platform = getPlatform();
+    if (getPluginHeader(pluginName)) {
+      // Native implementation available.
+      return true;
+    }
 
-    return !!plugin.implementations[platform];
+    return false;
   };
+
+  const getPluginHeader = (pluginName: string): PluginHeader | undefined =>
+    cap.PluginHeaders?.find(h => h.name === pluginName);
 
   const convertFileSrc = (filePath: string) =>
     convertFileSrcServerUrl(webviewServerUrl, filePath);

--- a/core/src/tests/runtime.spec.ts
+++ b/core/src/tests/runtime.spec.ts
@@ -22,6 +22,7 @@ describe('runtime', () => {
   it('used existing window.Capacitor.Plugins', () => {
     win.Capacitor = {
       Plugins: { Awesome: {} },
+      PluginHeaders: [{ name: 'Awesome', methods: [] }],
     } as any;
     cap = createCapacitor(win);
     expect(cap.isPluginAvailable('Awesome')).toBe(true);


### PR DESCRIPTION
This PR introduces the idea of "plugin headers" that are written to JS alongside the plugin skeleton implementations.

This is required because the [core refactor](https://github.com/ionic-team/capacitor/pull/3748) changed how the `Capacitor.Plugins` object is populated and broke `isPluginAvailable()`. The new headers are necessary to know if a plugin has an implementation on native. `isPluginAvailable()` has been updated to check JS and native implementations.

I want to do a refactor later to remove the plugin skeleton implementations because they're unnecessary with our proxy and with bundling the core together.