### PR TITLE
feat(iOS): Add automatic Date serialization to bridge communication

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		6296A78A253A2E49005A202A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6296A788253A2E49005A202A /* LaunchScreen.storyboard */; };
 		62A91C3425535F5700861508 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A91C3325535F5700861508 /* ConfigurationTests.swift */; };
 		62A91C3F2553710E00861508 /* nonjson.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 62A91C392553710300861508 /* nonjson.json */; };
+		62ADC0CA25CB678000E914DE /* PluginCallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62ADC0C925CB678000E914DE /* PluginCallResult.swift */; };
 		62D43AF02581817500673C24 /* WKWebView+Capacitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D43AEF2581817500673C24 /* WKWebView+Capacitor.swift */; };
 		62D43B652582A13D00673C24 /* WKWebView+Capacitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 62D43B642582A13D00673C24 /* WKWebView+Capacitor.m */; };
 		62E0736125535E8700BAAADB /* server.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 62E0735225535E6500BAAADB /* server.json */; };
@@ -192,6 +193,7 @@
 		6296A78B253A2E49005A202A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		62A91C3325535F5700861508 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		62A91C392553710300861508 /* nonjson.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nonjson.json; sourceTree = "<group>"; };
+		62ADC0C925CB678000E914DE /* PluginCallResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginCallResult.swift; sourceTree = "<group>"; };
 		62D43AEF2581817500673C24 /* WKWebView+Capacitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Capacitor.swift"; sourceTree = "<group>"; };
 		62D43B642582A13D00673C24 /* WKWebView+Capacitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WKWebView+Capacitor.m"; sourceTree = "<group>"; };
 		62E0735225535E6500BAAADB /* server.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = server.json; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				62959AE22524DA7700A3D7F1 /* CAPPluginCall.h */,
 				62959B062524DA7700A3D7F1 /* CAPPluginCall.m */,
 				62959AE62524DA7700A3D7F1 /* CAPPluginCall.swift */,
+				62ADC0C925CB678000E914DE /* PluginCallResult.swift */,
 				621ECCBB2542046400D3D615 /* JSTypes.swift */,
 				621ECCB62542045900D3D615 /* CAPBridgedJSTypes.h */,
 				621ECCB42542045900D3D615 /* CAPBridgedJSTypes.m */,
@@ -564,6 +567,7 @@
 				62959B1D2524DA7800A3D7F1 /* UIColor.swift in Sources */,
 				62959B332524DA7800A3D7F1 /* CAPPlugin.m in Sources */,
 				62959B1C2524DA7800A3D7F1 /* CAPPluginMethod.m in Sources */,
+				62ADC0CA25CB678000E914DE /* PluginCallResult.swift in Sources */,
 				62959B472524DA7800A3D7F1 /* CAPNotifications.swift in Sources */,
 				62D43B652582A13D00673C24 /* WKWebView+Capacitor.m in Sources */,
 				62959B312524DA7800A3D7F1 /* JS.swift in Sources */,

--- a/ios/Capacitor/Capacitor/Array+Capacitor.swift
+++ b/ios/Capacitor/Capacitor/Array+Capacitor.swift
@@ -1,7 +1,7 @@
 // convenience wrappers to transform Arrays between NSNull and Optional values, for interoperability with Obj-C
 extension Array: CapacitorExtension {}
-extension CapacitorExtensionTypeWrapper where T == Array<JSValue> {
-    public func replacingNullValues() -> Array<JSValue?> {
+extension CapacitorExtensionTypeWrapper where T == [JSValue] {
+    public func replacingNullValues() -> [JSValue?] {
         return baseType.map({ (value) -> JSValue? in
             if value is NSNull {
                 return nil
@@ -9,18 +9,18 @@ extension CapacitorExtensionTypeWrapper where T == Array<JSValue> {
             return value
         })
     }
-    
-    public func replacingOptionalValues() -> Array<JSValue> {
+
+    public func replacingOptionalValues() -> [JSValue] {
         return baseType
     }
 }
 
-extension CapacitorExtensionTypeWrapper where T == Array<JSValue?> {
-    public func replacingNullValues() -> Array<JSValue?> {
+extension CapacitorExtensionTypeWrapper where T == [JSValue?] {
+    public func replacingNullValues() -> [JSValue?] {
         return baseType
     }
-    
-    public func replacingOptionalValues() -> Array<JSValue> {
+
+    public func replacingOptionalValues() -> [JSValue] {
         return baseType.map({ (value) -> JSValue in
             if let value = value {
                 return value

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -121,7 +121,7 @@ import Cordova
 
     /**
      Allows any additional configuration to be performed. The `webView` and `bridge` properties will be set by this point.
-     
+
      - Note: This is called before the webview has been added to the view hierarchy. Not all operations may be possible at
      this time.
      */

--- a/ios/Capacitor/Capacitor/CAPPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPPlugin.h
@@ -12,6 +12,7 @@
 @property (nonatomic, strong, nonnull) NSString *pluginName;
 @property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, NSMutableArray<CAPPluginCall *>*> *eventListeners;
 @property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *retainedEventArguments;
+@property (nonatomic, assign) BOOL shouldStringifyDatesInCalls;
 
 - (instancetype _Nonnull) initWithBridge:(id<CAPBridgeProtocol> _Nonnull) bridge pluginId:(NSString* _Nonnull) pluginId pluginName:(NSString* _Nonnull) pluginName;
 - (void)addEventListener:(NSString* _Nonnull)eventName listener:(CAPPluginCall* _Nonnull)listener;

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -11,6 +11,7 @@
   self.pluginName = pluginName;
   self.eventListeners = [[NSMutableDictionary alloc] init];
   self.retainedEventArguments = [[NSMutableDictionary alloc] init];
+  self.shouldStringifyDatesInCalls = true;
   return self;
 }
 

--- a/ios/Capacitor/Capacitor/CAPPluginCall.h
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.h
@@ -1,24 +1,8 @@
-
-@interface CAPPluginCallResult : NSObject
-
-@property (nonatomic, strong) NSDictionary<NSString *, id>* data;
-
-- (instancetype)init:(NSDictionary<NSString *, id>*)data;
-
-@end
-
-@interface CAPPluginCallError : NSObject
-
-@property (nonatomic, strong) NSString *message;
-@property (nonatomic, strong) NSString *code;
-@property (nonatomic, strong) NSError *error;
-@property (nonatomic, strong) NSDictionary<NSString *, id> *data;
-
-- (instancetype)initWithMessage:(NSString *)message code:(NSString *)code error:(NSError *)error data:(NSDictionary<NSString *, id>*)data;
-
-@end
+#import <Foundation/Foundation.h>
 
 @class CAPPluginCall;
+@class CAPPluginCallResult;
+@class CAPPluginCallError;
 
 typedef void(^CAPPluginCallSuccessHandler)(CAPPluginCallResult *result, CAPPluginCall* call);
 typedef void(^CAPPluginCallErrorHandler)(CAPPluginCallError *error);
@@ -35,5 +19,3 @@ typedef void(^CAPPluginCallErrorHandler)(CAPPluginCallError *error);
 
 - (void)save;
 @end
-
-

--- a/ios/Capacitor/Capacitor/CAPPluginCall.m
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.m
@@ -1,25 +1,5 @@
 #import <Foundation/Foundation.h>
-
 #import "CAPPluginCall.h"
-
-@implementation CAPPluginCallResult
-- (instancetype)init:(NSDictionary<NSString *, id>*)data {
-  self.data = data;
-  return self;
-}
-@end
-
-@implementation CAPPluginCallError
-
-- (instancetype)initWithMessage:(NSString *)message code:(NSString *) code error:(NSError *)error data:(NSDictionary<NSString *,id> *)data {
-  self.message = message;
-  self.code = code;
-  self.error = error;
-  self.data = data;
-  return self;
-}
-
-@end
 
 @implementation CAPPluginCall
 

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -1,6 +1,9 @@
+import Foundation
+
+@available(*, deprecated, renamed: "PluginCallResultData")
 public typealias PluginCallErrorData = [String: Any]
+@available(*, deprecated, renamed: "PluginCallResultData")
 public typealias PluginResultData = [String: Any]
-public typealias PluginEventListener = CAPPluginCall
 
 /**
  * Swift niceties for CAPPluginCall
@@ -37,24 +40,24 @@ extension CAPPluginCall: JSValueContainer {
     }
 
     @available(*, deprecated, renamed: "resolve")
-    func success(_ data: PluginResultData = [:]) {
+    func success(_ data: PluginCallResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }
 
     func resolve() {
-        successHandler(CAPPluginCallResult(), self)
+        successHandler(CAPPluginCallResult(nil), self)
     }
 
-    func resolve(_ data: PluginResultData = [:]) {
+    func resolve(_ data: PluginCallResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
     }
 
     @available(*, deprecated, renamed: "reject")
-    func error(_ message: String, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
+    func error(_ message: String, _ error: Error? = nil, _ data: PluginCallResultData = [:]) {
         errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
     }
 
-    func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallErrorData = [:]) {
+    func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallResultData = [:]) {
         errorHandler(CAPPluginCallError(message: message, code: code, error: error, data: data))
     }
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -369,7 +369,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                 return
             }
 
-            //CAPLog.print("\n⚡️  Calling method \"\(call.method)\" on plugin \"\(plugin.getId()!)\"")
+            // CAPLog.print("\n⚡️  Calling method \"\(call.method)\" on plugin \"\(plugin.getId()!)\"")
 
             selector = method.selector
         }
@@ -383,7 +383,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
         // Create a plugin call object and handle the success/error callbacks
         dispatchQueue.async { [weak self] in
-            //let startTime = CFAbsoluteTimeGetCurrent()
+            // let startTime = CFAbsoluteTimeGetCurrent()
 
             let pluginCall = CAPPluginCall(callbackId: call.callbackId,
                                            options: JSTypes.coerceDictionaryToJSObject(call.options, formattingDatesAsStrings: plugin.shouldStringifyDatesInCalls) ?? [:],
@@ -408,8 +408,8 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                 }
             }
 
-            //let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
-            //CAPLog.print("Native call took", timeElapsed)
+            // let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+            // CAPLog.print("Native call took", timeElapsed)
         }
     }
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -386,7 +386,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
             //let startTime = CFAbsoluteTimeGetCurrent()
 
             let pluginCall = CAPPluginCall(callbackId: call.callbackId,
-                                           options: JSTypes.coerceDictionaryToJSObject(call.options) ?? [:],
+                                           options: JSTypes.coerceDictionaryToJSObject(call.options, formattingDatesAsStrings: plugin.shouldStringifyDatesInCalls) ?? [:],
                                            success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
                 if result != nil {
                     self?.toJs(result: JSResult(call: call, result: result!.data), save: pluginCall?.isSaved ?? false)

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -388,20 +388,19 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
             let pluginCall = CAPPluginCall(callbackId: call.callbackId,
                                            options: JSTypes.coerceDictionaryToJSObject(call.options, formattingDatesAsStrings: plugin.shouldStringifyDatesInCalls) ?? [:],
                                            success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
-                if let result = result {
-                    self?.toJs(result: JSResult(call: call, callResult: result), save: pluginCall?.isSaved ?? false)
-                } else {
-                    self?.toJs(result: JSResult(call: call, result: .dictionary([:])), save: pluginCall?.isSaved ?? false)
-                }
-            }, error: {(error: CAPPluginCallError?) -> Void in
-                if let error = error {
-                    self?.toJsError(error: JSResultError(call: call, callError: error))
-                }
-                else {
-                    self?.toJsError(error: JSResultError(call: call, errorMessage: "", errorDescription: "", errorCode: nil, result: .dictionary([:])))
-                }
-            })
-            
+                                            if let result = result {
+                                                self?.toJs(result: JSResult(call: call, callResult: result), save: pluginCall?.isSaved ?? false)
+                                            } else {
+                                                self?.toJs(result: JSResult(call: call, result: .dictionary([:])), save: pluginCall?.isSaved ?? false)
+                                            }
+                                           }, error: {(error: CAPPluginCallError?) -> Void in
+                                            if let error = error {
+                                                self?.toJsError(error: JSResultError(call: call, callError: error))
+                                            } else {
+                                                self?.toJsError(error: JSResultError(call: call, errorMessage: "", errorDescription: "", errorCode: nil, result: .dictionary([:])))
+                                            }
+                                           })
+
             if let pluginCall = pluginCall {
                 plugin.perform(selector, with: pluginCall)
                 if pluginCall.isSaved {
@@ -456,7 +455,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
              success: true,
              data: \(resultJson)
              })
-            """) { (result, error) in
+            """) { (_, error) in
                 if let error = error {
                     CAPLog.print(error)
                 }
@@ -469,7 +468,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
      */
     func toJsError(error: JSResultProtocol) {
         DispatchQueue.main.async {
-            self.webView?.evaluateJavaScript("window.Capacitor.fromNative({ callbackId: '\(error.callbackID)', pluginId: '\(error.pluginID)', methodName: '\(error.methodName)', success: false, error: \(error.jsonPayload())})") { (result, error) in
+            self.webView?.evaluateJavaScript("window.Capacitor.fromNative({ callbackId: '\(error.callbackID)', pluginId: '\(error.pluginID)', methodName: '\(error.methodName)', success: false, error: \(error.jsonPayload())})") { (_, error) in
                 if let error = error {
                     CAPLog.print(error)
                 }

--- a/ios/Capacitor/Capacitor/JS.swift
+++ b/ios/Capacitor/Capacitor/JS.swift
@@ -1,22 +1,26 @@
 import Foundation
 
 public class JSDate {
+    @available(*, deprecated, message: "No longer needed. Dates will be mapped to strings during serialization.")
     static func toString(_ date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         return formatter.string(from: date)
     }
 }
 
+@available(*, deprecated, renamed: "PluginCallResultData")
+public typealias JSResultBody = [String: Any]
+
 /**
  * A call originating from JavaScript land
  */
-public class JSCall {
-    public var options: [String: Any] = [:]
-    public var pluginId: String = ""
-    public var method: String = ""
-    public var callbackId: String = ""
+internal struct JSCall {
+    let options: [String: Any]
+    let pluginId: String
+    let method: String
+    let callbackId: String
 
-    public init(options: [String: Any], pluginId: String, method: String, callbackId: String) {
+    init(options: [String: Any], pluginId: String, method: String, callbackId: String) {
         self.options = options
         self.pluginId = pluginId
         self.method = method
@@ -24,85 +28,115 @@ public class JSCall {
     }
 }
 
-public typealias JSResultBody = [String: Any]
+internal protocol JSResultProtocol {
+    var call: JSCall { get }
+    var callbackID: String { get }
+    var pluginID: String { get }
+    var methodName: String { get }
+    func jsonPayload() -> String
+}
+
+internal extension JSResultProtocol {
+    var callbackID: String {
+        return call.callbackId
+    }
+    
+    var pluginID: String {
+        return call.pluginId
+    }
+    
+    var methodName: String {
+        return call.method
+    }
+}
+
+private enum SerializationResult: String {
+    case undefined = "undefined"
+    case empty = "{}"
+}
 
 /**
  * A result of processing a JSCall, contains
  * a reference to the original call and the new result.
  */
-public class JSResult {
-    public var call: JSCall
-    public var result: JSResultBody?
 
-    public init(call: JSCall, result: JSResultBody?) {
+internal struct JSResult: JSResultProtocol {
+    let call: JSCall
+    let result: PluginCallResult?
+    
+    init(call: JSCall, result: PluginCallResult?) {
         self.call = call
         self.result = result
     }
-
-    public func toJson() -> String {
-        if let result = result {
-            do {
-                if JSONSerialization.isValidJSONObject(result) {
-                    let theJSONData = try JSONSerialization.data(withJSONObject: result, options: [])
-
-                    return String(data: theJSONData,
-                                  encoding: .utf8)!
-                } else {
-                    CAPLog.print("[Capacitor Plugin Error] - \(call.pluginId) - \(call.method) - Unable to serialize plugin response as JSON." +
-                                    "Ensure that all data passed to success callback from module method is JSON serializable!")
-                }
-            } catch {
-                CAPLog.print("Unable to serialize plugin response as JSON: \(error.localizedDescription)")
-            }
-
-            return "{}"
-        } else {
-            return "undefined"
+    
+    func jsonPayload() -> String {
+        guard let result = result else {
+            return SerializationResult.undefined.rawValue
         }
+        do {
+            if let payload = try result.jsonRepresentation() {
+                return payload
+            }
+        } catch PluginCallResult.SerializationError.invalidObject {
+            CAPLog.print("[Capacitor Plugin Error] - \(call.pluginId) - \(call.method) - Unable to serialize plugin response as JSON." +
+                            "Ensure that all data passed to success callback from module method is JSON serializable!")
+        } catch {
+            CAPLog.print("Unable to serialize plugin response as JSON: \(error.localizedDescription)")
+        }
+        return SerializationResult.empty.rawValue
     }
 }
 
-public class JSResultError {
-    var call: JSCall
-    var error: JSResultBody
-    var message: String
-    var code: String?
-    var errorMessage: String
-
-    public init(call: JSCall, message: String, errorMessage: String, error: JSResultBody, code: String? = nil) {
+internal extension JSResult {
+    init(call: JSCall, callResult: CAPPluginCallResult) {
         self.call = call
-        self.message = message
+        self.result = callResult.resultData
+    }
+}
+
+internal struct JSResultError: JSResultProtocol {
+    let call: JSCall
+    let errorMessage: String
+    let errorDescription: String
+    let errorCode: String?
+    let result: PluginCallResult
+    
+    public init(call: JSCall, errorMessage: String, errorDescription: String, errorCode: String?, result: PluginCallResult) {
+        self.call = call
         self.errorMessage = errorMessage
-        self.error = error
-        self.code = code
+        self.errorDescription = errorDescription
+        self.errorCode = errorCode
+        self.result = result
     }
-
-    /**
-     * Return a linkable error that we can use to help users find help for common exceptions,
-     * much like AngularJS back in the day.
-     */
-    func getLinkableError(_ message: String) -> String? {
-        guard let data = message.data(using: .utf8)?.base64EncodedString() else {
-            return nil
+    
+    func jsonPayload() -> String {
+        var errorDictionary: [String: Any] = [
+            "message": self.errorMessage,
+            "errorMessage":  self.errorMessage
+        ]
+        errorDictionary["code"] = self.errorCode
+        
+        do {
+            if let payload = try result.jsonRepresentation(includingFields: errorDictionary) {
+                CAPLog.print("ERROR MESSAGE: ", payload.prefix(512))
+                return payload
+            }
+        } catch PluginCallResult.SerializationError.invalidObject {
+            CAPLog.print("[Capacitor Plugin Error] - \(call.pluginId) - \(call.method) - Unable to serialize plugin response as JSON." +
+                            "Ensure that all data passed to success callback from module method is JSON serializable!")
+        } catch {
+            CAPLog.print("Unable to serialize plugin response as JSON: \(error.localizedDescription)")
         }
-
-        return "\(CapacitorBridge.capacitorSite)error/ios?m=\(data)"
+        return SerializationResult.empty.rawValue
     }
+}
 
-    public func toJson() -> String {
-        var jsonResponse = "{}"
-
-        error["message"] = self.message
-        error["code"] = self.code
-        error["errorMessage"] = self.errorMessage
-        //error["_exlink"] = getLinkableError(self.message)
-
-        if let theJSONData = try? JSONSerialization.data(withJSONObject: error, options: []) {
-            jsonResponse = String(data: theJSONData,
-                                  encoding: .utf8)!
-            CAPLog.print("ERROR MESSAGE: ", jsonResponse.prefix(512))
-        }
-
-        return jsonResponse
+internal extension JSResultError {
+    init(call: JSCall, callError: CAPPluginCallError) {
+        self.call = call
+        errorMessage = callError.message
+        errorDescription = callError.error?.localizedDescription ?? ""
+        errorCode = callError.code
+        result = callError.resultData ?? .dictionary([:])
     }
 }

--- a/ios/Capacitor/Capacitor/JS.swift
+++ b/ios/Capacitor/Capacitor/JS.swift
@@ -40,11 +40,11 @@ internal extension JSResultProtocol {
     var callbackID: String {
         return call.callbackId
     }
-    
+
     var pluginID: String {
         return call.pluginId
     }
-    
+
     var methodName: String {
         return call.method
     }
@@ -63,12 +63,12 @@ private enum SerializationResult: String {
 internal struct JSResult: JSResultProtocol {
     let call: JSCall
     let result: PluginCallResult?
-    
+
     init(call: JSCall, result: PluginCallResult?) {
         self.call = call
         self.result = result
     }
-    
+
     func jsonPayload() -> String {
         guard let result = result else {
             return SerializationResult.undefined.rawValue
@@ -100,7 +100,7 @@ internal struct JSResultError: JSResultProtocol {
     let errorDescription: String
     let errorCode: String?
     let result: PluginCallResult
-    
+
     public init(call: JSCall, errorMessage: String, errorDescription: String, errorCode: String?, result: PluginCallResult) {
         self.call = call
         self.errorMessage = errorMessage
@@ -108,14 +108,14 @@ internal struct JSResultError: JSResultProtocol {
         self.errorCode = errorCode
         self.result = result
     }
-    
+
     func jsonPayload() -> String {
         var errorDictionary: [String: Any] = [
             "message": self.errorMessage,
-            "errorMessage":  self.errorMessage
+            "errorMessage": self.errorMessage
         ]
         errorDictionary["code"] = self.errorCode
-        
+
         do {
             if let payload = try result.jsonRepresentation(includingFields: errorDictionary) {
                 CAPLog.print("ERROR MESSAGE: ", payload.prefix(512))

--- a/ios/Capacitor/Capacitor/JSTypes.swift
+++ b/ios/Capacitor/Capacitor/JSTypes.swift
@@ -177,20 +177,22 @@ extension JSValueContainer {
  */
 public enum JSTypes {}
 extension JSTypes {
-    public static func coerceDictionaryToJSObject(_ dictionary: NSDictionary?) -> JSObject? {
-        return coerceToJSValue(dictionary) as? JSObject
+    public static func coerceDictionaryToJSObject(_ dictionary: NSDictionary?, formattingDatesAsStrings: Bool = false) -> JSObject? {
+        return coerceToJSValue(dictionary, formattingDates: formattingDatesAsStrings) as? JSObject
     }
 
-    public static func coerceDictionaryToJSObject(_ dictionary: [AnyHashable: Any]?) -> JSObject? {
-        return coerceToJSValue(dictionary) as? JSObject
+    public static func coerceDictionaryToJSObject(_ dictionary: [AnyHashable: Any]?, formattingDatesAsStrings: Bool = false) -> JSObject? {
+        return coerceToJSValue(dictionary, formattingDates: formattingDatesAsStrings) as? JSObject
     }
     
-    public static func coerceArrayToJSArray(_ array: [Any]?) -> JSArray? {
-        return array?.compactMap { coerceToJSValue($0) }
+    public static func coerceArrayToJSArray(_ array: [Any]?, formattingDatesAsStrings: Bool = false) -> JSArray? {
+        return array?.compactMap { coerceToJSValue($0, formattingDates: formattingDatesAsStrings) }
     }
 }
 
-private func coerceToJSValue(_ value: Any?) -> JSValue? {
+private let dateStringFormatter = ISO8601DateFormatter()
+
+private func coerceToJSValue(_ value: Any?, formattingDates: Bool) -> JSValue? {
     guard let value = value else {
         return nil
     }
@@ -208,16 +210,19 @@ private func coerceToJSValue(_ value: Any?) -> JSValue? {
     case let doubleValue as Double:
         return doubleValue
     case let dateValue as Date:
+        if formattingDates {
+            return dateStringFormatter.string(from: dateValue)
+        }
         return dateValue
     case let nullValue as NSNull:
         return nullValue
     case let arrayValue as NSArray:
-        return arrayValue.compactMap { coerceToJSValue($0) }
+        return arrayValue.compactMap { coerceToJSValue($0, formattingDates: formattingDates) }
     case let dictionaryValue as NSDictionary:
         let keys = dictionaryValue.allKeys.compactMap { $0 as? String }
         var result: JSObject = [:]
         for key in keys {
-            result[key] = coerceToJSValue(dictionaryValue[key])
+            result[key] = coerceToJSValue(dictionaryValue[key], formattingDates: formattingDates)
         }
         return result
     default:

--- a/ios/Capacitor/Capacitor/JSTypes.swift
+++ b/ios/Capacitor/Capacitor/JSTypes.swift
@@ -184,7 +184,7 @@ extension JSTypes {
     public static func coerceDictionaryToJSObject(_ dictionary: [AnyHashable: Any]?, formattingDatesAsStrings: Bool = false) -> JSObject? {
         return coerceToJSValue(dictionary, formattingDates: formattingDatesAsStrings) as? JSObject
     }
-    
+
     public static func coerceArrayToJSArray(_ array: [Any]?, formattingDatesAsStrings: Bool = false) -> JSArray? {
         return array?.compactMap { coerceToJSValue($0, formattingDates: formattingDatesAsStrings) }
     }

--- a/ios/Capacitor/Capacitor/PluginCallResult.swift
+++ b/ios/Capacitor/Capacitor/PluginCallResult.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public typealias PluginCallResultData = [String: Any]
+
+public enum PluginCallResult {
+    case dictionary(PluginCallResultData)
+    
+    enum SerializationError: Error {
+        case invalidObject
+    }
+    
+    func jsonRepresentation(includingFields: PluginCallResultData? = nil) throws -> String? {
+        switch self {
+        case .dictionary(var dictionary):
+            dictionary = prepare(dictionary: dictionary)
+            guard JSONSerialization.isValidJSONObject(dictionary) else {
+                throw SerializationError.invalidObject
+            }
+            if let fields = includingFields {
+                dictionary.merge(fields) { (current, _) in current }
+            }
+            let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+            return String(data: data, encoding: .utf8)
+        }
+    }
+    
+    private static let formatter = ISO8601DateFormatter()
+    
+    private func prepare(dictionary: PluginCallResultData) -> PluginCallResultData {
+        return dictionary.mapValues { (value) -> Any in
+            if let date = value as? Date {
+                return PluginCallResult.formatter.string(from: date)
+            }
+            else if let aDictionary = value as? PluginCallResultData {
+                return prepare(dictionary: aDictionary)
+            }
+            else if let anArray = value as? [Any] {
+                return prepare(array: anArray)
+            }
+            return value
+        }
+    }
+    
+    private func prepare(array: [Any]) -> [Any] {
+        return array.map { (value) -> Any in
+            if let date = value as? Date {
+                return PluginCallResult.formatter.string(from: date)
+            }
+            else if let aDictionary = value as? PluginCallResultData {
+                return prepare(dictionary: aDictionary)
+            }
+            else if let anArray = value as? [Any] {
+                return prepare(array: anArray)
+            }
+            return value
+        }
+    }
+}
+
+@objc public class CAPPluginCallResult: NSObject {
+    public var resultData: PluginCallResult?
+    
+    @objc public var data: PluginCallResultData? {
+        guard let result = resultData else {
+            return nil
+        }
+        switch result {
+        case .dictionary(let data):
+            return data
+        }
+    }
+    
+    @objc(init:)
+    public init(_ data: PluginCallResultData?) {
+        if let data = data {
+            resultData = .dictionary(data)
+        }
+    }
+}
+
+@objc public class CAPPluginCallError: NSObject {
+    @objc public var message: String
+    @objc public var code: String?
+    @objc public var error: Error?
+    public var resultData: PluginCallResult?
+    
+    @objc public var data: PluginCallResultData? {
+        guard let result = resultData else {
+            return nil
+        }
+        switch result {
+        case .dictionary(let data):
+            return data
+        }
+    }
+    
+    @objc(init:code:error:data:)
+    public init(message: String, code: String?, error: Error?, data: PluginCallResultData?) {
+        self.message = message
+        self.code = code
+        self.error = error
+        if let data = data {
+            self.resultData = .dictionary(data)
+        }
+    }
+}

--- a/ios/Capacitor/Capacitor/PluginCallResult.swift
+++ b/ios/Capacitor/Capacitor/PluginCallResult.swift
@@ -4,11 +4,11 @@ public typealias PluginCallResultData = [String: Any]
 
 public enum PluginCallResult {
     case dictionary(PluginCallResultData)
-    
+
     enum SerializationError: Error {
         case invalidObject
     }
-    
+
     func jsonRepresentation(includingFields: PluginCallResultData? = nil) throws -> String? {
         switch self {
         case .dictionary(var dictionary):
@@ -23,33 +23,29 @@ public enum PluginCallResult {
             return String(data: data, encoding: .utf8)
         }
     }
-    
+
     private static let formatter = ISO8601DateFormatter()
-    
+
     private func prepare(dictionary: PluginCallResultData) -> PluginCallResultData {
         return dictionary.mapValues { (value) -> Any in
             if let date = value as? Date {
                 return PluginCallResult.formatter.string(from: date)
-            }
-            else if let aDictionary = value as? PluginCallResultData {
+            } else if let aDictionary = value as? PluginCallResultData {
                 return prepare(dictionary: aDictionary)
-            }
-            else if let anArray = value as? [Any] {
+            } else if let anArray = value as? [Any] {
                 return prepare(array: anArray)
             }
             return value
         }
     }
-    
+
     private func prepare(array: [Any]) -> [Any] {
         return array.map { (value) -> Any in
             if let date = value as? Date {
                 return PluginCallResult.formatter.string(from: date)
-            }
-            else if let aDictionary = value as? PluginCallResultData {
+            } else if let aDictionary = value as? PluginCallResultData {
                 return prepare(dictionary: aDictionary)
-            }
-            else if let anArray = value as? [Any] {
+            } else if let anArray = value as? [Any] {
                 return prepare(array: anArray)
             }
             return value
@@ -59,7 +55,7 @@ public enum PluginCallResult {
 
 @objc public class CAPPluginCallResult: NSObject {
     public var resultData: PluginCallResult?
-    
+
     @objc public var data: PluginCallResultData? {
         guard let result = resultData else {
             return nil
@@ -69,7 +65,7 @@ public enum PluginCallResult {
             return data
         }
     }
-    
+
     @objc(init:)
     public init(_ data: PluginCallResultData?) {
         if let data = data {
@@ -83,7 +79,7 @@ public enum PluginCallResult {
     @objc public var code: String?
     @objc public var error: Error?
     public var resultData: PluginCallResult?
-    
+
     @objc public var data: PluginCallResultData? {
         guard let result = resultData else {
             return nil
@@ -93,7 +89,7 @@ public enum PluginCallResult {
             return data
         }
     }
-    
+
     @objc(init:code:error:data:)
     public init(message: String, code: String?, error: Error?, data: PluginCallResultData?) {
         self.message = message

--- a/ios/Capacitor/Capacitor/PluginCallResult.swift
+++ b/ios/Capacitor/Capacitor/PluginCallResult.swift
@@ -12,12 +12,12 @@ public enum PluginCallResult {
     func jsonRepresentation(includingFields: PluginCallResultData? = nil) throws -> String? {
         switch self {
         case .dictionary(var dictionary):
+            if let fields = includingFields {
+                dictionary.merge(fields) { (current, _) in current }
+            }
             dictionary = prepare(dictionary: dictionary)
             guard JSONSerialization.isValidJSONObject(dictionary) else {
                 throw SerializationError.invalidObject
-            }
-            if let fields = includingFields {
-                dictionary.merge(fields) { (current, _) in current }
             }
             let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
             return String(data: data, encoding: .utf8)

--- a/ios/Capacitor/Capacitor/PluginCallResult.swift
+++ b/ios/Capacitor/Capacitor/PluginCallResult.swift
@@ -54,7 +54,7 @@ public enum PluginCallResult {
 }
 
 @objc public class CAPPluginCallResult: NSObject {
-    public var resultData: PluginCallResult?
+    public let resultData: PluginCallResult?
 
     @objc public var data: PluginCallResultData? {
         guard let result = resultData else {
@@ -70,15 +70,17 @@ public enum PluginCallResult {
     public init(_ data: PluginCallResultData?) {
         if let data = data {
             resultData = .dictionary(data)
+        } else {
+            resultData = nil
         }
     }
 }
 
 @objc public class CAPPluginCallError: NSObject {
-    @objc public var message: String
-    @objc public var code: String?
-    @objc public var error: Error?
-    public var resultData: PluginCallResult?
+    @objc public let message: String
+    @objc public let code: String?
+    @objc public let error: Error?
+    public let resultData: PluginCallResult?
 
     @objc public var data: PluginCallResultData? {
         guard let result = resultData else {
@@ -96,7 +98,9 @@ public enum PluginCallResult {
         self.code = code
         self.error = error
         if let data = data {
-            self.resultData = .dictionary(data)
+            resultData = .dictionary(data)
+        } else {
+            resultData = nil
         }
     }
 }

--- a/ios/Capacitor/CapacitorTests/BridgedTypesTests.swift
+++ b/ios/Capacitor/CapacitorTests/BridgedTypesTests.swift
@@ -138,6 +138,29 @@ class BridgedTypesTests: XCTestCase {
         XCTAssertTrue(dateObject.compare(parsedDate) == .orderedSame)
     }
     
+    func testDateCoercion() throws {
+        let stringifiedDictionary = JSTypes.coerceDictionaryToJSObject(deserializedDictionary, formattingDatesAsStrings: true)!
+        let unstringifiedDictionary = JSTypes.coerceDictionaryToJSObject(deserializedDictionary, formattingDatesAsStrings: false)!
+        let stringifiedValue = stringifiedDictionary["testDateObject"]!
+        let unstringifiedValue = unstringifiedDictionary["testDateObject"]!
+        XCTAssertTrue(type(of: stringifiedValue) == String.self)
+        XCTAssertTrue(type(of: unstringifiedValue) == Date.self)
+        XCTAssertEqual(stringifiedValue as! String, stringifiedDictionary["testDateString"] as! String)
+    }
+    
+    func testDateResultWrapping() throws {
+        let result = try PluginCallResult.dictionary(["date": unserializedDictionary["testDateObject"]!]).jsonRepresentation()
+        XCTAssertEqual(result, "{\"date\":\"\(unserializedDictionary["testDateString"] as! String)\"}")
+    }
+    
+    func testResultMerging() throws {
+        let result = try PluginCallResult.dictionary(["number": 1]).jsonRepresentation(includingFields: ["string":"foo"])
+        // ordering of the pairs should be non-deterministic
+        if result != "{\"string\":\"foo\",\"number\":1}" && result != "{\"number\":1,\"string\":\"foo\"}" {
+            XCTAssert(false)
+        }
+    }
+    
     func testNullWrapping() throws {
         let dictionary: [AnyHashable: Any] = ["testInt": 1 as Int, "testNull": NSNull()]
         let coercedDictionary = JSTypes.coerceDictionaryToJSObject(dictionary)!


### PR DESCRIPTION
Currently, `WKWebView` will automatically translate JavaScript `Date` objects to NSDate/Date objects when sending data over the bridge from JavaScript -> Native. While this might be helpful it is potentially unexpected, and it is inconsistent with Android where the `Dates` are turned into strings. Dates are not handled at all when sending Native -> JavaScript and including a Date in the result dictionary will cause an exception to be thrown during serialization.

So, this branch does 3 things related to Dates and returning the result of a plugin call. 

1. It serializes Dates in plugin calls during type coercion. This operation is **not** performed for Cordova plugins to preserve backwards compatibility. In addition, a plugin can opt-out of the new behavior by setting its `shouldStringifyDatesInCalls` property to false.

2. It serializes Dates in result dictionaries automatically. A date in will result in an ISO 8601 string out in both directions now. Since the previous behavior was an error, there is no compatibility concerns and plugins can opt out of the serialization by transforming the dates before inserting them into the results.

3. It refactors some of the calling objects in service of 2, as well as to prepare for `Codable` support in the future and paying down tech debt:

    - The declaration/implementation of `CAPPluginCallResult` and `CAPPluginCallError` have been moved from Obj-C to Swift. This keeps the same Obj-C interface but allows them to use new swift types internally.

    - `PluginCallResult` is a new Swift enum to wrap result dictionaries that can be extended to support additional types (such as `Encodable` objects in future work).

    - Multiple `typealias` types have been consolidated.

    - `JSCall`, `JSResult`, and `JSResultError` classes have all been refactored into `internal` immutable structs. Since the methods that use those objects are all `internal`, it made no sense for them to be public. That is technically a breaking change but there is no reason for external code to be referencing them.

    - Some of the surrounding code has been cleaned up to become more idiomatic and to remove force-unwraps and unused code.

Closes https://github.com/ionic-team/capacitor/issues/4160

Documentation update: https://github.com/ionic-team/capacitor-site/pull/207