### PR TITLE
fix(cli): Allow prereleases on node version check

### DIFF
--- a/cli/bin/capacitor
+++ b/cli/bin/capacitor
@@ -5,7 +5,7 @@ var satisfies = require('semver/functions/satisfies');
 var packageJson = require('../package.json');
 var requiresNodeVersion = packageJson.engines.node;
 
-if (!satisfies(process.version, requiresNodeVersion)) {
+if (!satisfies(process.version, requiresNodeVersion, { includePrerelease: true})) {
   process.stdout.write(
     '\x1b[31m[fatal]\x1b[39m The Capacitor CLI requires NodeJS ' + requiresNodeVersion + '\n' +
     '        Please install the latest LTS version.\n'


### PR DESCRIPTION
Our node version check doesn't allow prerelease versions, by adding `includePrerelease` option it will


closes https://github.com/ionic-team/capacitor/issues/4466