### PR TITLE
chore(ci): Update swiftlint config/commands for latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lerna:publish:next": "lerna publish from-git --force-publish --dist-tag next --yes",
     "lerna:publish:latest": "lerna publish from-git --force-publish --dist-tag latest --yes",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- autocorrect --format",
+    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
     "prettier": "prettier \"**/*.{css,html,java,js,mjs,ts}\"",
     "eslint": "eslint . --ext ts",
     "swiftlint": "node-swiftlint",

--- a/swiftlint.config.js
+++ b/swiftlint.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   ...require('@ionic/swiftlint-config'),
-  included: ['ios', 'ios-template'],
-  excluded: ['ios/Capacitor/CapacitorTests', 'ios/Capacitor/TestsHostApp'],
+  included: ['${PWD}/ios', '${PWD}/ios-template'],
+  excluded: [
+    '${PWD}/ios/Capacitor/CapacitorTests',
+    '${PWD}/ios/Capacitor/TestsHostApp',
+  ],
 };


### PR DESCRIPTION
`autocorrect` was renamed to `--fix`

`includes`/`excluded` require the full path, that can be accomplished by appending `${PWD}/` to the paths.