### PR TITLE
Give option to skip sync when doing a cap add

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -93,7 +93,8 @@ export class Config implements CliConfig {
     },
     server: {
       cleartext: false
-    }
+    },
+    skipSyncOnAdd: false
   };
 
   plugins = {

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -88,6 +88,7 @@ export interface CliConfigApp {
    */
   bundledWebRuntime: boolean;
   assets: CliConfigPlatformAssets;
+  skipSyncOnAdd: boolean;
 }
 
 export interface CliConfigPlugins {

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -122,7 +122,7 @@ async function editPlatforms(config: Config, platformName: string) {
 
 function shouldSync(config: Config, platformName: string) {
   // Don't sync if we're adding the iOS platform not on a mac
-  if (config.cli.os !== OS.Mac && platformName === 'ios') {
+  if (config.app.skipSyncOnAdd || (config.cli.os !== OS.Mac && platformName === 'ios')) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Change

This adds a new option to Capacitor's config called skipSyncOnAdd. If set to true, it will not do a `cap sync` during the `cap add` stage. false by default to retain original behaviour.

## Justification

When doing a `cap add`, Capacitor also does a `cap sync` internally. This causes problems if we have private iOS plugins specified in our package.json, as they fail to resolve because we didn't have the  chance to update `ios/App/Podfile` with private repository information.

What's happening at the moment:

```
npx cap add ios

...
✖ update ios:
[error] Analyzing dependencies
[!] Unable to find a specification for `<private package>` depended upon by `CustomPlugin`
```

To solve this, we just need to delay doing a `cap sync` until we modified the `Podfile`, like this:

1. `cap add` with no `cap sync`
2. Manually add private repository info to `ios/App/Podfile`.
3. `cap sync`

The change in this pull request is required to achieve the above.

## Why not use Capacitor 3?

We're hoping to switch to Capacitor 3, but can't do so at the moment as it drops iOS 11 support. So this pull request is for Capacitor 2 for now.

Is this something that could be merged in? 🙂 