### PR TITLE
fix(cli): init failure if config.xml is present

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -59,7 +59,7 @@
     "semver": "^7.3.2",
     "tar": "^6.0.5",
     "tslib": "^2.1.0",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",


### PR DESCRIPTION
[parseStringPromise was added in xml2js 0.4.20](https://github.com/Leonidas-from-XIV/node-xml2js/commit/c7597111d758f8850fc40810a9fd4ef58d922052), so bumping the minimum version should resolve the issue for people with old cached installations.

alternative to https://github.com/ionic-team/capacitor/pull/4224
fixes https://github.com/ionic-team/capacitor/issues/4223