### PR TITLE
feat(ios): add credentials to webview for auth challenge

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04CF072125FFBB3F00E16E54 /* WebViewCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CF072025FFBB3F00E16E54 /* WebViewCredential.swift */; };
 		373A69C1255C9360000A6F44 /* NotificationHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A69C0255C9360000A6F44 /* NotificationHandlerProtocol.swift */; };
 		373A69F2255C95D0000A6F44 /* NotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A69F1255C95D0000A6F44 /* NotificationRouter.swift */; };
 		501CBAA71FC0A723009B0D4D /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501CBAA61FC0A723009B0D4D /* WebKit.framework */; };
@@ -130,6 +131,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04CF072025FFBB3F00E16E54 /* WebViewCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewCredential.swift; sourceTree = "<group>"; };
 		373A69C0255C9360000A6F44 /* NotificationHandlerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandlerProtocol.swift; sourceTree = "<group>"; };
 		373A69F1255C95D0000A6F44 /* NotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRouter.swift; sourceTree = "<group>"; };
 		501CBAA61FC0A723009B0D4D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
@@ -311,6 +313,7 @@
 				62959B0A2524DA7700A3D7F1 /* CAPBridgeDelegate.swift */,
 				62E207AD2588234500A78983 /* WebViewDelegationHandler.swift */,
 				625AF1EC258963C700869675 /* WebViewAssetHandler.swift */,
+				04CF072025FFBB3F00E16E54 /* WebViewCredential.swift */,
 				62959AEA2524DA7700A3D7F1 /* Plugins */,
 				623D6907254C6FDF002D01D1 /* CAPInstanceDescriptor.h */,
 				623D6908254C6FDF002D01D1 /* CAPInstanceDescriptor.m */,
@@ -588,6 +591,7 @@
 				623D691E254C7462002D01D1 /* CAPInstanceConfiguration.m in Sources */,
 				623D68FA254C5037002D01D1 /* KeyPath.swift in Sources */,
 				62959B222524DA7800A3D7F1 /* Console.swift in Sources */,
+				04CF072125FFBB3F00E16E54 /* WebViewCredential.swift in Sources */,
 				62959B3A2524DA7800A3D7F1 /* CAPLog.swift in Sources */,
 				6214934725509C3F006C36F9 /* CAPInstanceConfiguration.swift in Sources */,
 				623D6914254C7030002D01D1 /* CAPInstanceDescriptor.swift in Sources */,

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -10,6 +10,7 @@ import Cordova
 
     public fileprivate(set) var webView: WKWebView?
 
+    public var credential: WebViewCredential?
     public var isStatusBarVisible = true
     public var statusBarStyle: UIStatusBarStyle = .default
     public var statusBarAnimation: UIStatusBarAnimation = .slide
@@ -44,6 +45,7 @@ import Cordova
         let assetHandler = WebViewAssetHandler()
         assetHandler.setAssetPath(configuration.appLocation.path)
         let delegationHandler = WebViewDelegationHandler()
+        delegationHandler.credential = credential
         prepareWebView(with: configuration, assetHandler: assetHandler, delegationHandler: delegationHandler)
         view = webView
         // create the bridge

--- a/ios/Capacitor/Capacitor/WebViewCredential.swift
+++ b/ios/Capacitor/Capacitor/WebViewCredential.swift
@@ -8,12 +8,20 @@
 
 import Foundation
 
-public struct WebViewCredential {
-    public let user: String
-    public let password: String
-    public let persistence: URLCredential.Persistence
+@objc(WebViewCredential)
+open class WebViewCredential: NSObject {
+    @objc public let user: String
+    @objc public let password: String
+    @objc public let persistence: URLCredential.Persistence
 
-    public var asURLCredential: URLCredential {
+    @objc public var asURLCredential: URLCredential {
         URLCredential(user: user, password: password, persistence: persistence)
+    }
+
+    @objc public init(user: String, password: String, persistence: URLCredential.Persistence) {
+        self.user = user
+        self.password = password
+        self.persistence = persistence
+        super.init()
     }
 }

--- a/ios/Capacitor/Capacitor/WebViewCredential.swift
+++ b/ios/Capacitor/Capacitor/WebViewCredential.swift
@@ -1,0 +1,19 @@
+//
+//  WebViewCredential.swift
+//  Capacitor
+//
+//  Created by Kachalov, Victor on 15.03.21.
+//  Copyright © 2021 Drifty Co. All rights reserved.
+//
+
+import Foundation
+
+public struct WebViewCredential {
+    public let user: String
+    public let password: String
+    public let persistence: URLCredential.Persistence
+
+    public var asURLCredential: URLCredential {
+        URLCredential(user: user, password: password, persistence: persistence)
+    }
+}

--- a/ios/Capacitor/Capacitor/WebViewCredential.swift
+++ b/ios/Capacitor/Capacitor/WebViewCredential.swift
@@ -1,11 +1,3 @@
-//
-//  WebViewCredential.swift
-//  Capacitor
-//
-//  Created by Kachalov, Victor on 15.03.21.
-//  Copyright © 2021 Drifty Co. All rights reserved.
-//
-
 import Foundation
 
 @objc(WebViewCredential)

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -6,6 +6,7 @@ import WebKit
 @objc(CAPWebViewDelegationHandler)
 internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
     weak var bridge: CapacitorBridge?
+    var credential: WebViewCredential?
     fileprivate(set) var contentController = WKUserContentController()
     enum WebViewLoadingState {
         case unloaded
@@ -234,6 +235,16 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
         return nil
+    }
+
+    public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        guard let credential = self.credential else {
+            CAPLog.print("⚡️  Error didReceive challenge. Nil credentials")
+            return
+        }
+        let urlCredential = credential.asURLCredential
+        challenge.sender?.use(urlCredential, for: challenge)
+        completionHandler(.useCredential, urlCredential)
     }
 
     // MARK: - Private


### PR DESCRIPTION
If the hybrid approach is required when Capacitor is an addition to the native app, sometimes the Web App may request basic auth in order to allow the connection. In order not to inject the credentials inside the capacitor.config.json file, there should be an opportunity to provide credentials in a native way when the callback 

`webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)`

is called (for iOS).