### PR TITLE
chore: clean up npx cap add hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ npx cap init
 Next, install any of the desired native platforms:
 
 ```
+npm install @capacitor/android
 npx cap add android
+npm install @capacitor/ios
 npx cap add ios
 ```
 

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -299,9 +299,7 @@ export async function selectPlatforms(
       }
       fatal(
         `${c.strong(platformName)} platform has not been added yet.\n` +
-          `Use ${c.input(
-            `npx cap add ${platformName}`,
-          )} to add the platform to your project.`,
+          `https://capacitorjs.com/docs/v3/${platformName}#adding-the-${platformName}-platform`,
       );
     }
 

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -304,7 +304,11 @@ export async function selectPlatforms(
       }
       fatal(
         `${c.strong(platformName)} platform has not been added yet.\n` +
-          `https://capacitorjs.com/docs/v3/${platformName}#adding-the-${platformName}-platform`,
+          `See the docs for adding the ${c.strong(
+            platformName,
+          )} platform: ${c.strong(
+            `https://capacitorjs.com/docs/v3/${platformName}#adding-the-${platformName}-platform`,
+          )}`,
       );
     }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -340,7 +340,9 @@ async function determineXcodeWorkspaceDirAbs(
   if (!(await pathExists(xcodeDir))) {
     fatal(
       'Xcode workspace does not exist.\n' +
-        `https://capacitorjs.com/docs/v3/ios#adding-the-ios-platform`,
+        `See the docs for adding the ${c.strong('ios')} platform: ${c.strong(
+          'https://capacitorjs.com/docs/v3/ios#adding-the-ios-platform',
+        )}`,
     );
   }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -340,7 +340,7 @@ async function determineXcodeWorkspaceDirAbs(
   if (!(await pathExists(xcodeDir))) {
     fatal(
       'Xcode workspace does not exist.\n' +
-        `Run ${c.input('npx cap add ios')} to bootstrap a new iOS project.`,
+        `https://capacitorjs.com/docs/v3/ios#adding-the-ios-platform`,
     );
   }
 

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from '@ionic/utils-fs';
 import { resolve } from 'path';
 
 import c from '../colors';
-import { checkCapacitorPlatform, getProjectPlatformDirectory } from '../common';
+import { checkCapacitorPlatform } from '../common';
 import { getIncompatibleCordovaPlugins } from '../cordova';
 import type { Config } from '../definitions';
 import { OS } from '../definitions';

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -26,17 +26,6 @@ export async function checkCocoaPods(config: Config): Promise<string | null> {
   return null;
 }
 
-export async function checkIOSProject(config: Config): Promise<string | null> {
-  const platformDir = await getProjectPlatformDirectory(config, 'ios');
-  if (!platformDir) {
-    return (
-      `${c.strong('ios')} platform has not been added yet.\n` +
-      `Use ${c.input(`npx cap add ios`)} to add the platform to your project.`
-    );
-  }
-  return null;
-}
-
 export async function getIOSPlugins(allPlugins: Plugin[]): Promise<Plugin[]> {
   const resolved = await Promise.all(
     allPlugins.map(async plugin => await resolvePlugin(plugin)),

--- a/cli/src/ios/doctor.ts
+++ b/cli/src/ios/doctor.ts
@@ -4,7 +4,7 @@ import { fatal } from '../errors';
 import { logSuccess } from '../log';
 import { isInstalled } from '../util/subprocess';
 
-import { checkCocoaPods, checkIOSProject } from './common';
+import { checkCocoaPods } from './common';
 
 export async function doctorIOS(config: Config): Promise<void> {
   // DOCTOR ideas for iOS:
@@ -21,7 +21,6 @@ export async function doctorIOS(config: Config): Promise<void> {
   try {
     await check([
       () => checkCocoaPods(config),
-      () => checkIOSProject(config),
       () => checkWebDir(config),
       checkXcode,
     ]);

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -34,13 +34,6 @@ export async function copyCommand(
     }
   } else {
     const platforms = await selectPlatforms(config, selectedPlatformName);
-    if (platforms.length === 0) {
-      logger.info(
-        `There are no platforms to copy yet.\n` +
-          `Add platforms with ${c.input('npx cap add')}.`,
-      );
-      return;
-    }
     try {
       await allSerial(
         platforms.map(platformName => () => copy(config, platformName)),

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -168,9 +168,6 @@ function printNextSteps(newConfigName: string) {
   output.write(
     `\nCheck next steps: \n${c.strong(
       `https://capacitorjs.com/docs/v3/getting-started#where-to-go-next`,
-    )}\n` +
-      `And follow the Developer Workflow guide to get building:\n${c.strong(
-        `https://capacitorjs.com/docs/v3/basics/workflow`,
-      )}\n`,
+    )}\n`,
   );
 }

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -166,10 +166,10 @@ async function mergeConfig(
 function printNextSteps(newConfigName: string) {
   logSuccess(`${c.strong(newConfigName)} created!`);
   output.write(
-    `\nAdd platforms using ${c.input('npx cap add')}:\n` +
-      `  ${c.input('npx cap add android')}\n` +
-      `  ${c.input('npx cap add ios')}\n\n` +
-      `Follow the Developer Workflow guide to get building:\n${c.strong(
+    `\nCheck next steps: \n${c.strong(
+      `https://capacitorjs.com/docs/v3/getting-started#where-to-go-next`,
+    )}\n` +
+      `And follow the Developer Workflow guide to get building:\n${c.strong(
         `https://capacitorjs.com/docs/v3/basics/workflow`,
       )}\n`,
   );

--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -166,7 +166,7 @@ async function mergeConfig(
 function printNextSteps(newConfigName: string) {
   logSuccess(`${c.strong(newConfigName)} created!`);
   output.write(
-    `\nCheck next steps: \n${c.strong(
+    `\nNext steps: \n${c.strong(
       `https://capacitorjs.com/docs/v3/getting-started#where-to-go-next`,
     )}\n`,
   );

--- a/cli/src/tasks/list.ts
+++ b/cli/src/tasks/list.ts
@@ -14,13 +14,6 @@ export async function listCommand(
   selectedPlatformName: string,
 ): Promise<void> {
   const platforms = await selectPlatforms(config, selectedPlatformName);
-  if (platforms.length === 0) {
-    logger.info(
-      `There are no platforms to list yet.\n` +
-        `Add platforms with ${c.input('npx cap add')}.`,
-    );
-    return;
-  }
   try {
     await allSerial(
       platforms.map(platformName => () => list(config, platformName)),

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -27,13 +27,7 @@ export async function openCommand(
   } else {
     const platforms = await selectPlatforms(config, selectedPlatformName);
     let platformName: string;
-    if (platforms.length === 0) {
-      logger.info(
-        `There are no platforms to open yet.\n` +
-          `Add platforms with ${c.input('npx cap add')}.`,
-      );
-      return;
-    } else if (platforms.length === 1) {
+    if (platforms.length === 1) {
       platformName = platforms[0];
     } else {
       platformName = await promptForPlatform(

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -39,13 +39,7 @@ export async function runCommand(
   } else {
     const platforms = await selectPlatforms(config, selectedPlatformName);
     let platformName: string;
-    if (platforms.length === 0) {
-      logger.info(
-        `There are no platforms to run yet.\n` +
-          `Add platforms with ${c.input('npx cap add')}.`,
-      );
-      return;
-    } else if (platforms.length === 1) {
+    if (platforms.length === 1) {
       platformName = platforms[0];
     } else {
       platformName = await promptForPlatform(

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -32,13 +32,6 @@ export async function syncCommand(
   } else {
     const then = +new Date();
     const platforms = await selectPlatforms(config, selectedPlatformName);
-    if (platforms.length === 0) {
-      logger.info(
-        `There are no platforms to sync yet.\n` +
-          `Add platforms with ${c.input('npx cap add')}.`,
-      );
-      return;
-    }
     try {
       await check([
         () => checkPackage(),

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -1,4 +1,3 @@
-import c from '../colors';
 import {
   check,
   checkPackage,

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -60,9 +60,7 @@ export function updateChecks(
   const checks: CheckFunction[] = [];
   for (const platformName of platforms) {
     if (platformName === config.ios.name) {
-      checks.push(
-        () => checkCocoaPods(config),
-      );
+      checks.push(() => checkCocoaPods(config));
     } else if (platformName === config.android.name) {
       continue;
     } else if (platformName === config.web.name) {

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -12,7 +12,7 @@ import {
 } from '../common';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
-import { checkCocoaPods, checkIOSProject } from '../ios/common';
+import { checkCocoaPods } from '../ios/common';
 import { updateIOS } from '../ios/update';
 import { logger } from '../log';
 import { allSerial } from '../util/promise';
@@ -32,13 +32,6 @@ export async function updateCommand(
   } else {
     const then = +new Date();
     const platforms = await selectPlatforms(config, selectedPlatformName);
-    if (platforms.length === 0) {
-      logger.info(
-        `There are no platforms to update yet.\n` +
-          `Add platforms with ${c.input('npx cap add')}.`,
-      );
-      return;
-    }
     try {
       await check([() => checkPackage(), ...updateChecks(config, platforms)]);
 
@@ -69,7 +62,6 @@ export function updateChecks(
     if (platformName === config.ios.name) {
       checks.push(
         () => checkCocoaPods(config),
-        () => checkIOSProject(config),
       );
     } else if (platformName === config.android.name) {
       continue;


### PR DESCRIPTION
Removed the `platforms.length === 0` checks as we always return at least web as platform, so they will never be 0.
Removed the `checkIOSProject` checks as the ios folder was already being checked by `selectPlatforms` function, so that code was not reachable.
Replaced the npx cap add instructions on `init` with a link to `https://capacitorjs.com/docs/v3/getting-started#where-to-go-next`

closes https://github.com/ionic-team/capacitor/issues/4030