### PR TITLE
fix(bridge): Fix type errors with new Platforms API

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -559,7 +559,7 @@ initBridge(
     ? (window as any)
     : typeof global !== 'undefined'
     ? (global as any)
-    : ({} as WindowCapacitor),
+    : ({} as any),
 );
 
 // Export only for tests

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -552,14 +552,14 @@ const initBridge = (w: any): void => {
 
 initBridge(
   typeof globalThis !== 'undefined'
-    ? (globalThis as any)
+    ? (globalThis as WindowCapacitor)
     : typeof self !== 'undefined'
-    ? (self as any)
+    ? (self as WindowCapacitor)
     : typeof window !== 'undefined'
-    ? (window as any)
+    ? (window as WindowCapacitor)
     : typeof global !== 'undefined'
-    ? (global as any)
-    : ({} as any),
+    ? (global as WindowCapacitor)
+    : ({} as WindowCapacitor),
 );
 
 // Export only for tests

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -552,13 +552,13 @@ const initBridge = (w: any): void => {
 
 initBridge(
   typeof globalThis !== 'undefined'
-    ? (globalThis as WindowCapacitor)
+    ? (globalThis as any)
     : typeof self !== 'undefined'
-    ? (self as WindowCapacitor)
+    ? (self as any)
     : typeof window !== 'undefined'
-    ? (window as WindowCapacitor)
+    ? (window as any)
     : typeof global !== 'undefined'
-    ? (global as WindowCapacitor)
+    ? (global as any)
     : ({} as WindowCapacitor),
 );
 

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -167,7 +167,7 @@ export interface StoredCallback {
 
 export interface WindowCapacitor {
   Capacitor?: CapacitorInstance;
-  CapacitorPlatforms: CapacitorPlatformsInstance;
+  CapacitorPlatforms?: CapacitorPlatformsInstance;
   Ionic?: {
     WebView?: {
       getServerBasePath?: any;

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -4,7 +4,7 @@ import type {
   PluginResultData,
   PluginResultError,
 } from './definitions';
-import { CapacitorPlatformsInstance } from './platforms';
+import type { CapacitorPlatformsInstance } from './platforms';
 
 export interface PluginHeaderMethod {
   readonly name: string;

--- a/core/src/platforms.ts
+++ b/core/src/platforms.ts
@@ -1,49 +1,52 @@
-import { PluginImplementations } from "./definitions";
-import { PluginHeader } from "./definitions-internal";
+import type { PluginImplementations } from './definitions';
+import type { PluginHeader } from './definitions-internal';
 
 export interface CapacitorPlatform {
   name: string;
   getPlatform?(): string;
   isPluginAvailable?(pluginName: string): boolean;
   getPluginHeader?(pluginName: string): PluginHeader | undefined;
-  registerPlugin?(pluginName: string, jsImplementations: PluginImplementations): any;
+  registerPlugin?(
+    pluginName: string,
+    jsImplementations: PluginImplementations,
+  ): any;
   isNativePlatform?(): boolean;
 }
 
 export interface CapacitorPlatformsInstance {
   currentPlatform: CapacitorPlatform;
-  platforms: Map<string, CapacitorPlatform>,
+  platforms: Map<string, CapacitorPlatform>;
   addPlatform(name: string, platform: CapacitorPlatform): void;
   setPlatform(name: string): void;
 }
 
-
 const createCapacitorPlatforms = (win: any): CapacitorPlatformsInstance => {
   const defaultPlatformMap = new Map<string, CapacitorPlatform>();
-  defaultPlatformMap.set('web', {name: 'web'});
-  
+  defaultPlatformMap.set('web', { name: 'web' });
+
   const capPlatforms: CapacitorPlatformsInstance = win.CapacitorPlatforms || {
-    currentPlatform: {name: 'web'},
+    currentPlatform: { name: 'web' },
     platforms: defaultPlatformMap,
   };
 
   const addPlatform = (name: string, platform: CapacitorPlatform) => {
     capPlatforms.platforms.set(name, platform);
-  }
+  };
 
   const setPlatform = (name: string) => {
     if (capPlatforms.platforms.has(name)) {
       capPlatforms.currentPlatform = capPlatforms.platforms.get(name);
     }
-  }
+  };
 
   capPlatforms.addPlatform = addPlatform;
   capPlatforms.setPlatform = setPlatform;
 
-  return capPlatforms
-}
+  return capPlatforms;
+};
 
-const initPlatforms = (win: any) => (win.CapacitorPlatforms = createCapacitorPlatforms(win))
+const initPlatforms = (win: any) =>
+  (win.CapacitorPlatforms = createCapacitorPlatforms(win));
 
 export const CapacitorPlatforms = /*#__PURE__*/ initPlatforms(
   (typeof globalThis !== 'undefined'

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -20,11 +20,11 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
 
   const defaultGetPlatform = () => getPlatformId(win);
   const getPlatform =
-    capPlatforms.currentPlatform.getPlatform || defaultGetPlatform;
+    capPlatforms?.currentPlatform?.getPlatform || defaultGetPlatform;
 
   const defaultIsNativePlatform = () => getPlatformId(win) !== 'web';
   const isNativePlatform =
-    capPlatforms.currentPlatform.isNativePlatform || defaultIsNativePlatform;
+    capPlatforms?.currentPlatform?.isNativePlatform || defaultIsNativePlatform;
 
   const defaultIsPluginAvailable = (pluginName: string): boolean => {
     const plugin = registeredPlugins.get(pluginName);
@@ -42,14 +42,15 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
     return false;
   };
   const isPluginAvailable =
-    capPlatforms.currentPlatform.isPluginAvailable || defaultIsPluginAvailable;
+    capPlatforms?.currentPlatform?.isPluginAvailable ||
+    defaultIsPluginAvailable;
 
   const defaultGetPluginHeader = (
     pluginName: string,
   ): PluginHeader | undefined =>
     cap.PluginHeaders?.find(h => h.name === pluginName);
   const getPluginHeader =
-    capPlatforms.currentPlatform.getPluginHeader || defaultGetPluginHeader;
+    capPlatforms?.currentPlatform?.getPluginHeader || defaultGetPluginHeader;
 
   const handleError = (err: Error) => win.console.error(err);
 
@@ -222,7 +223,7 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
     return proxy;
   };
   const registerPlugin =
-    capPlatforms.currentPlatform.registerPlugin || defaultRegisterPlugin;
+    capPlatforms?.currentPlatform?.registerPlugin || defaultRegisterPlugin;
 
   // Add in convertFileSrc for web, it will already be available in native context
   if (!cap.convertFileSrc) {

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -4,8 +4,8 @@ import type {
   PluginHeader,
   WindowCapacitor,
 } from './definitions-internal';
-import { CapacitorException, getPlatformId, ExceptionCode } from './util';
 import type { CapacitorPlatformsInstance } from './platforms';
+import { CapacitorException, getPlatformId, ExceptionCode } from './util';
 
 export interface RegisteredPlugin {
   readonly name: string;
@@ -19,10 +19,12 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
   const capPlatforms: CapacitorPlatformsInstance = win.CapacitorPlatforms;
 
   const defaultGetPlatform = () => getPlatformId(win);
-  const getPlatform = capPlatforms.currentPlatform.getPlatform || defaultGetPlatform;
+  const getPlatform =
+    capPlatforms.currentPlatform.getPlatform || defaultGetPlatform;
 
   const defaultIsNativePlatform = () => getPlatformId(win) !== 'web';
-  const isNativePlatform = capPlatforms.currentPlatform.isNativePlatform || defaultIsNativePlatform;
+  const isNativePlatform =
+    capPlatforms.currentPlatform.isNativePlatform || defaultIsNativePlatform;
 
   const defaultIsPluginAvailable = (pluginName: string): boolean => {
     const plugin = registeredPlugins.get(pluginName);
@@ -39,10 +41,15 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
 
     return false;
   };
-  const isPluginAvailable = capPlatforms.currentPlatform.isPluginAvailable || defaultIsPluginAvailable;
+  const isPluginAvailable =
+    capPlatforms.currentPlatform.isPluginAvailable || defaultIsPluginAvailable;
 
-  const defaultGetPluginHeader = (pluginName: string): PluginHeader | undefined => cap.PluginHeaders?.find(h => h.name === pluginName);
-  const getPluginHeader = capPlatforms.currentPlatform.getPluginHeader || defaultGetPluginHeader;
+  const defaultGetPluginHeader = (
+    pluginName: string,
+  ): PluginHeader | undefined =>
+    cap.PluginHeaders?.find(h => h.name === pluginName);
+  const getPluginHeader =
+    capPlatforms.currentPlatform.getPluginHeader || defaultGetPluginHeader;
 
   const handleError = (err: Error) => win.console.error(err);
 
@@ -214,7 +221,8 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
 
     return proxy;
   };
-  const registerPlugin = capPlatforms.currentPlatform.registerPlugin || defaultRegisterPlugin;
+  const registerPlugin =
+    capPlatforms.currentPlatform.registerPlugin || defaultRegisterPlugin;
 
   // Add in convertFileSrc for web, it will already be available in native context
   if (!cap.convertFileSrc) {


### PR DESCRIPTION
Merging in #4255 seemed to make tests and types not work anymore even though they worked fine on their own individual branch...This PR makes some changes such as

- Making the `CapacitorPlatforms` optional like all of the other types on `WindowCapacitor`
- optional chaining to allow web platform to default correctly to the bridge functions if no platform was initialized (mostly for tests)