### PR TITLE
feat(android): set WebChromeClient geolocation permission strings in Activity or Plugin

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -92,6 +92,7 @@ public class Bridge {
     private CordovaWebView cordovaWebView;
     private CordovaPreferences preferences;
     private BridgeWebViewClient webViewClient;
+    private BridgeWebChromeClient webChromeClient;
     private App app;
 
     // Our MessageHandler for sending and receiving data to the WebView
@@ -142,6 +143,7 @@ public class Bridge {
         this.context = context;
         this.webView = webView;
         this.webViewClient = new BridgeWebViewClient(this);
+        this.webChromeClient = new BridgeWebChromeClient(this);
         this.initialPlugins = initialPlugins;
         this.cordovaInterface = cordovaInterface;
         this.preferences = preferences;
@@ -211,7 +213,7 @@ public class Bridge {
 
         Logger.debug("Loading app at " + appUrl);
 
-        webView.setWebChromeClient(new BridgeWebChromeClient(this));
+        webView.setWebChromeClient(this.webChromeClient);
         webView.setWebViewClient(this.webViewClient);
 
         if (!isDeployDisabled() && !isNewBinary()) {
@@ -1093,6 +1095,10 @@ public class Bridge {
 
     public void setWebViewClient(BridgeWebViewClient client) {
         this.webViewClient = client;
+    }
+
+    BridgeWebChromeClient getWebChromeClient() {
+        return this.webChromeClient;
     }
 
     static class Builder {

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -240,7 +240,21 @@ public class BridgeActivity extends AppCompatActivity {
         this.bridge.onConfigurationChanged(newConfig);
     }
 
-    public void registerWebGeolocationPermissionHandler(BridgeWebChromeClient.WebGeoPermissionInterface webGeoPermissionInterface) {
-        bridge.getWebChromeClient().setGeoPermissionInterface(webGeoPermissionInterface);
+    /**
+     * Registers the geolocation permissions used by Google Chrome if location is requested from
+     * the browser API. This registered interface will override any defined on a plugin using
+     * {@link Plugin#registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface)},
+     * if present
+     *
+     * @param geolocationPermissionInterface the implemented GeolocationPermissionInterface that
+     *                                       returns the desired Android geolocation permission strings
+     *                                       to be used by the WebChromeClient
+     */
+    public void registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface geolocationPermissionInterface) {
+        if (bridge == null) {
+            Logger.error("Geolocation permissions must be registered in onStart() or later in the Activity Lifecycle!");
+        } else {
+            bridge.getWebChromeClient().setGeoPermissionInterface(geolocationPermissionInterface);
+        }
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -244,7 +244,7 @@ public class BridgeActivity extends AppCompatActivity {
      * Registers the geolocation permissions used by Google Chrome if location is requested from
      * the browser API. This registered interface will override any defined on a plugin using
      * {@link Plugin#registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface)},
-     * if present
+     * if present.
      *
      * @param geolocationPermissionInterface the implemented GeolocationPermissionInterface that
      *                                       returns the desired Android geolocation permission strings

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -239,4 +239,8 @@ public class BridgeActivity extends AppCompatActivity {
 
         this.bridge.onConfigurationChanged(newConfig);
     }
+
+    public void registerWebGeolocationPermissionHandler(BridgeWebChromeClient.WebGeoPermissionInterface webGeoPermissionInterface) {
+        bridge.getWebChromeClient().setGeoPermissionInterface(webGeoPermissionInterface);
+    }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -878,6 +878,20 @@ public class Plugin {
     }
 
     /**
+     * Registers the geolocation permissions used by Google Chrome if location is requested from
+     * the browser API. If an interface is registered on the Activity by an app developer using
+     * {@link BridgeActivity#registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface)},
+     * that interface will override this one.
+     *
+     * @param geolocationPermissionInterface the implemented GeolocationPermissionInterface that
+     *                                       returns the desired Android geolocation permission strings
+     *                                       to be used by the WebChromeClient
+     */
+    public void registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface geolocationPermissionInterface) {
+        bridge.getWebChromeClient().setGeoPermissionInterface(geolocationPermissionInterface);
+    }
+
+    /**
      * Handle request permissions result. A plugin using the deprecated {@link NativePlugin}
      * should override this to handle the result, or this method will handle the result
      * for our convenient requestPermissions call.

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -883,6 +883,9 @@ public class Plugin {
      * {@link BridgeActivity#registerGeolocationPermissions(BridgeWebChromeClient.GeolocationPermissionInterface)},
      * that interface will override this one.
      *
+     * Note: this method is not used to request geolocation permissions. To request permissions in
+     * a plugin see {@link #requestPermissionForAlias(String, PluginCall, String)}
+     *
      * @param geolocationPermissionInterface the implemented GeolocationPermissionInterface that
      *                                       returns the desired Android geolocation permission strings
      *                                       to be used by the WebChromeClient


### PR DESCRIPTION
On Android, Google Chrome calls into BridgeWebChromeClient when the web app tries to use the web geolocation API to get permission information (not native mobile code).

This PR removes the geolocation permission strings from BridgeWebChromeClient and requires to use `registerGeolocationPermissions` from their Activity, or plugin authors to use `registerGeolocationPermissions` from their Plugin class if they wish to use the web geolocation API from the web app used in Capacitor.

Google has started scanning apps for their permission usage and identifies all Capacitor apps as using geolocation services, even if they are not explicitly using it in the web app. This can result in Play Store submission rejections if Google does not think the location permission usage is appropriate, such as in apps targeted towards children.

Usage examples:

From an Activity
```java
@Override
public void onStart() {
    super.onStart();
    registerGeolocationPermissions(() -> new String[]{ 
        Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION 
    });
}
```

From a Plugin
```java
@Override
public void load() {
    implementation = new Geolocation(getContext());
    registerGeolocationPermissions(() -> new String[] { 
        Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION 
    });
}
```