### PR TITLE
refactor(android): permission API cleanup

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.net.Uri;
@@ -868,10 +869,13 @@ public class Bridge {
             } else {
                 for (String permString : perm.strings()) {
                     String key = perm.alias().isEmpty() ? permString : perm.alias();
-                    PermissionState permissionStatus = plugin.hasPermission(permString) ? PermissionState.GRANTED : PermissionState.PROMPT;
+                    PermissionState permissionStatus;
+                    if (ActivityCompat.checkSelfPermission(this.getContext(), permString) == PackageManager.PERMISSION_GRANTED) {
+                        permissionStatus = PermissionState.GRANTED;
+                    } else {
+                        permissionStatus = PermissionState.PROMPT;
 
-                    // Check if there is a cached permission state for the "Never ask again" state
-                    if (permissionStatus == PermissionState.PROMPT) {
+                        // Check if there is a cached permission state for the "Never ask again" state
                         SharedPreferences prefs = getContext().getSharedPreferences(PERMISSION_PREFS_NAME, Activity.MODE_PRIVATE);
                         String state = prefs.getString(permString, null);
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -830,7 +830,7 @@ public class Bridge {
 
         String[] permStrings = permissions.keySet().toArray(new String[0]);
 
-        if (!plugin.hasDefinedPermissions(permStrings)) {
+        if (!PermissionHelper.hasDefinedPermissions(getContext(), permStrings)) {
             StringBuilder builder = new StringBuilder();
             builder.append("Missing the following permissions in AndroidManifest.xml:\n");
             String[] missing = PermissionHelper.getUndefinedPermissions(getContext(), permStrings);

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -753,6 +753,7 @@ public class Bridge {
         }
     }
 
+    @Deprecated
     public void startActivityForPluginWithResult(PluginCall call, Intent intent, int requestCode) {
         Logger.debug("Starting activity for result");
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -377,12 +377,14 @@ public class Plugin {
     }
 
     /**
-     * If the {@link CapacitorPlugin} annotation specified a set of permissions,
-     * this method checks if each is granted. Note: if you are okay
-     * with a limited subset of the permissions being granted, check
-     * each one individually instead with hasPermission
+     * If the plugin annotation specified a set of permissions, this method checks if each is
+     * granted
+     * @deprecated use {@link #getPermissionState(String)} or {@link #getPermissionStates()} to
+     * check whether permissions are granted or not
+     *
      * @return
      */
+    @Deprecated
     public boolean hasRequiredPermissions() {
         CapacitorPlugin annotation = handle.getPluginAnnotation();
         if (annotation == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -191,7 +191,7 @@ public class Plugin {
      * Set the Bridge instance for this plugin
      * @param bridge
      */
-    void setBridge(Bridge bridge) {
+    public void setBridge(Bridge bridge) {
         this.bridge = bridge;
     }
 
@@ -208,7 +208,7 @@ public class Plugin {
      * as indexed methods for reflection, and {@link CapacitorPlugin} annotation data).
      * @param pluginHandle
      */
-    void setPluginHandle(PluginHandle pluginHandle) {
+    public void setPluginHandle(PluginHandle pluginHandle) {
         this.handle = pluginHandle;
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -16,7 +16,6 @@ import androidx.core.app.ActivityCompat;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.util.PermissionHelper;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -192,7 +191,7 @@ public class Plugin {
      * Set the Bridge instance for this plugin
      * @param bridge
      */
-    public void setBridge(Bridge bridge) {
+    void setBridge(Bridge bridge) {
         this.bridge = bridge;
     }
 
@@ -209,7 +208,7 @@ public class Plugin {
      * as indexed methods for reflection, and {@link CapacitorPlugin} annotation data).
      * @param pluginHandle
      */
-    public void setPluginHandle(PluginHandle pluginHandle) {
+    void setPluginHandle(PluginHandle pluginHandle) {
         this.handle = pluginHandle;
     }
 
@@ -343,9 +342,15 @@ public class Plugin {
 
     /**
      * Check whether the given permission has been granted by the user
+     * @deprecated use {@link #getPermissionState(String)} and {@link #getPermissionStates()} to get
+     * the states of permissions defined on the Plugin in conjunction with the @CapacitorPlugin
+     * annotation. Use the Android API {@link ActivityCompat#checkSelfPermission(Context, String)}
+     * methods to check permissions with Android permission strings
+     *
      * @param permission
      * @return
      */
+    @Deprecated
     public boolean hasPermission(String permission) {
         return ActivityCompat.checkSelfPermission(this.getContext(), permission) == PackageManager.PERMISSION_GRANTED;
     }
@@ -363,7 +368,7 @@ public class Plugin {
             // Check for legacy plugin annotation, @NativePlugin
             NativePlugin legacyAnnotation = handle.getLegacyPluginAnnotation();
             for (String perm : legacyAnnotation.permissions()) {
-                if (!hasPermission(perm)) {
+                if (ActivityCompat.checkSelfPermission(this.getContext(), perm) != PackageManager.PERMISSION_GRANTED) {
                     return false;
                 }
             }
@@ -373,7 +378,7 @@ public class Plugin {
 
         for (Permission perm : annotation.permissions()) {
             for (String permString : perm.strings()) {
-                if (!hasPermission(permString)) {
+                if (ActivityCompat.checkSelfPermission(this.getContext(), permString) != PackageManager.PERMISSION_GRANTED) {
                     return false;
                 }
             }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -548,18 +548,6 @@ public class Plugin {
     }
 
     /**
-     * Helper for requesting specific permissions
-     * @deprecated use {@link #requestPermissions(PluginCall)} in conjunction with @CapacitorPlugin
-     *
-     * @param permissions the set of permissions to request
-     * @param requestCode the requestCode to use to associate the result with the plugin
-     */
-    @Deprecated
-    public void pluginRequestPermissions(String[] permissions, int requestCode) {
-        ActivityCompat.requestPermissions(getActivity(), permissions, requestCode);
-    }
-
-    /**
      * Request all of the specified permissions in the CapacitorPlugin annotation (if any)
      * @deprecated use {@link #requestAllPermissions(PluginCall)} in conjunction with @CapacitorPlugin
      */
@@ -579,6 +567,19 @@ public class Plugin {
     @Deprecated
     public void pluginRequestPermission(String permission, int requestCode) {
         ActivityCompat.requestPermissions(getActivity(), new String[] { permission }, requestCode);
+    }
+
+    /**
+     * Helper for requesting specific permissions
+     * @deprecated use {@link #requestPermissionForAliases(String[], PluginCall)} in conjunction
+     * with @CapacitorPlugin
+     *
+     * @param permissions the set of permissions to request
+     * @param requestCode the requestCode to use to associate the result with the plugin
+     */
+    @Deprecated
+    public void pluginRequestPermissions(String[] permissions, int requestCode) {
+        ActivityCompat.requestPermissions(getActivity(), permissions, requestCode);
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/util/PermissionHelper.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/PermissionHelper.java
@@ -52,6 +52,22 @@ public class PermissionHelper {
     }
 
     /**
+     * Check whether all of the given permissions have been defined in the AndroidManifest.xml
+     * @param context the app context
+     * @param permissions a list of permissions
+     * @return true only if all permissions are defined in the AndroidManifest.xml
+     */
+    public static boolean hasDefinedPermissions(Context context, String[] permissions) {
+        for (String permission : permissions) {
+            if (!PermissionHelper.hasDefinedPermission(context, permission)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get the permissions defined in AndroidManifest.xml
      *
      * @since 3.0.0


### PR DESCRIPTION
**Manifest Permission Declaration**
- Added `isPermissionDeclared(String alias)` allowing plugin developers to check if permissions are declared in Manifest using Aliases. (Naming "declared" matches how [Android documentation](https://developer.android.com/training/permissions/declaring) discusses adding these permission strings).
- Deprecated `hasDefinedPermissions(String[] permissions)` and moved to `PermissionHelper`. Expected use internal only but kept as a helper.
- Deprecated `hasDefinedRequiredPermissions`. Plugin authors can use `isPermissionDeclared` with aliases to check if needed.
- Removed `hasDefinedPermissions(Permission[] permissions)` method added during earlier Capacitor 3 work, was similar to `hasDefinedPermissions(String[] permissions)`.

**Checking Permissions**
- Deprecated `hasPermission` since plugin authors can get permission states with Aliases using `getPermissionState` or `getPermissionStates`. This was a thin wrapper around `ActivityCompat.checkSelfPermission` and this Android API method can be used directly instead.
- Deprecated `hasRequiredPermissions`. This helper checked if all defined permissions were "granted" and returned true only if all were granted. This is useful but we now have `getPermissionState` and `getPermissionStates` for plugin authors to check states more granularly. Keeps API concise.

---

**Remaining Permissions API**
These changes leave the following Permission API methods:

- **checkPermissions**
External plugin method for apps to check permissions defined on the plugin.

- **requestPermissions**
External plugin method for apps to request permissions defined on the plugin.

- **requestAllPermissions**
Requests every permission defined on the plugin.

- **requestPermissionForAlias**
Requests permission with a single alias.

- **requestPermissionForAliases**
Requests permission with an array of Aliases.

- **getPermissionState**
Gets the state of a single permission alias.

- **getPermissionStates**
Gets the state map of all permission aliases on the plugin.