### PR TITLE
fix(ios): fire resume/pause events if no cordova plugins installed

### DIFF
--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -220,6 +220,13 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         if injectCordovaFiles {
             exportCordovaJS()
             registerCordovaPlugins()
+        } else {
+            NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+                self?.triggerDocumentJSEvent(eventName: "resume")
+            }
+            NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+                self?.triggerDocumentJSEvent(eventName: "pause")
+            }
         }
     }
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -106,6 +106,8 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
     // Background dispatch queue for plugin calls
     var dispatchQueue = DispatchQueue(label: "bridge")
+    // Array of block based observers
+    var observers: [NSObjectProtocol] = []
 
     // MARK: - CAPBridgeProtocol: Deprecated
 
@@ -189,14 +191,17 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         exportCoreJS(localUrl: configuration.localURL.absoluteString)
         registerPlugins()
         setupCordovaCompatibility()
-        NotificationCenter.default.addObserver(forName: type(of: self).tmpVCAppeared.name, object: .none, queue: .none) { [weak self] _ in
+        observers.append(NotificationCenter.default.addObserver(forName: type(of: self).tmpVCAppeared.name, object: .none, queue: .none) { [weak self] _ in
             self?.tmpWindow = nil
-        }
+        })
     }
 
     deinit {
         // the message handler needs to removed to avoid any retain cycles
         webViewDelegationHandler.cleanUp()
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     // MARK: - Plugins
@@ -221,12 +226,12 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
             exportCordovaJS()
             registerCordovaPlugins()
         } else {
-            NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
                 self?.triggerDocumentJSEvent(eventName: "resume")
-            }
-            NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+            })
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
                 self?.triggerDocumentJSEvent(eventName: "pause")
-            }
+            })
         }
     }
 


### PR DESCRIPTION
Cordova fires pause and resume events, but if there are no cordova plugins installed, cordova doesn't get initialized, so the events are not fired.
This PR fires pause/resume when there are no cordova plugins installed for compatibility

closes https://github.com/ionic-team/capacitor/issues/4456