### PR TITLE
fix(core): Call native implementation before web implementation

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -123,12 +123,7 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
             cap.nativePromise(pluginName, prop.toString(), options);
         } else {
           return (options: any, callback: any) =>
-            cap.nativeCallback(
-              pluginName,
-              prop.toString(),
-              options,
-              callback,
-            );
+            cap.nativeCallback(pluginName, prop.toString(), options, callback);
         }
       } else if (impl) {
         return impl[prop]?.bind(impl);

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -124,7 +124,12 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
               cap.nativePromise(pluginName, prop.toString(), options);
           } else {
             return (options: any, callback: any) =>
-              cap.nativeCallback(pluginName, prop.toString(), options, callback);
+              cap.nativeCallback(
+                pluginName,
+                prop.toString(),
+                options,
+                callback,
+              );
           }
         } else if (impl) {
           return impl[prop]?.bind(impl);

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -116,14 +116,18 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
       impl: any,
       prop: PropertyKey,
     ): ((...args: any[]) => any) => {
-      const methodHeader = pluginHeader.methods.find(m => prop === m.name);
-      if (pluginHeader && methodHeader) {
-        if (methodHeader.rtype === 'promise') {
-          return (options: any) =>
-            cap.nativePromise(pluginName, prop.toString(), options);
-        } else {
-          return (options: any, callback: any) =>
-            cap.nativeCallback(pluginName, prop.toString(), options, callback);
+      if (pluginHeader) {
+        const methodHeader = pluginHeader?.methods.find(m => prop === m.name);
+        if (methodHeader) {
+          if (methodHeader.rtype === 'promise') {
+            return (options: any) =>
+              cap.nativePromise(pluginName, prop.toString(), options);
+          } else {
+            return (options: any, callback: any) =>
+              cap.nativeCallback(pluginName, prop.toString(), options, callback);
+          }
+        } else if (impl) {
+          return impl[prop]?.bind(impl);
         }
       } else if (impl) {
         return impl[prop]?.bind(impl);

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -116,25 +116,22 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
       impl: any,
       prop: PropertyKey,
     ): ((...args: any[]) => any) => {
-      if (impl) {
-        return impl[prop]?.bind(impl);
-      } else if (pluginHeader) {
-        const methodHeader = pluginHeader.methods.find(m => prop === m.name);
-
-        if (methodHeader) {
-          if (methodHeader.rtype === 'promise') {
-            return (options: any) =>
-              cap.nativePromise(pluginName, prop.toString(), options);
-          } else {
-            return (options: any, callback: any) =>
-              cap.nativeCallback(
-                pluginName,
-                prop.toString(),
-                options,
-                callback,
-              );
-          }
+      const methodHeader = pluginHeader.methods.find(m => prop === m.name);
+      if (pluginHeader && methodHeader) {
+        if (methodHeader.rtype === 'promise') {
+          return (options: any) =>
+            cap.nativePromise(pluginName, prop.toString(), options);
+        } else {
+          return (options: any, callback: any) =>
+            cap.nativeCallback(
+              pluginName,
+              prop.toString(),
+              options,
+              callback,
+            );
         }
+      } else if (impl) {
+        return impl[prop]?.bind(impl);
       } else {
         throw new CapacitorException(
           `"${pluginName}" plugin is not implemented on ${platform}`,


### PR DESCRIPTION
On plugins that mix native and web implementations, current implementation causes an infinite loop because it always tries to use the web implementation before the native implementation, so when it reaches `Plugins.PluginName`, it tries to call the native code, but the proxy returns the web code, which tries to call the native code again and causes the infinite loop.

By changing the order, it will use the native code if available, and if not, use the web implementation.

closes https://github.com/ionic-team/capacitor/issues/4492