### PR TITLE
fix(ios): Don't auto release saved calls

### DIFF
--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -456,8 +456,6 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
                 plugin.perform(selector, with: pluginCall)
                 if pluginCall.keepAlive {
                     self?.saveCall(pluginCall)
-                } else {
-                    self?.releaseCall(pluginCall)
                 }
             }
 


### PR DESCRIPTION
According to the [saving calls docs](https://capacitorjs.com/docs/v3/core-apis/saving-calls) if you save a call you have to release it, but at the moment it's being released automatically, which prevents the saveCall from working. (can be reproduced on https://github.com/ionic-team/capacitor-plugins/pull/374)

closes https://github.com/ionic-team/capacitor/issues/4531