### PR TITLE
fix(core): do not add window.cordova on web apps

### DIFF
--- a/core/src/legacy/legacy-handlers.ts
+++ b/core/src/legacy/legacy-handlers.ts
@@ -7,7 +7,6 @@ export const initLegacyHandlers = (
   win: WindowCapacitor,
   cap: CapacitorInstance,
 ): void => {
-
   if (cap.isNativePlatform()) {
     // define cordova if it's not there already
     win.cordova = win.cordova || {};

--- a/core/src/legacy/legacy-handlers.ts
+++ b/core/src/legacy/legacy-handlers.ts
@@ -7,35 +7,38 @@ export const initLegacyHandlers = (
   win: WindowCapacitor,
   cap: CapacitorInstance,
 ): void => {
-  // define cordova if it's not there already
-  win.cordova = win.cordova || {};
 
-  const doc = win.document;
-  const nav = win.navigator;
+  if (cap.isNativePlatform()) {
+    // define cordova if it's not there already
+    win.cordova = win.cordova || {};
 
-  if (nav) {
-    nav.app = nav.app || {};
-    nav.app.exitApp = () => {
-      cap.nativeCallback('App', 'exitApp', {});
-    };
-  }
+    const doc = win.document;
+    const nav = win.navigator;
 
-  if (doc) {
-    const docAddEventListener = doc.addEventListener;
-    doc.addEventListener = (...args: any[]) => {
-      const eventName = args[0];
-      const handler = args[1];
-      if (eventName === 'deviceready' && handler) {
-        Promise.resolve().then(handler);
-      } else if (eventName === 'backbutton' && cap.Plugins.App) {
-        // Add a dummy listener so Capacitor doesn't do the default
-        // back button action
-        cap.Plugins.App.addListener('backButton', () => {
-          // ignore
-        });
-      }
-      return docAddEventListener.apply(doc, args);
-    };
+    if (nav) {
+      nav.app = nav.app || {};
+      nav.app.exitApp = () => {
+        cap.nativeCallback('App', 'exitApp', {});
+      };
+    }
+
+    if (doc) {
+      const docAddEventListener = doc.addEventListener;
+      doc.addEventListener = (...args: any[]) => {
+        const eventName = args[0];
+        const handler = args[1];
+        if (eventName === 'deviceready' && handler) {
+          Promise.resolve().then(handler);
+        } else if (eventName === 'backbutton' && cap.Plugins.App) {
+          // Add a dummy listener so Capacitor doesn't do the default
+          // back button action
+          cap.Plugins.App.addListener('backButton', () => {
+            // ignore
+          });
+        }
+        return docAddEventListener.apply(doc, args);
+      };
+    }
   }
 
   // deprecated in v3, remove from v4

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -7,7 +7,7 @@ import { WebPlugin } from '../web-plugin';
 describe('legacy', () => {
   let win: WindowCapacitor;
   let cap: CapacitorGlobal;
-  const LegacyWebPlugin = class extends WebPlugin {};
+  const LegacyWebPlugin = class extends WebPlugin { };
   const orgConsoleWarn = console.warn;
   const noop = () => {
     // do nothing
@@ -102,8 +102,8 @@ describe('legacy', () => {
 
   it('doc.addEventListener backbutton', done => {
     const AppWeb = class {
-      async addListener(eventName: string) {
-        expect(eventName).toBe('backButton');
+      async addListener(event: any) {
+        expect(event.eventName).toBe("backButton");
         done();
       }
     };
@@ -116,10 +116,12 @@ describe('legacy', () => {
           expect(eventName).toBe('backbutton');
         },
       },
+      androidBridge: { postMessage: noop },
     };
     cap = createCapacitor(win);
     cap.registerPlugin<any>('App', {
       web: new AppWeb(),
+      android: new AppWeb()
     });
 
     win.document.addEventListener('backbutton', bbCallback);
@@ -132,6 +134,7 @@ describe('legacy', () => {
           // ignore
         },
       },
+      androidBridge: { postMessage: noop }
     };
     createCapacitor(win);
     win.document.addEventListener('deviceready', done);
@@ -140,13 +143,16 @@ describe('legacy', () => {
   it('add navigator.app.exitApp', () => {
     win = {
       navigator: {},
+      androidBridge: { postMessage: noop }
     };
     createCapacitor(win);
     expect(win.navigator.app.exitApp).toBeDefined();
   });
 
   it('cordova global', () => {
-    win = {};
+    win = {
+      androidBridge: { postMessage: noop },
+    };
     createCapacitor(win);
     expect(win.cordova).toBeDefined();
   });

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -7,7 +7,7 @@ import { WebPlugin } from '../web-plugin';
 describe('legacy', () => {
   let win: WindowCapacitor;
   let cap: CapacitorGlobal;
-  const LegacyWebPlugin = class extends WebPlugin { };
+  const LegacyWebPlugin = class extends WebPlugin {};
   const orgConsoleWarn = console.warn;
   const noop = () => {
     // do nothing
@@ -103,7 +103,7 @@ describe('legacy', () => {
   it('doc.addEventListener backbutton', done => {
     const AppWeb = class {
       async addListener(event: any) {
-        expect(event.eventName).toBe("backButton");
+        expect(event.eventName).toBe('backButton');
         done();
       }
     };
@@ -121,7 +121,7 @@ describe('legacy', () => {
     cap = createCapacitor(win);
     cap.registerPlugin<any>('App', {
       web: new AppWeb(),
-      android: new AppWeb()
+      android: new AppWeb(),
     });
 
     win.document.addEventListener('backbutton', bbCallback);
@@ -134,7 +134,7 @@ describe('legacy', () => {
           // ignore
         },
       },
-      androidBridge: { postMessage: noop }
+      androidBridge: { postMessage: noop },
     };
     createCapacitor(win);
     win.document.addEventListener('deviceready', done);
@@ -143,7 +143,7 @@ describe('legacy', () => {
   it('add navigator.app.exitApp', () => {
     win = {
       navigator: {},
-      androidBridge: { postMessage: noop }
+      androidBridge: { postMessage: noop },
     };
     createCapacitor(win);
     expect(win.navigator.app.exitApp).toBeDefined();


### PR DESCRIPTION
I wrapped the logic in the legacy handlers to only add the empty Cordova object and the native event handlers to only be executed when it is running on a device. This fixes the issue with Ionic Core wrongly identifying web apps as being identified as Cordova and hybrid apps as brought up in issue #4198.