### PR TITLE
Support retrieval of NSNumber values from CAPPluginCall options

### DIFF
--- a/ios/Capacitor/Capacitor/CAPPlugin.m
+++ b/ios/Capacitor/Capacitor/CAPPlugin.m
@@ -36,6 +36,19 @@
   return TRUE;
 }
 
+-(NSNumber *) getNumber:(CAPPluginCall *)call field:(NSString *)field defaultValue:(NSNumber *)defaultValue 
+{
+  id idVal = [call.options objectForKey:field];
+  if(![idVal isKindOfClass:[NSNumber class]]) {
+    return defaultValue;
+  }
+  NSNumber *value = (NSNumber *)idVal;
+  if(value == nil) {
+    return defaultValue;
+  }
+  return value;
+}
+
 -(NSString *) getString:(CAPPluginCall *)call field:(NSString *)field defaultValue:(NSString *)defaultValue
 {
   id idVal = [call.options objectForKey:field];


### PR DESCRIPTION
There is no current shortcut to retrieve `NSNumber` values from CAPPluginCall options (only NSString and BOOL are currently supported). 

This PR adds the missing convenience method which is required for retrieving numeric and numeric enum values passed through native plugins via the IOS capacitor bridge.