### PR TITLE
chore: Remove iOS 12 available checks

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -9,7 +9,6 @@ import WebKit
     var notificationRouter: NotificationRouter { get }
     var isSimEnvironment: Bool { get }
     var isDevEnvironment: Bool { get }
-    @available(iOS 12.0, *)
     var userInterfaceStyle: UIUserInterfaceStyle { get }
     var statusBarVisible: Bool { get set }
     var statusBarStyle: UIStatusBarStyle { get set }
@@ -31,7 +30,6 @@ import WebKit
     @available(*, deprecated, renamed: "statusBarStyle")
     func getStatusBarStyle() -> UIStatusBarStyle
 
-    @available(iOS 12.0, *)
     @available(*, deprecated, renamed: "userInterfaceStyle")
     func getUserInterfaceStyle() -> UIUserInterfaceStyle
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -39,7 +39,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         #endif
     }
 
-    @available(iOS 12.0, *)
     public var userInterfaceStyle: UIUserInterfaceStyle {
         return viewController?.traitCollection.userInterfaceStyle ?? .unspecified
     }
@@ -137,7 +136,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         statusBarStyle = style
     }
 
-    @available(iOS 12.0, *)
     public func getUserInterfaceStyle() -> UIUserInterfaceStyle {
         return userInterfaceStyle
     }


### PR DESCRIPTION
We no longer support iOS 11, so all those checks are not needed anymore