### PR TITLE
fix(iOS): Handle NSString in JSValue type casting

### DIFF
--- a/ios/Capacitor/Capacitor/JSTypes.swift
+++ b/ios/Capacitor/Capacitor/JSTypes.swift
@@ -2,6 +2,7 @@ import Foundation
 
 // declare our empty protocol, and conformance, for typing
 public protocol JSValue {}
+extension NSString: JSValue {}
 extension String: JSValue {}
 extension Bool: JSValue {}
 extension Int: JSValue {}


### PR DESCRIPTION
This PR adds support for type casting NSString to JSValue

See below for example problem (taken from https://github.com/ionic-team/capacitor-plugins/pull/211):
```swift
var notificationExtras = request.content.userInfo["cap_extra"] as? [String: Any?]
if let notificationExtras = notificationExtras {
    var extra: JSObject = [:]
    for(key, value) in notificationExtras {
        extra[key] = value as? JSValue // will be nil if value is NSString
    }    
}
```