### PR TITLE
fix(android): calls re-saved during permission/activity result callbacks were being released

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -140,15 +140,15 @@ public class Plugin {
 
         // validate permissions and invoke the permission result callback
         if (bridge.validatePermissions(this, savedCall, permissionResultMap)) {
+            if (!savedCall.isKeptAlive()) {
+                savedCall.release(bridge);
+            }
+
             try {
                 method.setAccessible(true);
                 method.invoke(this, savedCall);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
-            }
-
-            if (!savedCall.isKeptAlive()) {
-                savedCall.release(bridge);
             }
         }
     }
@@ -159,16 +159,16 @@ public class Plugin {
             savedCall = bridge.getPluginCallForLastActivity();
         }
 
+        if (!savedCall.isKeptAlive()) {
+            savedCall.release(bridge);
+        }
+
         // invoke the activity result callback
         try {
             method.setAccessible(true);
             method.invoke(this, savedCall, result);
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
-        }
-
-        if (!savedCall.isKeptAlive()) {
-            savedCall.release(bridge);
         }
     }
 


### PR DESCRIPTION
A bug was observed (resolves #4277) where if permission was requested and the callback contained another permission/activity launch with a result, the app would crash claiming the savedCall was null.

What was happening was the call was originally saved for the first permission request, then during the callback the call would save again for the following activity result. The initial permission request would then try to cleanup after the callback was called and remove the saved call that was still being used by the waiting callback, resulting in it being null when the second callback returned. 

Fix: I moved the cleanup of the savedCall before the callback is triggered so that if the same PluginCall is saved again, it won't be accidentally removed.