### PR TITLE
Ensure capacitor fires pause and resume events for Ionic/Angular

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/App.swift
+++ b/ios/Capacitor/Capacitor/Plugins/App.swift
@@ -45,6 +45,7 @@ public class CAPAppPlugin : CAPPlugin {
   }
   
   public func fireChange(isActive: Bool) {
+    self.bridge.triggerDocumentJSEvent(eventName: isActive ? "resume" : "pause")
     notifyListeners("appStateChange", data: [
       "isActive": isActive
     ])


### PR DESCRIPTION
Capacitor does not fire pause or resume events on the document. This means the Ionic/Angular Platform service pause and resume events never fire. They do on the Android release.