### PR TITLE
fix(core): Use web listener if there is no native implementation

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -216,7 +216,7 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
             case '$$typeof':
               return undefined;
             case 'addListener':
-              return isNativePlatform() ? addListenerNative : addListener;
+              return pluginHeader ? addListenerNative : addListener;
             case 'removeListener':
               return removeListener;
             default:

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -102,8 +102,8 @@ describe('legacy', () => {
 
   it('doc.addEventListener backbutton', done => {
     const AppWeb = class {
-      async addListener(event: any) {
-        expect(event).toBe('backButton');
+      async addListener(eventName: string) {
+        expect(eventName).toBe('backButton');
         done();
       }
     };

--- a/core/src/tests/legacy.spec.ts
+++ b/core/src/tests/legacy.spec.ts
@@ -103,7 +103,7 @@ describe('legacy', () => {
   it('doc.addEventListener backbutton', done => {
     const AppWeb = class {
       async addListener(event: any) {
-        expect(event.eventName).toBe('backButton');
+        expect(event).toBe('backButton');
         done();
       }
     };


### PR DESCRIPTION
Instead of always using the native listener on the native platforms, check if the native platform has a native implementation for the plugin (if pluginHeader is defined), and if not, use the web listener.

closes https://github.com/ionic-team/capacitor/issues/4331