### PR TITLE
fix(android): Reset bridge on onPageStarted only

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -1,5 +1,6 @@
 package com.getcapacitor;
 
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -42,5 +43,11 @@ public class BridgeWebViewClient extends WebViewClient {
                 listener.onPageLoaded(view);
             }
         }
+    }
+
+    @Override
+    public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        super.onPageStarted(view, url, favicon);
+        bridge.reset();
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -266,7 +266,6 @@ public class WebViewLocalServer {
 
             responseStream = jsInjector.getInjectedStream(responseStream);
 
-            bridge.reset();
             int statusCode = getStatusCode(responseStream, handler.getStatusCode());
             return new WebResourceResponse(
                 "text/html",
@@ -295,7 +294,6 @@ public class WebViewLocalServer {
             // TODO: Conjure up a bit more subtlety than this
             if (ext.equals(".html")) {
                 responseStream = jsInjector.getInjectedStream(responseStream);
-                bridge.reset();
             }
 
             String mimeType = getMimeType(path, responseStream);
@@ -351,7 +349,6 @@ public class WebViewLocalServer {
                     }
                     InputStream responseStream = conn.getInputStream();
                     responseStream = jsInjector.getInjectedStream(responseStream);
-                    bridge.reset();
                     return new WebResourceResponse(
                         "text/html",
                         handler.getEncoding(),


### PR DESCRIPTION
Whenever a html file is requested (i.e, a fetch/xhr call to a .html file), the bridge is being reset, which causes problems such as the mentioned on https://github.com/ionic-team/capacitor/issues/3444, as it cleans all the saved calls, making it impossible to clean listeners and also to return values on plugins that use callbacks.

So, instead of reseting the bridge when a .html file is requested, reset it when onPageStarted is called, which is not called on xhr/fetch/iframes, etc.

closes https://github.com/ionic-team/capacitor/issues/3444