### PR TITLE
fix(android): Release the call after reject/resolve

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -109,6 +109,9 @@ public class MessageHandler {
         } catch (Exception ex) {
             Logger.error("sendResponseMessage: error: " + ex);
         }
+        if (!call.isKeptAlive()) {
+            call.release(bridge);
+        }
     }
 
     private void callPluginMethod(String callbackId, String pluginId, String methodName, JSObject methodData) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -140,10 +140,6 @@ public class Plugin {
 
         // validate permissions and invoke the permission result callback
         if (bridge.validatePermissions(this, savedCall, permissionResultMap)) {
-            if (!savedCall.isKeptAlive()) {
-                savedCall.release(bridge);
-            }
-
             try {
                 method.setAccessible(true);
                 method.invoke(this, savedCall);
@@ -158,11 +154,6 @@ public class Plugin {
         if (savedCall == null) {
             savedCall = bridge.getPluginCallForLastActivity();
         }
-
-        if (!savedCall.isKeptAlive()) {
-            savedCall.release(bridge);
-        }
-
         // invoke the activity result callback
         try {
             method.setAccessible(true);


### PR DESCRIPTION
Capacitor calls are being saved when an intent is being launched and then released after the intent returns a result, but before the plugin returns the result, and in cases where there are multiple intents launched by the same plugin call it ends up creating null pointer exceptions in some cases where the call was released sooner than expected and needed later.

This PR removes the early releases of the calls and put it where the call actually rejects or resolves to the JS side.

closes https://github.com/ionic-team/capacitor/issues/4307