### PR TITLE
fix(cli): Don't prompt cordova preferences if non interactive

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -31,6 +31,7 @@ import {
 } from './plugin';
 import type { Plugin } from './plugin';
 import { resolveNode } from './util/node';
+import { isInteractive } from './util/term';
 import { buildXmlElement, parseXML, readXML, writeXML } from './util/xml';
 
 /**
@@ -513,43 +514,45 @@ export async function getCordovaPreferences(config: Config): Promise<any> {
     }
   }
   if (cordova.preferences && Object.keys(cordova.preferences).length > 0) {
-    const answers = await logPrompt(
-      `${c.strong(
-        `Cordova preferences can be automatically ported to ${c.strong(
-          config.app.extConfigName,
-        )}.`,
-      )}\n` +
-        `Keep in mind: Not all values can be automatically migrated from ${c.strong(
-          'config.xml',
-        )}. There may be more work to do.\n` +
-        `More info: ${c.strong(
-          'https://capacitorjs.com/docs/cordova/migrating-from-cordova-to-capacitor',
-        )}`,
-      {
-        type: 'confirm',
-        name: 'confirm',
-        message: `Migrate Cordova preferences from config.xml?`,
-        initial: true,
-      },
-    );
-    if (answers.confirm) {
-      if (config.app.extConfig?.cordova?.preferences) {
-        const answers = await prompts(
-          [
-            {
-              type: 'confirm',
-              name: 'confirm',
-              message: `${config.app.extConfigName} already contains Cordova preferences. Overwrite?`,
-            },
-          ],
-          { onCancel: () => process.exit(1) },
-        );
-        if (!answers.confirm) {
-          cordova = config.app.extConfig?.cordova;
+    if (isInteractive()) {
+      const answers = await logPrompt(
+        `${c.strong(
+          `Cordovaaa preferences can be automatically ported to ${c.strong(
+            config.app.extConfigName,
+          )}.`,
+        )}\n` +
+          `Keep in mind: Not all values can be automatically migrated from ${c.strong(
+            'config.xml',
+          )}. There may be more work to do.\n` +
+          `More info: ${c.strong(
+            'https://capacitorjs.com/docs/cordova/migrating-from-cordova-to-capacitor',
+          )}`,
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `Migrate Cordova preferences from config.xml?`,
+          initial: true,
+        },
+      );
+      if (answers.confirm) {
+        if (config.app.extConfig?.cordova?.preferences) {
+          const answers = await prompts(
+            [
+              {
+                type: 'confirm',
+                name: 'confirm',
+                message: `${config.app.extConfigName} already contains Cordova preferences. Overwrite?`,
+              },
+            ],
+            { onCancel: () => process.exit(1) },
+          );
+          if (!answers.confirm) {
+            cordova = config.app.extConfig?.cordova;
+          }
         }
+      } else {
+        cordova = config.app.extConfig?.cordova;
       }
-    } else {
-      cordova = config.app.extConfig?.cordova;
     }
   } else {
     cordova = config.app.extConfig?.cordova;


### PR DESCRIPTION
If there is a config.xml present, capacitor CLI will prompt the user if they want to migrate preferences from config.xml to capacitor config file.
In non interactive environments (such as when run inside ionic CLI) it will hang as it can't choose an answer.
So, in cases is a non interactive environment, migrate the preferences without asking.

closes https://github.com/ionic-team/capacitor/issues/4678