### PR TITLE
fix(android): Reject on permission prompt cancelation

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/Filesystem.java
@@ -654,6 +654,13 @@ public class Filesystem extends Plugin {
 
     PluginCall savedCall = getSavedCall();
 
+    if (grantResults.length == 0) {
+      Logger.debug(getLogTag(), "Permission prompt was canceled.");
+      savedCall.error(PERMISSION_DENIED_ERROR);
+      this.freeSavedCall();
+      return;
+    }
+
     for (int i = 0; i < grantResults.length; i++) {
       int result = grantResults[i];
       String perm = permissions[i];


### PR DESCRIPTION
If a permission prompt is present and you manage to show another one, the previous one gets canceled and crash the app.
When the prompt is canceled, the `grantResults.length` is `0`, so the PR checks the lenght and if 0, reject with `PERMISSION_DENIED_ERROR`.
Could use a new error, but that probably requires a minor release, and verified that the problem is not present on Capacitor 3 (probably because of the usage of the callback APIs), so this will be short lived.

closes https://github.com/ionic-team/capacitor/issues/4170