### PR TITLE
fix(ios): cordova-plugin-screen-orientation not working

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -13,7 +13,7 @@ import Cordova
     public var isStatusBarVisible = true
     public var statusBarStyle: UIStatusBarStyle = .default
     public var statusBarAnimation: UIStatusBarAnimation = .slide
-    public var supportedOrientations: [Int] = []
+    @objc public var supportedOrientations: [Int] = []
 
     public lazy final var isNewBinary: Bool = {
         if let curVersionCode = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,


### PR DESCRIPTION
`cordova-plugin-screen-orientation` sets the screen orientation of the view controller but when `CAPBridgeViewController` was made public the `@objc` was removed.
Since `cordova-plugin-screen-orientation` is an Objective-C plugin it can't set the value anymore, so putting the `@objc` back fixes the problems.

closes https://github.com/ionic-team/capacitor/issues/4357