### PR TITLE
fix: Make isPluginAvailable available on bridge

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -308,7 +308,7 @@ const nativeBridge = (function (exports) {
             const isNativePlatform = () => true;
             const getPlatform = () => getPlatformId(win);
             cap.getPlatform = getPlatform;
-            cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
+            cap.isPluginAvailable = name => Object.prototype.hasOwnProperty.call(cap.Plugins, name);
             cap.isNativePlatform = isNativePlatform;
             // create the postToNative() fn if needed
             if (getPlatformId(win) === 'android') {

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -308,6 +308,7 @@ const nativeBridge = (function (exports) {
             const isNativePlatform = () => true;
             const getPlatform = () => getPlatformId(win);
             cap.getPlatform = getPlatform;
+            cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
             cap.isNativePlatform = isNativePlatform;
             // create the postToNative() fn if needed
             if (getPlatformId(win) === 'android') {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -372,7 +372,8 @@ const initBridge = (w: any): void => {
     const getPlatform = () => getPlatformId(win);
 
     cap.getPlatform = getPlatform;
-    cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
+    cap.isPluginAvailable = name =>
+      Object.prototype.hasOwnProperty.call(cap.Plugins, name);
     cap.isNativePlatform = isNativePlatform;
 
     // create the postToNative() fn if needed

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -372,6 +372,7 @@ const initBridge = (w: any): void => {
     const getPlatform = () => getPlatformId(win);
 
     cap.getPlatform = getPlatform;
+    cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
     cap.isNativePlatform = isNativePlatform;
 
     // create the postToNative() fn if needed

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -308,7 +308,7 @@ const nativeBridge = (function (exports) {
             const isNativePlatform = () => true;
             const getPlatform = () => getPlatformId(win);
             cap.getPlatform = getPlatform;
-            cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
+            cap.isPluginAvailable = name => Object.prototype.hasOwnProperty.call(cap.Plugins, name);
             cap.isNativePlatform = isNativePlatform;
             // create the postToNative() fn if needed
             if (getPlatformId(win) === 'android') {

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -308,6 +308,7 @@ const nativeBridge = (function (exports) {
             const isNativePlatform = () => true;
             const getPlatform = () => getPlatformId(win);
             cap.getPlatform = getPlatform;
+            cap.isPluginAvailable = (name) => cap.Plugins.hasOwnProperty(name);
             cap.isNativePlatform = isNativePlatform;
             // create the postToNative() fn if needed
             if (getPlatformId(win) === 'android') {


### PR DESCRIPTION
ionic relies on `isPluginAvailable` being on `Capacitor` object, so adding it to the bridge

closes https://github.com/ionic-team/capacitor/issues/4588