### PR TITLE
feat(iOS): Unifying saving plugin calls

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -38,13 +38,20 @@ import WebKit
     @available(*, deprecated, message: "Moved - equivalent is found on config.localURL")
     func getLocalUrl() -> String
 
+    @available(*, deprecated, renamed: "savedCall(withID:)")
+    func getSavedCall(_ callbackId: String) -> CAPPluginCall?
+
+    @available(*, deprecated, renamed: "releaseCall(withID:)")
+    func releaseCall(callbackId: String)
+
     // MARK: - Plugin Access
     func plugin(withName: String) -> CAPPlugin?
 
     // MARK: - Call Management
-    func getSavedCall(_ callbackId: String) -> CAPPluginCall?
+    func saveCall(_ call: CAPPluginCall)
+    func savedCall(withID: String) -> CAPPluginCall?
     func releaseCall(_ call: CAPPluginCall)
-    func releaseCall(callbackId: String)
+    func releaseCall(withID: String)
 
     // MARK: - JavaScript Handling
     // `js` is a short name but needs to be preserved for backwards compatibility.

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -118,9 +118,9 @@
 - (void)removeListener:(CAPPluginCall *)call {
   NSString *eventName = [call.options objectForKey:@"eventName"];
   NSString *callbackId = [call.options objectForKey:@"callbackId"];
-  CAPPluginCall *storedCall = [self.bridge getSavedCall:callbackId];
+  CAPPluginCall *storedCall = [self.bridge savedCallWithID:callbackId];
   [self removeEventListener:eventName listener:storedCall];
-  [self.bridge releaseCallWithCallbackId:callbackId];
+  [self.bridge releaseCallWithID:callbackId];
 }
 
 - (void)removeAllListeners:(CAPPluginCall *)call {

--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -111,7 +111,7 @@
 
 - (void)addListener:(CAPPluginCall *)call {
   NSString *eventName = [call.options objectForKey:@"eventName"];
-  [call setIsSaved:TRUE];
+  [call setKeepAlive:TRUE];
   [self addEventListener:eventName listener:call];
 }
 

--- a/ios/Capacitor/Capacitor/CAPPluginCall.h
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.h
@@ -9,7 +9,8 @@ typedef void(^CAPPluginCallErrorHandler)(CAPPluginCallError *error);
 
 @interface CAPPluginCall : NSObject
 
-@property (nonatomic, assign) BOOL isSaved;
+@property (nonatomic, assign) BOOL isSaved DEPRECATED_MSG_ATTRIBUTE("Use 'keepAlive' instead.");
+@property (nonatomic, assign) BOOL keepAlive;
 @property (nonatomic, strong) NSString *callbackId;
 @property (nonatomic, strong) NSDictionary *options;
 @property (nonatomic, copy) CAPPluginCallSuccessHandler successHandler;
@@ -17,5 +18,5 @@ typedef void(^CAPPluginCallErrorHandler)(CAPPluginCallError *error);
 
 - (instancetype)initWithCallbackId:(NSString *)callbackId options:(NSDictionary *)options success:(CAPPluginCallSuccessHandler)success error:(CAPPluginCallErrorHandler)error;
 
-- (void)save;
+- (void)save DEPRECATED_MSG_ATTRIBUTE("Use the 'keepAlive' property instead.");
 @end

--- a/ios/Capacitor/Capacitor/CAPPluginCall.m
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.m
@@ -11,8 +11,16 @@
   return self;
 }
 
+- (BOOL)isSaved {
+    return self.keepAlive;
+}
+
+- (void)setIsSaved:(BOOL)saved {
+    self.keepAlive = saved;
+}
+
 - (void)save {
-  self.isSaved = true;
+  self.keepAlive = true;
 }
 
 @end

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -438,8 +438,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                 plugin.perform(selector, with: pluginCall)
                 if pluginCall.keepAlive {
                     self?.saveCall(pluginCall)
-                }
-                else {
+                } else {
                     self?.releaseCall(pluginCall)
                 }
             }

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -303,10 +303,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         return plugin
     }
 
-    func savePluginCall(_ call: CAPPluginCall) {
-        storedCalls[call.callbackId] = call
-    }
-
     // MARK: - CAPBridgeProtocol: Plugin Access
 
     @objc public func plugin(withName: String) -> CAPPlugin? {
@@ -315,17 +311,33 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
     // MARK: - CAPBridgeProtocol: Call Management
 
-    @objc public func getSavedCall(_ callbackId: String) -> CAPPluginCall? {
-        return storedCalls[callbackId]
+    @objc public func saveCall(_ call: CAPPluginCall) {
+        storedCalls[call.callbackId] = call
+    }
+
+    @objc public func savedCall(withID: String) -> CAPPluginCall? {
+        return storedCalls[withID]
     }
 
     @objc public func releaseCall(_ call: CAPPluginCall) {
-        storedCalls.removeValue(forKey: call.callbackId)
+        releaseCall(withID: call.callbackId)
+    }
+
+    @objc public func releaseCall(withID: String) {
+        storedCalls.removeValue(forKey: withID)
+    }
+
+    // MARK: - Deprecated Versions
+
+    @objc public func getSavedCall(_ callbackId: String) -> CAPPluginCall? {
+        return savedCall(withID: callbackId)
     }
 
     @objc public func releaseCall(callbackId: String) {
-        storedCalls.removeValue(forKey: callbackId)
+        releaseCall(withID: callbackId)
     }
+
+    // MARK: - Internal
 
     func getDispatchQueue() -> DispatchQueue {
         return self.dispatchQueue
@@ -406,9 +418,9 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                                                                                        formattingDatesAsStrings: plugin.shouldStringifyDatesInCalls) ?? [:],
                                            success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
                                             if let result = result {
-                                                self?.toJs(result: JSResult(call: call, callResult: result), save: pluginCall?.isSaved ?? false)
+                                                self?.toJs(result: JSResult(call: call, callResult: result), save: pluginCall?.keepAlive ?? false)
                                             } else {
-                                                self?.toJs(result: JSResult(call: call, result: .dictionary([:])), save: pluginCall?.isSaved ?? false)
+                                                self?.toJs(result: JSResult(call: call, result: .dictionary([:])), save: pluginCall?.keepAlive ?? false)
                                             }
                                            }, error: {(error: CAPPluginCallError?) -> Void in
                                             if let error = error {
@@ -424,8 +436,11 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
             if let pluginCall = pluginCall {
                 plugin.perform(selector, with: pluginCall)
-                if pluginCall.isSaved {
-                    self?.savePluginCall(pluginCall)
+                if pluginCall.keepAlive {
+                    self?.saveCall(pluginCall)
+                }
+                else {
+                    self?.releaseCall(pluginCall)
                 }
             }
 


### PR DESCRIPTION
This branch revisits and updates how plugin calls should be saved to clarify usage and better align the API between platforms.
- Deprecated `CAPPluginCall`'s `save` method and `isSaved` property and replaced with `keepAlive` to make the implications of the flag clearer.
- Exposed `saveCall` on the bridge and renamed related methods to be more idiomatic and consistent.

Closes https://github.com/ionic-team/capacitor/issues/4087
Companion to https://github.com/ionic-team/capacitor/pull/4254
Documented in https://github.com/ionic-team/capacitor-site/pull/238