### PR TITLE
fix(cli): Make tests work on npm 7

### DIFF
--- a/cli/test/util.ts
+++ b/cli/test/util.ts
@@ -76,15 +76,6 @@ const APP_INDEX = `
 </html>
 `;
 
-const APP_PACKAGE_JSON = `
-{
-  "name": "test-app",
-  "dependencies": {
-    "${CORDOVA_PLUGIN_ID}": "latest"
-  }
-}
-`;
-
 export async function installPlatform(
   appDir: string,
   platform: string,
@@ -102,6 +93,15 @@ export async function makeAppDir(monoRepoLike = false): Promise<void> {
   if (monoRepoLike) {
     await mkdir(rootDir);
   }
+  const cordovaPluginPath = join(tmpDir, CORDOVA_PLUGIN_ID);
+  const APP_PACKAGE_JSON = `
+{
+  "name": "test-app",
+  "dependencies": {
+    "${CORDOVA_PLUGIN_ID}": "file:${cordovaPluginPath}"
+  }
+}
+`;
   const appDir = monoRepoLike ? join(rootDir, 'test-app') : rootDir;
   await mkdir(appDir);
   // Make the web dir
@@ -120,7 +120,6 @@ export async function makeAppDir(monoRepoLike = false): Promise<void> {
   });
 
   // Make a fake cordova plugin
-  const cordovaPluginPath = join(tmpDir, CORDOVA_PLUGIN_ID);
   await makeCordovaPlugin(cordovaPluginPath);
 
   await runCommand('npm', ['install', '--save', cordovaPluginPath], {


### PR DESCRIPTION
The sample app has a dependency to "latest" of a plugin that doesn't exist, that wasn't a problem on npm 6 since we first install the plugin from a local folder, but on npm 7 it tries to get it from npm after installing the local version for some reason.

This PR changes "latest" with the local file path of the generated plugin.