### PR TITLE
refactor(core): deprecate options as callback for nativeCallback()

### DIFF
--- a/core/src/bridge.ts
+++ b/core/src/bridge.ts
@@ -191,12 +191,15 @@ export const initBridge = (
     // toNative bridge found
     cap.nativeCallback = (pluginName, methodName, options, callback) => {
       if (typeof options === 'function') {
-        callback = options;
-        options = null;
+        console.warn(
+          `Using a callback as the 'options' parameter of 'nativeCallback()' is deprecated.`,
+        );
+
+        (callback as any) = options;
+        (options as any) = null;
       }
-      return cap.toNative(pluginName, methodName, options, {
-        callback: callback,
-      });
+
+      return cap.toNative(pluginName, methodName, options, { callback });
     };
 
     cap.nativePromise = (pluginName, methodName, options) => {

--- a/core/src/definitions.ts
+++ b/core/src/definitions.ts
@@ -40,10 +40,10 @@ export interface CapacitorGlobal {
    * Sends data over the bridge to the native layer.
    * Returns the Callback Id.
    */
-  nativeCallback: (
+  nativeCallback: <O>(
     pluginName: string,
     methodName: string,
-    options?: any,
+    options?: O,
     callback?: PluginCallback,
   ) => string;
 
@@ -52,11 +52,11 @@ export interface CapacitorGlobal {
    * resolves the promise when it receives the data from
    * the native implementation.
    */
-  nativePromise: (
+  nativePromise: <O, R>(
     pluginName: string,
     methodName: string,
-    options?: any,
-  ) => Promise<any>;
+    options?: O,
+  ) => Promise<R>;
 
   registerPlugin: RegisterPlugin;
 


### PR DESCRIPTION
Not sure if anyone is using `nativeCallback()` directly, but if they are, this particular usage should probably be deprecated.