### PR TITLE
documentation(iOS): Annotating CAPInstanceDescriptor

### DIFF
--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -22,36 +22,104 @@ extern NSString * _Nonnull const CAPInstanceDescriptorDefaultHostname NS_SWIFT_U
 
 NS_SWIFT_NAME(InstanceDescriptor)
 @interface CAPInstanceDescriptor : NSObject
-
-@property (nonatomic, copy, nullable) NSString *appendedUserAgentString;
-@property (nonatomic, copy, nullable) NSString *overridenUserAgentString;
-@property (nonatomic, retain, nullable) UIColor *backgroundColor;
-@property (nonatomic, copy, nonnull) NSArray<NSString*> *allowedNavigationHostnames;
-@property (nonatomic, copy, nullable) NSString *urlScheme;
-@property (nonatomic, copy, nullable) NSString *urlHostname;
-@property (nonatomic, copy, nullable) NSString *serverURL;
-@property (nonatomic, retain, nonnull) NSDictionary *pluginConfigurations;
-@property (nonatomic, assign) BOOL enableLogging;
-@property (nonatomic, assign) BOOL enableScrolling;
-@property (nonatomic, assign) BOOL allowLinkPreviews;
-@property (nonatomic, assign) BOOL handleApplicationNotifications;
-@property (nonatomic, assign) UIScrollViewContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior;
-@property (nonatomic, copy, nonnull) NSURL *appLocation;
-@property (nonatomic, copy, nullable) NSString *appStartPath;
-@property (nonatomic, copy, nonnull) CDVConfigParser *cordovaConfiguration;
-@property (nonatomic, assign) CAPInstanceWarning warnings;
-@property (nonatomic, readonly) CAPInstanceType instanceType;
-@property (nonatomic, retain, nonnull) NSDictionary *legacyConfig;
-
 /**
- Initialize the descriptor with the default environment. This assumes that the application was built with the help of the Capacitor CLI
- and that that the web app is located inside the application bundle at `public/`.
+ @brief A value to append to the @c User-Agent string. Ignored if @c overridenUserAgentString is set.
+ @discussion Set by @c appendUserAgent in the configuration file.
+ */
+@property (nonatomic, copy, nullable) NSString *appendedUserAgentString;
+/**
+ @brief A value that will completely replace the @c User-Agent string. Overrides @c appendedUserAgentString.
+ @discussion Set by @c overrideUserAgent in the configuration file.
+ */
+@property (nonatomic, copy, nullable) NSString *overridenUserAgentString;
+/**
+ @brief The backbround color to set on the WKWebView.
+ @discussion Set by @c backgroundColor in the configuration file.
+ */
+@property (nonatomic, retain, nullable) UIColor *backgroundColor;
+/**
+ @brief Hostnames to which the web view is allowed to navigate without opening an external browser.
+ @discussion Set by @c allowNavigation in the configuration file.
+ */
+@property (nonatomic, copy, nonnull) NSArray<NSString*> *allowedNavigationHostnames;
+/**
+ @brief The scheme that will be used for the server URL.
+ @discussion Defaults to @c capacitor. Set by @c server.iosScheme in the configuration file.
+ */
+@property (nonatomic, copy, nullable) NSString *urlScheme;
+/**
+ @brief The hostname that will be used for the server URL.
+ @discussion Defaults to @c localhost. Set by @c server.hostname in the configuration file.
+ */
+@property (nonatomic, copy, nullable) NSString *urlHostname;
+/**
+ @brief The fully formed URL that will be used as the server URL.
+ @discussion Defaults to nil, in which case the server URL will be constructed from @c urlScheme and @c urlHostname. If set, it will override the other properties. Set by @c server.url in the configuration file.
+ */
+@property (nonatomic, copy, nullable) NSString *serverURL;
+/**
+ @brief The JSON dictionary that contains the plugin-specific configuration information.
+ @discussion Set by @c plugins in the configuration file.
+ */
+@property (nonatomic, retain, nonnull) NSDictionary *pluginConfigurations;
+/**
+ @brief Whether or not logging is turned on.
+ @discussion Set by @c hideLogs in the configuration file.
+ */
+@property (nonatomic, assign) BOOL enableLogging;
+/**
+ @brief Whether or not the web view can scroll.
+ @discussion Set by @c ios.scrollEnabled in the configuration file. Corresponds to @c isScrollEnabled on WKWebView.
+ */
+@property (nonatomic, assign) BOOL enableScrolling;
+/**
+ @brief Whether or not the web view will preview links.
+ @discussion Set by @c ios.allowsLinkPreview in the configuration file. Corresponds to @c allowsLinkPreview on WKWebView.
+ */
+@property (nonatomic, assign) BOOL allowLinkPreviews;
+/**
+ @brief Whether or not the Capacitor runtime will set itself as the @c UNUserNotificationCenter delegate.
+ @discussion Defaults to @c true. Required to be @c true for notification plugins to work correctly. Set to @c false if your application will handle notifications independently.
+ */
+@property (nonatomic, assign) BOOL handleApplicationNotifications;
+/**
+ @brief How the web view will inset its content
+ @discussion Set by @c ios.contentInset in the configuration file. Corresponds to @c contentInsetAdjustmentBehavior on WKWebView.
+ */
+@property (nonatomic, assign) UIScrollViewContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior;
+/**
+ @brief The base file URL from which Capacitor will load resources
+ @discussion Defaults to @c public/ located at the root of the application bundle.
+ */
+@property (nonatomic, copy, nonnull) NSURL *appLocation;
+/**
+ @brief The path (relative to @c appLocation) which Capacitor will use for the inital URL at launch.
+ @discussion Defaults to nil, in which case Capacitor will attempt to load @c index.html.
+ */
+@property (nonatomic, copy, nullable) NSString *appStartPath;
+/**
+ @brief The parser used to load the cofiguration for Cordova plugins.
+ */
+@property (nonatomic, copy, nonnull) CDVConfigParser *cordovaConfiguration;
+/**
+ @brief Warnings generated during initialization.
+ */
+@property (nonatomic, assign) CAPInstanceWarning warnings;
+/**
+ @brief The type of instance.
+ */
+@property (nonatomic, readonly) CAPInstanceType instanceType;
+/**
+ @brief The JSON dictionary representing the contents of the configuration file.
+ @warning Deprecated. Do not use.
+ */
+@property (nonatomic, retain, nonnull) NSDictionary *legacyConfig;
+/**
+ @brief Initialize the descriptor with the default environment. This assumes that the application was built with the help of the Capacitor CLI and that that the web app is located inside the application bundle at @c public/.
  */
 - (instancetype _Nonnull)initAsDefault NS_SWIFT_NAME(init());
-
 /**
- Initialize the descriptor for use in other contexts. The app location is the one required parameter.
- 
+ @brief Initialize the descriptor for use in other contexts. The app location is the one required parameter.
  @param appURL The location of the folder containing the web app.
  @param configURL The location of the Capacitor configuration file.
  @param cordovaURL The location of the Cordova configuration file.

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -33,7 +33,7 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, copy, nullable) NSString *overridenUserAgentString;
 /**
- @brief The backbround color to set on the WKWebView.
+ @brief The background color to set on the web view where content is not visible.
  @discussion Set by @c backgroundColor in the configuration file.
  */
 @property (nonatomic, retain, nullable) UIColor *backgroundColor;


### PR DESCRIPTION
This branch adds inline documentation for the assorted`CAPInstanceDescriptor` properties.