### PR TITLE
fix(android): Avoid handling redirection response in WebViewLocalServer (#4240)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -362,20 +362,23 @@ public class WebViewLocalServer {
                      */
                     conn.setInstanceFollowRedirects(false);
                     conn.connect();
-                    int status = conn.getResponseCode();
-                    if (
-                        status == HttpURLConnection.HTTP_MOVED_TEMP ||
-                        status == HttpURLConnection.HTTP_MOVED_PERM ||
-                        status == HttpURLConnection.HTTP_SEE_OTHER
-                    ) {
-                        // Return null so that this request will not be intercepted.
-                        return null;
-                    }
 
                     String cookie = conn.getHeaderField("Set-Cookie");
                     if (cookie != null) {
                         CookieManager.getInstance().setCookie(url, cookie);
                     }
+
+                    int status = conn.getResponseCode();
+                    if (
+                        status == HttpURLConnection.HTTP_MOVED_TEMP ||
+                        status == HttpURLConnection.HTTP_MOVED_PERM ||
+                        status == HttpURLConnection.HTTP_SEE_OTHER ||
+                        status == 307 // Temporary Redirect
+                    ) {
+                        // Return null so that this request will not be intercepted.
+                        return null;
+                    }
+
                     InputStream responseStream = conn.getInputStream();
                     responseStream = jsInjector.getInjectedStream(responseStream);
                     return new WebResourceResponse(


### PR DESCRIPTION
Fixes #4240

In `WebViewLocalServer.handleProxyRequest()`, avoid intercepting network request which will result in a redirection response. This is because intercepting redirection response in `handleProxyRequest()` will caused the redirection resolving in HttpURLConnection, rather than in web view. This in turn causes the window URL to be unchanged when we expected it to change after a redirect response.

