### PR TITLE
chore(ios): Use AnyObject instead of class for protocol inheritance

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeDelegate.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeDelegate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal protocol CAPBridgeDelegate: class {
+internal protocol CAPBridgeDelegate: AnyObject {
     var bridgedWebView: WKWebView? { get }
     var bridgedViewController: UIViewController? { get }
 }


### PR DESCRIPTION
When compiling with @capacitor/ios 3.0.0-rc.3 we get the following warning. This fixes this warning.

/Users/morten/MyProject/node_modules/@capacitor/ios/Capacitor/Capacitor/CAPBridgeDelegate.swift:3:38: Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead