### PR TITLE
fix(cli): init failure if config.xml is present

### DIFF
--- a/cli/src/util/xml.ts
+++ b/cli/src/util/xml.ts
@@ -2,20 +2,16 @@ import { readFile } from '@ionic/utils-fs';
 import xml2js from 'xml2js';
 
 export async function readXML(path: string): Promise<any> {
-  return new Promise(async (resolve, reject) => {
+  try {
+    const xmlStr = await readFile(path, { encoding: 'utf-8' });
     try {
-      const xmlStr = await readFile(path, { encoding: 'utf-8' });
-      xml2js.parseString(xmlStr, (e, result) => {
-        if (e) {
-          reject(`Error parsing: ${path}, ${e.stack ?? e}`);
-        } else {
-          resolve(result);
-        }
-      });
+      return parseString(xmlStr);
     } catch (e) {
-      throw `Unable to read: ${path}`;
+      throw `Error parsing: ${path}, ${e.stack ?? e}` ;
     }
-  });
+  } catch (e) {
+    throw `Unable to read: ${path}`;
+  }
 }
 
 export function parseXML(xmlStr: string): any {
@@ -49,4 +45,16 @@ export function buildXmlElement(configElement: any, rootName: string): string {
   });
 
   return builder.buildObject(configElement);
+}
+
+function parseString(xmlStr: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+      xml2js.parseString(xmlStr, (e, result) => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve(result);
+        }
+      });
+  });
 }

--- a/cli/src/util/xml.ts
+++ b/cli/src/util/xml.ts
@@ -7,7 +7,7 @@ export async function readXML(path: string): Promise<any> {
     try {
       return parseString(xmlStr);
     } catch (e) {
-      throw `Error parsing: ${path}, ${e.stack ?? e}` ;
+      throw `Error parsing: ${path}, ${e.stack ?? e}`;
     }
   } catch (e) {
     throw `Unable to read: ${path}`;
@@ -49,12 +49,12 @@ export function buildXmlElement(configElement: any, rootName: string): string {
 
 function parseString(xmlStr: string): Promise<any> {
   return new Promise((resolve, reject) => {
-      xml2js.parseString(xmlStr, (e, result) => {
-        if (e) {
-          reject(e);
-        } else {
-          resolve(result);
-        }
-      });
+    xml2js.parseString(xmlStr, (e, result) => {
+      if (e) {
+        reject(e);
+      } else {
+        resolve(result);
+      }
+    });
   });
 }

--- a/cli/src/util/xml.ts
+++ b/cli/src/util/xml.ts
@@ -2,16 +2,20 @@ import { readFile } from '@ionic/utils-fs';
 import xml2js from 'xml2js';
 
 export async function readXML(path: string): Promise<any> {
-  try {
-    const xmlStr = await readFile(path, { encoding: 'utf-8' });
+  return new Promise(async (resolve, reject) => {
     try {
-      return await xml2js.parseStringPromise(xmlStr);
+      const xmlStr = await readFile(path, { encoding: 'utf-8' });
+      xml2js.parseString(xmlStr, (e, result) => {
+        if (e) {
+          reject(`Error parsing: ${path}, ${e.stack ?? e}`);
+        } else {
+          resolve(result);
+        }
+      });
     } catch (e) {
-      throw `Error parsing: ${path}, ${e.stack ?? e}`;
+      throw `Unable to read: ${path}`;
     }
-  } catch (e) {
-    throw `Unable to read: ${path}`;
-  }
+  });
 }
 
 export function parseXML(xmlStr: string): any {

--- a/cli/src/util/xml.ts
+++ b/cli/src/util/xml.ts
@@ -5,7 +5,7 @@ export async function readXML(path: string): Promise<any> {
   try {
     const xmlStr = await readFile(path, { encoding: 'utf-8' });
     try {
-      return parseString(xmlStr);
+      return await parseString(xmlStr);
     } catch (e) {
       throw `Error parsing: ${path}, ${e.stack ?? e}`;
     }


### PR DESCRIPTION
For some unknown reason, `parseStringPromise` is failing only when you install from npm or from npm pack, but not if installed locally or linked

The PR uses the callback based `parseString` that seems to work fine.


closes https://github.com/ionic-team/capacitor/issues/4223