### PR TITLE
feat(cli): do not require webDir when server.url is set

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -30,6 +30,7 @@ import {
   getPlugins,
   printPlugins,
 } from '../plugin';
+import { copy as copyTask } from '../tasks/copy';
 import { convertToUnixPath } from '../util/fs';
 import { resolveNode } from '../util/node';
 import { extractTemplate } from '../util/template';
@@ -55,6 +56,9 @@ export async function updateAndroid(config: Config): Promise<void> {
   );
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
+  }
+  if (!(await pathExists(config.android.webDirAbs))) {
+    await copyTask(config, platform);
   }
   await handleCordovaPluginsJS(cordovaPlugins, config, platform);
   await checkPluginDependencies(plugins, platform);

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -19,6 +19,11 @@ export async function check(checks: CheckFunction[]): Promise<void> {
 }
 
 export async function checkWebDir(config: Config): Promise<string | null> {
+  // We can skip checking the web dir if a server URL is set.
+  if (config.app.extConfig.server?.url) {
+    return null;
+  }
+
   const invalidFolders = ['', '.', '..', '../', './'];
   if (invalidFolders.includes(config.app.webDir)) {
     return `"${config.app.webDir}" is not a valid value for webDir`;

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -1,6 +1,7 @@
 import {
   copy,
   ensureDir,
+  mkdirp,
   pathExists,
   readFile,
   remove,
@@ -29,7 +30,6 @@ import {
   getPlugins,
   printPlugins,
 } from './plugin';
-import { copy as copyTask } from './tasks/copy';
 import { resolveNode } from './util/node';
 import { buildXmlElement, parseXML, readXML, writeXML } from './util/xml';
 
@@ -291,9 +291,9 @@ export async function handleCordovaPluginsJS(
   config: Config,
   platform: string,
 ): Promise<void> {
-  if (!(await pathExists(await getWebDir(config, platform)))) {
-    await copyTask(config, platform);
-  }
+  const webDir = await getWebDir(config, platform);
+  await mkdirp(webDir);
+
   if (cordovaPlugins.length > 0) {
     printPlugins(cordovaPlugins, platform, 'cordova');
     await copyCordovaJS(config, platform);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -27,10 +27,10 @@ import {
   getPlugins,
   printPlugins,
 } from '../plugin';
+import { copy as copyTask } from '../tasks/copy';
 import { convertToUnixPath } from '../util/fs';
 import { resolveNode } from '../util/node';
 import { runCommand } from '../util/subprocess';
-import { copy as copyTask } from '../tasks/copy';
 import { extractTemplate } from '../util/template';
 
 import { getIOSPlugins } from './common';

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -1,4 +1,11 @@
-import { copy, remove, readFile, realpath, writeFile } from '@ionic/utils-fs';
+import {
+  copy,
+  remove,
+  pathExists,
+  readFile,
+  realpath,
+  writeFile,
+} from '@ionic/utils-fs';
 import { basename, dirname, join, relative } from 'path';
 
 import c from '../colors';
@@ -23,6 +30,7 @@ import {
 import { convertToUnixPath } from '../util/fs';
 import { resolveNode } from '../util/node';
 import { runCommand } from '../util/subprocess';
+import { copy as copyTask } from '../tasks/copy';
 import { extractTemplate } from '../util/template';
 
 import { getIOSPlugins } from './common';
@@ -47,6 +55,9 @@ export async function updateIOS(
   );
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
+  }
+  if (!(await pathExists(await config.ios.webDirAbs))) {
+    await copyTask(config, platform);
   }
   await handleCordovaPluginsJS(cordovaPlugins, config, platform);
   await checkPluginDependencies(plugins, platform);

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -1,4 +1,4 @@
-import { copy as fsCopy, remove, writeJSON } from '@ionic/utils-fs';
+import { copy as fsCopy, pathExists, remove, writeJSON } from '@ionic/utils-fs';
 import { basename, join, relative } from 'path';
 
 import c from '../colors';
@@ -104,14 +104,26 @@ async function copyWebDir(config: Config, nativeAbsDir: string) {
   const webRelDir = basename(webAbsDir);
   const nativeRelDir = relative(config.app.rootDir, nativeAbsDir);
 
-  if (config.app.extConfig.server?.url) {
-  } else {
-    await runTask(
-      `Copying web assets from ${c.strong(webRelDir)} to ${nativeRelDir}`,
-      async () => {
-        await remove(nativeAbsDir);
-        return fsCopy(webAbsDir, nativeAbsDir);
-      },
+  if (config.app.extConfig.server?.url && !(await pathExists(webAbsDir))) {
+    logger.warn(
+      `Cannot copy web assets from ${c.strong(
+        webRelDir,
+      )} to ${nativeRelDir}\n` +
+        `Web asset directory specified by ${c.input(
+          'webDir',
+        )} does not exist. This is not an error because ${c.input(
+          'server.url',
+        )} is set in config.`,
     );
+
+    return;
   }
+
+  await runTask(
+    `Copying web assets from ${c.strong(webRelDir)} to ${nativeRelDir}`,
+    async () => {
+      await remove(nativeAbsDir);
+      return fsCopy(webAbsDir, nativeAbsDir);
+    },
+  );
 }

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -104,11 +104,14 @@ async function copyWebDir(config: Config, nativeAbsDir: string) {
   const webRelDir = basename(webAbsDir);
   const nativeRelDir = relative(config.app.rootDir, nativeAbsDir);
 
-  await runTask(
-    `Copying web assets from ${c.strong(webRelDir)} to ${nativeRelDir}`,
-    async () => {
-      await remove(nativeAbsDir);
-      return fsCopy(webAbsDir, nativeAbsDir);
-    },
-  );
+  if (config.app.extConfig.server?.url) {
+  } else {
+    await runTask(
+      `Copying web assets from ${c.strong(webRelDir)} to ${nativeRelDir}`,
+      async () => {
+        await remove(nativeAbsDir);
+        return fsCopy(webAbsDir, nativeAbsDir);
+      },
+    );
+  }
 }


### PR DESCRIPTION
The Capacitor CLI developer experience can be improved when using livereload by not requiring the web asset directory to exist if `server.url` is being used. 

BEFORE:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/236501/107805496-4b030b00-6d1a-11eb-8f02-5cb6b936eaa8.png">

AFTER:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/236501/107805527-53f3dc80-6d1a-11eb-8bf4-1c93ea03bc76.png">
