### PR TITLE
Give option to skip sync on add

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -59,6 +59,7 @@ export async function loadConfig(): Promise<Config> {
       },
       ...conf,
       bundledWebRuntime: conf.extConfig.bundledWebRuntime ?? false,
+      skipSyncOnAdd: conf.extConfig.skipSyncOnAdd ?? false,
     },
   };
 

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -42,6 +42,17 @@ export interface CapacitorConfig {
   bundledWebRuntime?: boolean;
 
   /**
+   * Whether to skip doing a `cap sync` during `cap add`
+   *
+   * Sometimes you may not wish to perform a `cap sync` when adding a platform. e.g. if you're using
+   * private plugins that may cause the `cap sync` to fail.
+   *
+   * @since 3.0.0
+   * @default false
+   */
+   skipSyncOnAdd?: boolean;
+
+  /**
    * Hide or show the native logs for iOS and Android.
    *
    * @since 2.1.0

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -68,6 +68,7 @@ export interface AppConfig {
    * module imports, set this to "true" and import "capacitor.js" manually.
    */
   readonly bundledWebRuntime: boolean;
+  readonly skipSyncOnAdd: boolean;
 }
 
 export interface AndroidConfig extends PlatformConfig {

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -156,7 +156,7 @@ async function editPlatforms(config: Config, platformName: string) {
 
 function shouldSync(config: Config, platformName: string) {
   // Don't sync if we're adding the iOS platform not on a mac
-  if (config.cli.os !== OS.Mac && platformName === 'ios') {
+  if (config.app.skipSyncOnAdd || (config.cli.os !== OS.Mac && platformName === 'ios')) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Change

This adds a new option to Capacitor's config called skipSyncOnAdd. If set to true, it will not do a `cap sync` during the `cap add` stage. false by default to retain original behaviour.

## Justification

When doing a `cap add`, Capacitor also does a `cap sync` internally. This causes problems if we have private iOS plugins specified in our package.json, as they fail to resolve because we didn't have the chance to update `ios/App/Podfile` with private repository information.

What's happening at the moment:

```
npx cap add ios

...
✖ update ios:
[error] Analyzing dependencies
[!] Unable to find a specification for `<private package>` depended upon by `CustomPlugin`
```

To solve this, we just need to delay doing a cap sync until we modified the Podfile, like this:

1. `cap add` with no `cap sync`
2. Manually add private repository info to `ios/App/Podfile`.
3. `cap sync`

The change in this pull request is required to achieve the above.