### PR TITLE
set layout for display cutout mode on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -2,7 +2,9 @@ package com.getcapacitor;
 
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
+import android.view.WindowManager;
 import androidx.appcompat.app.AppCompatActivity;
 import com.getcapacitor.android.R;
 import java.util.ArrayList;
@@ -22,6 +24,9 @@ public class BridgeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         bridgeBuilder.setInstanceState(savedInstanceState);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            getWindow().getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+        }
     }
 
     /**


### PR DESCRIPTION
this addresses [this plugin issue](https://github.com/ionic-team/capacitor-plugins/issues/329), where an Android device with cutout (notch) and without status bar wouldn't fill the content.