### PR TITLE
fix(android): live reload not working when using adb reverse

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -172,7 +172,7 @@ public class WebViewLocalServer {
       return null;
     }
 
-    if (isLocalFile(loadingUrl) || loadingUrl.getHost().equalsIgnoreCase(bridge.getHost()) || (bridge.getServerUrl() == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()))) {
+    if (isLocalFile(loadingUrl) || isMainUrl(loadingUrl) || !isAllowedUrl(loadingUrl)) {
       Logger.debug("Handling local request: " + request.getUrl().toString());
       return handleLocalRequest(request, handler);
     } else {
@@ -186,6 +186,14 @@ public class WebViewLocalServer {
       return true;
     }
     return false;
+  }
+
+  private boolean isMainUrl(Uri loadingUrl) {
+    return (bridge.getServerUrl() == null && loadingUrl.getHost().equalsIgnoreCase(bridge.getHost()));
+  }
+
+  private boolean isAllowedUrl(Uri loadingUrl) {
+    return !(bridge.getServerUrl() == null && !bridge.getAppAllowNavigationMask().matches(loadingUrl.getHost()));
   }
 
   private WebResourceResponse handleLocalRequest(WebResourceRequest request, PathHandler handler) {


### PR DESCRIPTION
When using adb reverse live reload is not working because of the `loadingUrl.getHost().equalsIgnoreCase(bridge.getHost())` check, so add an extra check to see if live reload is enabled, and if so, use the proxy instead of loading local assets.
Also split each check in different functions to make it more readable.

closes https://github.com/ionic-team/capacitor/issues/4125