### PR TITLE
refactor(core): remove plugin skeleton implementations

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -3,19 +3,13 @@ package com.getcapacitor;
 import static com.getcapacitor.FileUtils.readFile;
 
 import android.content.Context;
-import android.text.TextUtils;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class JSExport {
-
-    private static String CATCHALL_OPTIONS_PARAM = "_options";
-    private static String CALLBACK_PARAM = "_callback";
 
     public static String getGlobalJS(Context context, boolean isDebug) {
         return "window.Capacitor = { DEBUG: " + isDebug + ", Plugins: {} };";
@@ -42,40 +36,13 @@ public class JSExport {
     }
 
     public static String getPluginJS(Collection<PluginHandle> plugins) {
-        List<String> lines = new ArrayList<>();
         JSONArray pluginArray = new JSONArray();
 
-        lines.add("// Begin: Capacitor Plugin JS");
-
         for (PluginHandle plugin : plugins) {
-            lines.add(
-                "(function(w) {\n" +
-                "var a = (w.Capacitor = w.Capacitor || {});\n" +
-                "var p = (a.Plugins = a.Plugins || {});\n" +
-                "var t = (p['" +
-                plugin.getId() +
-                "'] = {});\n" +
-                "t.addListener = function(eventName, callback) {\n" +
-                "  return w.Capacitor.addListener('" +
-                plugin.getId() +
-                "', eventName, callback);\n" +
-                "}"
-            );
-            Collection<PluginMethodHandle> methods = plugin.getMethods();
-            for (PluginMethodHandle method : methods) {
-                if (method.getName().equals("addListener") || method.getName().equals("removeListener")) {
-                    // Don't export add/remove listener, we do that automatically above as they are "special snowflakes"
-                    continue;
-                }
-                lines.add(generateMethodJS(plugin, method));
-            }
-
-            lines.add("})(window);\n");
-
             pluginArray.put(createPluginHeader(plugin));
         }
 
-        return TextUtils.join("\n", lines) + "\nwindow.Capacitor.PluginHeaders = " + pluginArray.toString() + ";";
+        return "window.Capacitor.PluginHeaders = " + pluginArray.toString() + ";";
     }
 
     public static String getCordovaPluginJS(Context context) {
@@ -131,59 +98,5 @@ public class JSExport {
         }
 
         return methodObj;
-    }
-
-    private static String generateMethodJS(PluginHandle plugin, PluginMethodHandle method) {
-        List<String> lines = new ArrayList<>();
-
-        List<String> args = new ArrayList<>();
-        // Add the catch all param that will take a full javascript object to pass to the plugin
-        args.add(CATCHALL_OPTIONS_PARAM);
-
-        String returnType = method.getReturnType();
-        if (returnType.equals(PluginMethod.RETURN_CALLBACK)) {
-            args.add(CALLBACK_PARAM);
-        }
-
-        // Create the method function declaration
-        lines.add("t['" + method.getName() + "'] = function(" + TextUtils.join(", ", args) + ") {");
-
-        switch (returnType) {
-            case PluginMethod.RETURN_NONE:
-                lines.add(
-                    "return w.Capacitor.nativeCallback('" +
-                    plugin.getId() +
-                    "', '" +
-                    method.getName() +
-                    "', " +
-                    CATCHALL_OPTIONS_PARAM +
-                    ")"
-                );
-                break;
-            case PluginMethod.RETURN_PROMISE:
-                lines.add(
-                    "return w.Capacitor.nativePromise('" + plugin.getId() + "', '" + method.getName() + "', " + CATCHALL_OPTIONS_PARAM + ")"
-                );
-                break;
-            case PluginMethod.RETURN_CALLBACK:
-                lines.add(
-                    "return w.Capacitor.nativeCallback('" +
-                    plugin.getId() +
-                    "', '" +
-                    method.getName() +
-                    "', " +
-                    CATCHALL_OPTIONS_PARAM +
-                    ", " +
-                    CALLBACK_PARAM +
-                    ")"
-                );
-                break;
-            default:
-            // TODO: Do something here?
-        }
-
-        lines.add("}");
-
-        return TextUtils.join("\n", lines);
     }
 }

--- a/core/src/definitions.ts
+++ b/core/src/definitions.ts
@@ -144,8 +144,8 @@ export interface Plugin {
   addListener(
     eventName: string,
     listenerFunc: (...args: any[]) => any,
-  ): PluginListenerHandle;
-  removeAllListeners(): void;
+  ): Promise<PluginListenerHandle>;
+  removeAllListeners(): Promise<void>;
 }
 
 export type PermissionState =
@@ -155,7 +155,7 @@ export type PermissionState =
   | 'denied';
 
 export interface PluginListenerHandle {
-  remove: () => void;
+  remove: () => Promise<void>;
 }
 
 export interface PluginResultData {

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -20,7 +20,7 @@ export const initEvents = (
       callback,
     );
     return {
-      remove: () => {
+      remove: async () => {
         win?.console?.debug('Removing listener', pluginName, eventName);
         cap.removeListener(pluginName, callbackId, eventName, callback);
       },

--- a/core/src/legacy/legacy-handlers.ts
+++ b/core/src/legacy/legacy-handlers.ts
@@ -31,7 +31,7 @@ export const initLegacyHandlers = (
         // Add a dummy listener so Capacitor doesn't do the default
         // back button action
         cap.Plugins.App.addListener('backButton', () => {
-          /**/
+          // ignore
         });
       }
       return docAddEventListener.apply(doc, args);

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -35,7 +35,7 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
   const isPluginAvailable = (pluginName: string): boolean => {
     const plugin = registeredPlugins.get(pluginName);
 
-    if (plugin && plugin.platforms.has(getPlatform())) {
+    if (plugin?.platforms.has(getPlatform())) {
       // JS implementation available for the current platform.
       return true;
     }

--- a/core/src/tests/bridge.spec.ts
+++ b/core/src/tests/bridge.spec.ts
@@ -112,7 +112,7 @@ describe('bridge', () => {
 
     try {
       cap.nativeCallback('pluginName', 'methodName', {}, () => {
-        /**/
+        // ignore
       });
       done('did not throw');
     } catch (e) {

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -10,7 +10,7 @@ describe('legacy', () => {
   const LegacyWebPlugin = class extends WebPlugin {};
   const orgConsoleWarn = console.warn;
   const noop = () => {
-    /**/
+    // do nothing
   };
 
   beforeAll(() => {
@@ -102,13 +102,13 @@ describe('legacy', () => {
 
   it('doc.addEventListener backbutton', done => {
     const AppWeb = class {
-      addListener(eventName: string) {
+      async addListener(eventName: string) {
         expect(eventName).toBe('backButton');
         done();
       }
     };
     const bbCallback = () => {
-      /**/
+      // ignore
     };
     win = {
       document: {
@@ -129,7 +129,7 @@ describe('legacy', () => {
     win = {
       document: {
         addEventListener() {
-          /**/
+          // ignore
         },
       },
     };

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -78,7 +78,7 @@ describe('legacy', () => {
     expect(cap.Plugins['Legacy']).toBe(Legacy);
   });
 
-  it('error registerWebPlugin() w/out config.name', () => {
+  it('error registerWebPlugin() w/out config.name', async () => {
     win = {};
     cap = createCapacitor(win) as any;
 
@@ -89,7 +89,7 @@ describe('legacy', () => {
     );
   });
 
-  it('error registerWebPlugin() w/out config', () => {
+  it('error registerWebPlugin() w/out config', async () => {
     win = {};
     cap = createCapacitor(win) as any;
 

--- a/core/src/tests/plugin.spec.ts
+++ b/core/src/tests/plugin.spec.ts
@@ -54,7 +54,7 @@ describe('plugin', () => {
 
     // core runtime creates the actual Capacitor instance
     cap = createCapacitor(win);
-    cap.nativePromise = async () => 88;
+    cap.nativePromise = async () => 88 as any;
 
     // user runtime registers the plugin
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');

--- a/core/src/tests/plugin.spec.ts
+++ b/core/src/tests/plugin.spec.ts
@@ -1,4 +1,4 @@
-import type { Plugin, PluginResultError } from '../definitions';
+import type { Plugin } from '../definitions';
 import type {
   CapacitorInstance,
   WindowCapacitor,
@@ -19,9 +19,9 @@ describe('plugin', () => {
     // mock the global with the android bridge
     mockAndroidBridge();
 
-    // simulate native adding the bridge before the core runtime
-    // but it's not adding the mph() method
-    mockNativeImplementationJsBridge('Awesome', 'whatever');
+    // simulate native adding the plugin header with a garbage method before
+    // the core runtime
+    mockAndroidPlugin('Awesome', 'whatever');
 
     // core runtime creates the actual Capacitor instance
     cap = createCapacitor(win);
@@ -49,11 +49,12 @@ describe('plugin', () => {
     // mock the global with the android bridge
     mockAndroidBridge();
 
-    // simulate native adding the bridge before the core runtime
-    mockNativeImplementationJsBridge('Awesome', 'mph');
+    // simulate native adding the plugin header before the core runtime
+    mockAndroidPlugin('Awesome', 'mph');
 
     // core runtime creates the actual Capacitor instance
     cap = createCapacitor(win);
+    cap.nativePromise = async () => 88;
 
     // user runtime registers the plugin
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
@@ -98,7 +99,9 @@ describe('plugin', () => {
     cap = createCapacitor(win);
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      android: () => Promise.reject('unable to load module'),
+      android: async () => {
+        throw 'unable to load module';
+      },
     });
 
     try {
@@ -129,9 +132,7 @@ describe('plugin', () => {
     };
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      android: () =>
-        // lazy load implementation
-        Promise.resolve().then(() => new AwesomePlugin()),
+      android: async () => new AwesomePlugin(),
     });
 
     const p1 = Awesome.mph();
@@ -174,29 +175,21 @@ describe('plugin', () => {
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
       android: {
-        mph: () => {
+        mph: async () => {
           throw new Error('nope!');
         },
       },
     });
 
-    expect(() => {
-      Awesome.mph();
-    }).toThrowError('nope!');
-
-    expect(() => {
-      cap.Plugins.Awesome.mph();
-    }).toThrowError('nope!');
+    expect(async () => Awesome.mph()).rejects.toThrowError('nope!');
+    expect(async () => cap.Plugins.Awesome.mph()).rejects.toThrowError('nope!');
   });
 
   it('missing method on lazy loaded implementation', async done => {
     cap = createCapacitor(win);
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      web: () =>
-        Promise.resolve().then(() => {
-          return {};
-        }),
+      web: async () => ({}),
     });
 
     try {
@@ -217,7 +210,7 @@ describe('plugin', () => {
     }
   });
 
-  it('missing method on already loaded implementation', done => {
+  it('missing method on already loaded implementation', async done => {
     mockAndroidBridge();
     cap = createCapacitor(win);
 
@@ -226,7 +219,7 @@ describe('plugin', () => {
     });
 
     try {
-      Awesome.mph();
+      await Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome.mph()" is not implemented on android`);
@@ -234,7 +227,7 @@ describe('plugin', () => {
     }
 
     try {
-      cap.Plugins.Awesome.mph();
+      await cap.Plugins.Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome.mph()" is not implemented on android`);
@@ -243,38 +236,14 @@ describe('plugin', () => {
     }
   });
 
-  it('automatically register native plugins on global', async () => {
-    mockAndroidBridge();
-
-    let count = 88;
-    win.Capacitor = {
-      Plugins: {
-        Awesome: {
-          mph: () => {
-            return count++;
-          },
-        },
-      },
-    } as any;
-
-    cap = createCapacitor(win);
-
-    const results1 = await cap.Plugins.Awesome.mph();
-    expect(results1).toBe(88);
-
-    const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
-    const results2 = await Awesome.mph();
-    expect(results2).toBe(89);
-  });
-
-  it('no web platform implementation', done => {
+  it('no web platform implementation', async done => {
     cap = createCapacitor(win);
     expect(cap.getPlatform()).toBe('web');
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
 
     try {
-      Awesome.mph();
+      await Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome" plugin is not implemented on web`);
@@ -282,7 +251,7 @@ describe('plugin', () => {
     }
 
     try {
-      cap.Plugins.Awesome.mph();
+      await cap.Plugins.Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome" plugin is not implemented on web`);
@@ -291,17 +260,17 @@ describe('plugin', () => {
     }
   });
 
-  it('no native platform implementation', done => {
-    mockAndroidBridge({ mph: 88 });
+  it('no native platform implementation', async done => {
+    mockAndroidBridge();
     cap = createCapacitor(win);
     expect(cap.getPlatform()).toBe('android');
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      web: { mph: () => 88 },
+      web: { mph: async () => 88 },
     });
 
     try {
-      Awesome.mph();
+      await Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome" plugin is not implemented on android`);
@@ -309,7 +278,7 @@ describe('plugin', () => {
     }
 
     try {
-      cap.Plugins.Awesome.mph();
+      await cap.Plugins.Awesome.mph();
       done('should throw error');
     } catch (e) {
       expect(e.message).toBe(`"Awesome" plugin is not implemented on android`);
@@ -319,7 +288,8 @@ describe('plugin', () => {
   });
 
   it('do not double register a plugin', () => {
-    mockAndroidBridge({ mph: 88 });
+    mockAndroidBridge();
+    mockAndroidPlugin('Awesome', 'mph');
     cap = createCapacitor(win);
     expect(cap.getPlatform()).toBe('android');
 
@@ -329,26 +299,20 @@ describe('plugin', () => {
     expect(Awesome1).toBe(Awesome2);
   });
 
-  it('addListener, w/out addListener on implementation', done => {
+  it('addListener, w/out addListener on implementation', async done => {
     const LazyWeb = class {
       val = 88;
-      addListener(_eventName: string, fn: any) {
+      async addListener(_eventName: string, fn: any) {
         fn(this.val);
       }
     };
 
     cap = createCapacitor(win);
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      web: () =>
-        new Promise(resolve => {
-          setTimeout(() => {
-            const lazyWeb = new LazyWeb();
-            resolve(lazyWeb);
-          }, 100);
-        }),
+      web: async () => new LazyWeb(),
     });
 
-    const rtn = Awesome.addListener('eventName', data => {
+    Awesome.addListener('eventName', data => {
       try {
         expect(data).toEqual(88);
         done();
@@ -356,71 +320,68 @@ describe('plugin', () => {
         done(e);
       }
     });
-
-    expect(rtn).toBeDefined();
-    expect(typeof rtn.remove === 'function').toBe(true);
   });
 
-  it('removeAllListeners, return void, lazy load and call implementation', done => {
-    let called = false;
+  it('sync addListener on android', async () => {
+    mockAndroidBridge();
+    mockAndroidPlugin('Awesome', 'mph');
+    cap = createCapacitor(win);
+
+    const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
+
+    const rtn = Awesome.addListener('eventName', () => {});
+    expect(rtn).toBeDefined();
+    expect(typeof (rtn as any).remove === 'function').toBe(true);
+  });
+
+  it('async addListener on android', async () => {
+    mockAndroidBridge();
+    mockAndroidPlugin('Awesome', 'mph');
+    cap = createCapacitor(win);
+
+    const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
+
+    const rtn = await Awesome.addListener('eventName', () => {});
+    expect(rtn).toBeDefined();
+    expect(typeof (rtn as any).remove === 'function').toBe(true);
+  });
+
+  it('async removeAllListeners on web, lazy load and call implementation', async done => {
     const AwesomeWeb = class extends WebPlugin {
-      removeAllListeners() {
-        called = true;
+      async removeAllListeners() {
+        setImmediate(() => done());
       }
     };
     cap = createCapacitor(win);
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome', {
-      web: () => Promise.resolve(new AwesomeWeb()),
+      web: async () => new AwesomeWeb(),
     });
 
-    const rtn = Awesome.removeAllListeners();
+    const rtn = await Awesome.removeAllListeners();
     expect(rtn).toBeUndefined();
-
-    setTimeout(() => {
-      expect(called).toBe(true);
-      done();
-    }, 100);
   });
 
-  const mockAndroidBridge = (responseData?: any, err?: PluginResultError) => {
+  const mockAndroidBridge = () => {
     win.androidBridge = {
-      postMessage: m => {
-        const d = JSON.parse(m);
-        Promise.resolve().then(() => {
-          cap.fromNative({
-            callbackId: d.callbackId,
-            methodName: d.methodName,
-            data: responseData,
-            error: err,
-            success: !err,
-          });
-        });
+      postMessage: () => {
+        // ignore
       },
     };
   };
 
-  const mockNativeImplementationJsBridge = (
-    pluginClassName: string,
-    methodName: string,
-  ) => {
-    // mocking how native code adds their plugin js bridge to the global
-    // ios/Capacitor/Capacitor/JSExport.swift
-    // android/capacitor/src/main/java/com/getcapacitor/JSExport.java
-
-    (function (w) {
-      const a = (w.Capacitor = w.Capacitor || {});
-      const p = (a.Plugins = a.Plugins || {});
-      const t = (p[pluginClassName] = {}) as any;
-      t.addListener = function (eventName: any, callback: any) {
-        return w.Capacitor.addListener(pluginClassName, eventName, callback);
-      };
-
-      t[methodName] = function () {
-        return new Promise(resolve => {
-          resolve(88);
-        });
-      };
-    })(win as any);
+  const mockAndroidPlugin = (pluginClassName: string, methodName: string) => {
+    const w: any = win;
+    w.Capacitor = w.Capacitor ?? {};
+    w.Capacitor.PluginHeaders = w.Capacitor.PluginHeaders ?? [];
+    w.Capacitor.PluginHeaders.push({
+      name: pluginClassName,
+      methods: [
+        { name: methodName, rtype: 'promise' },
+        { name: 'addListener' },
+        { name: 'removeListener' },
+        { name: 'removeAllListeners' },
+      ],
+    });
   };
 });
 

--- a/core/src/tests/plugin.spec.ts
+++ b/core/src/tests/plugin.spec.ts
@@ -329,7 +329,10 @@ describe('plugin', () => {
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
 
-    const rtn = Awesome.addListener('eventName', () => {});
+    const rtn = Awesome.addListener('eventName', () => {
+      // ignore
+    });
+
     expect(rtn).toBeDefined();
     expect(typeof (rtn as any).remove === 'function').toBe(true);
   });
@@ -341,7 +344,10 @@ describe('plugin', () => {
 
     const Awesome = cap.registerPlugin<AwesomePlugin>('Awesome');
 
-    const rtn = await Awesome.addListener('eventName', () => {});
+    const rtn = await Awesome.addListener('eventName', () => {
+      // ignore
+    });
+
     expect(rtn).toBeDefined();
     expect(typeof (rtn as any).remove === 'function').toBe(true);
   });

--- a/core/src/tests/web-plugin.spec.ts
+++ b/core/src/tests/web-plugin.spec.ts
@@ -15,12 +15,12 @@ describe('Web Plugin', () => {
     plugin = new MockPlugin();
   });
 
-  it('Should add event listeners', () => {
+  it('Should add event listeners', async () => {
     const lf = (event: any) => {
       console.log(event);
     };
 
-    const handle = plugin.addListener('test', lf);
+    const handle = await plugin.addListener('test', lf);
 
     const listener = plugin.listeners['test'];
     expect(listener).not.toBe(undefined);
@@ -28,7 +28,7 @@ describe('Web Plugin', () => {
     handle.remove();
   });
 
-  it('Should manage multiple event listeners', () => {
+  it('Should manage multiple event listeners', async () => {
     const lf1 = (event: any) => {
       console.log(event);
     };
@@ -38,9 +38,9 @@ describe('Web Plugin', () => {
     const lf3 = (event: any) => {
       console.log(event);
     };
-    const handle1 = plugin.addListener('test', lf1);
-    const handle2 = plugin.addListener('test', lf2);
-    const handle3 = plugin.addListener('test', lf3);
+    const handle1 = await plugin.addListener('test', lf1);
+    const handle2 = await plugin.addListener('test', lf2);
+    const handle3 = await plugin.addListener('test', lf3);
 
     const listener = plugin.listeners['test'];
     expect(listener.length).toEqual(3);
@@ -52,20 +52,20 @@ describe('Web Plugin', () => {
     expect(listener.length).toEqual(0);
   });
 
-  it('Should remove event listeners', () => {
+  it('Should remove event listeners', async () => {
     const lf = (event: any) => {
       console.log(event);
     };
-    const handle = plugin.addListener('test', lf);
+    const handle = await plugin.addListener('test', lf);
     handle.remove();
 
     const listener = plugin.listeners['test'];
     expect(listener).toEqual([]);
   });
 
-  it('Should notify listeners', () => {
+  it('Should notify listeners', async () => {
     const lf = jest.fn();
-    const handle = plugin.addListener('test', lf);
+    const handle = await plugin.addListener('test', lf);
 
     plugin.trigger();
 
@@ -76,7 +76,7 @@ describe('Web Plugin', () => {
     handle.remove();
   });
 
-  it('Should register and remove window listeners', () => {
+  it('Should register and remove window listeners', async () => {
     const pluginAddWindowListener = jest.spyOn(
       MockPlugin.prototype as any,
       'addWindowListener',
@@ -84,7 +84,7 @@ describe('Web Plugin', () => {
     plugin.registerWindowListener('fake', 'test');
 
     const lf = jest.fn();
-    const handle = plugin.addListener('test', lf);
+    const handle = await plugin.addListener('test', lf);
 
     // Make sure the window listener was added
     let windowListener = plugin.windowListeners['test'];

--- a/core/src/tests/web-plugin.spec.ts
+++ b/core/src/tests/web-plugin.spec.ts
@@ -6,6 +6,18 @@ class MockPlugin extends WebPlugin {
       value: 'Capacitors on top of toast!',
     });
   }
+
+  getListeners() {
+    return this.listeners;
+  }
+
+  getWindowListeners() {
+    return this.windowListeners;
+  }
+
+  registerFakeWindowListener() {
+    this.registerWindowListener('fake', 'test');
+  }
 }
 
 describe('Web Plugin', () => {
@@ -22,7 +34,7 @@ describe('Web Plugin', () => {
 
     const handle = await plugin.addListener('test', lf);
 
-    const listener = plugin.listeners['test'];
+    const listener = plugin.getListeners()['test'];
     expect(listener).not.toBe(undefined);
     expect(listener.length).toEqual(1);
     handle.remove();
@@ -42,7 +54,7 @@ describe('Web Plugin', () => {
     const handle2 = await plugin.addListener('test', lf2);
     const handle3 = await plugin.addListener('test', lf3);
 
-    const listener = plugin.listeners['test'];
+    const listener = plugin.getListeners()['test'];
     expect(listener.length).toEqual(3);
     handle1.remove();
     expect(listener.length).toEqual(2);
@@ -59,7 +71,7 @@ describe('Web Plugin', () => {
     const handle = await plugin.addListener('test', lf);
     handle.remove();
 
-    const listener = plugin.listeners['test'];
+    const listener = plugin.getListeners()['test'];
     expect(listener).toEqual([]);
   });
 
@@ -81,13 +93,13 @@ describe('Web Plugin', () => {
       MockPlugin.prototype as any,
       'addWindowListener',
     );
-    plugin.registerWindowListener('fake', 'test');
+    plugin.registerFakeWindowListener();
 
     const lf = jest.fn();
     const handle = await plugin.addListener('test', lf);
 
     // Make sure the window listener was added
-    let windowListener = plugin.windowListeners['test'];
+    let windowListener = plugin.getWindowListeners()['test'];
     expect(windowListener.registered).toEqual(true);
     expect(pluginAddWindowListener.mock.calls.length).toEqual(1);
 
@@ -103,15 +115,15 @@ describe('Web Plugin', () => {
     expect(eventArg.detail.value).toEqual('Capacitors on top of toast!');
 
     handle.remove();
-    windowListener = plugin.windowListeners['test'];
+    windowListener = plugin.getWindowListeners()['test'];
     expect(windowListener.registered).toEqual(false);
   });
 
   it('Should only call window event if listeners bound', () => {
-    plugin.registerWindowListener('fake', 'test');
+    plugin.registerFakeWindowListener();
 
     // Make sure the window listener was added
-    const windowListener = plugin.windowListeners['test'];
+    const windowListener = plugin.getWindowListeners()['test'];
 
     expect(windowListener.registered).toEqual(false);
 

--- a/ios/Capacitor/Capacitor/JSExport.swift
+++ b/ios/Capacitor/Capacitor/JSExport.swift
@@ -38,53 +38,35 @@ internal class JSExport {
             CAPLog.print("ERROR: Unable to read required cordova files. Cordova plugins will not function!")
             throw CapacitorBridgeError.errorExportingCoreJS
         }
-
     }
 
     /**
      * Export the JS required to implement the given plugin.
      */
     public static func exportJS(userContentController: WKUserContentController, pluginClassName: String, pluginType: CAPPlugin.Type) {
-        var lines = [String]()
-
-        lines.append("""
-            (function(w) {
-            var a = (w.Capacitor = w.Capacitor || {});
-            var p = (a.Plugins = a.Plugins || {});
-            var t = (p['\(pluginClassName)'] = {});
-            t.addListener = function(eventName, callback) {
-            return w.Capacitor.addListener('\(pluginClassName)', eventName, callback);
-            }
-            """)
-        if let bridgeType = pluginType as? CAPBridgedPlugin.Type, let methods = bridgeType.pluginMethods() as? [CAPPluginMethod] {
-            for method in methods {
-                lines.append(generateMethod(pluginClassName: pluginClassName, method: method))
-            }
-        }
-
-        lines.append("""
-    })(window);
-    """)
-
         if let data = try? JSONEncoder().encode(createPluginHeader(pluginClassName: pluginClassName, pluginType: pluginType)), let header = String(data: data, encoding: .utf8) {
-            lines.append("""
+            let js = """
                 (function(w) {
                 var a = (w.Capacitor = w.Capacitor || {});
                 var h = (a.PluginHeaders = a.PluginHeaders || []);
                 h.push(\(header));
                 })(window);
-                """)
+                """
+            let userScript = WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+            userContentController.addUserScript(userScript)
         }
-
-        let js = lines.joined(separator: "\n")
-
-        let userScript = WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: true)
-        userContentController.addUserScript(userScript)
     }
 
     private static func createPluginHeader(pluginClassName: String, pluginType: CAPPlugin.Type) -> PluginHeader? {
-        if let bridgeType = pluginType as? CAPBridgedPlugin.Type, let methods = bridgeType.pluginMethods() as? [CAPPluginMethod] {
-            return PluginHeader(name: pluginClassName, methods: methods.map { createPluginHeaderMethod(method: $0) })
+        if let bridgeType = pluginType as? CAPBridgedPlugin.Type, let pluginMethods = bridgeType.pluginMethods() as? [CAPPluginMethod] {
+            let methods = [
+                PluginHeaderMethod(name: "addListener", rtype: nil),
+                PluginHeaderMethod(name: "removeListener", rtype: nil),
+                PluginHeaderMethod(name: "removeAllListeners", rtype: nil),
+                PluginHeaderMethod(name: "checkPermissions", rtype: "promise"),
+                PluginHeaderMethod(name: "requestPermissions", rtype: "promise")
+            ]
+            return PluginHeader(name: pluginClassName, methods: methods + pluginMethods.map { createPluginHeaderMethod(method: $0) })
         }
 
         return nil
@@ -96,58 +78,6 @@ internal class JSExport {
             rtype = nil
         }
         return PluginHeaderMethod(name: method.name, rtype: rtype)
-    }
-
-    private static func generateMethod(pluginClassName: String, method: CAPPluginMethod) -> String {
-        let methodName = method.name!
-        let returnType = method.returnType!
-        var paramList = [String]()
-
-        // add the catch-all
-        // options argument which takes a full object and converts each
-        // key/value pair into an option for plugin call.
-        paramList.append(catchallOptionsParameter)
-
-        // Automatically add the _callback param if returning data through a callback
-        if returnType == CAPPluginReturnCallback {
-            paramList.append(callbackParameter)
-        }
-
-        // Create a param string of the form "param1, param2, param3"
-        let paramString = paramList.joined(separator: ", ")
-
-        // Generate the argument object that will be sent on each call
-        let argObjectString = catchallOptionsParameter
-
-        var lines = [String]()
-
-        // Create the function declaration
-        lines.append("t['\(method.name!)'] = function(\(paramString)) {")
-
-        // Create the call to Capacitor ...
-        if returnType == CAPPluginReturnNone {
-            // ...using none
-            lines.append("""
-                return w.Capacitor.nativeCallback('\(pluginClassName)', '\(methodName)', \(argObjectString));
-                """)
-        } else if returnType == CAPPluginReturnPromise {
-
-            // ...using a promise
-            lines.append("""
-                return w.Capacitor.nativePromise('\(pluginClassName)', '\(methodName)', \(argObjectString));
-                """)
-        } else if returnType == CAPPluginReturnCallback {
-            // ...using a callback
-            lines.append("""
-                return w.Capacitor.nativeCallback('\(pluginClassName)', '\(methodName)', \(argObjectString), \(callbackParameter));
-                """)
-        } else {
-            CAPLog.print("Error: plugin method return type \(returnType) is not supported!")
-        }
-
-        // Close the function
-        lines.append("}")
-        return lines.joined(separator: "\n")
     }
 
     public static func exportCordovaPluginsJS(userContentController: WKUserContentController) throws {


### PR DESCRIPTION
In 3.0.0-beta.1, `Geolocation.watchPosition()` is currently broken on web. It returns a callback ID synchronously on native but asynchronously on web (due to the [core refactor](https://github.com/ionic-team/capacitor/pull/3748)). Since all plugin methods are supposed to be asynchronous now, this PR cleans up some additional things:

- The `addListener()`, `removeListener()`, and `removeAllListeners()` methods from Capacitor 2 should be asynchronous (see https://github.com/ionic-team/capacitor-plugins/pull/223).
- The auto-generated JS plugin functions for calling into native have been removed. Instead, the core now relies more on the proxy object to hijack the plugin methods. This is achieved by relying on the "plugin headers" written by native platforms (introduced in https://github.com/ionic-team/capacitor/pull/4114).
- The proxy code itself has been substantially simplified.

**Notes**

There is a horribly gross and complicated backwards-compatibility layer that makes `addListener(...).remove()` work synchronously with a console warning that synchronous usage is deprecated. We should remove this in Capacitor 4.

**TODO**
- [x] Make sure Geolocation is OK
- [x] Fix `isPluginAvailable()`
- [x] Fix tests