### PR TITLE
fix(cli): Throw error if native-run didn't find targets

### DIFF
--- a/cli/src/util/native-run.ts
+++ b/cli/src/util/native-run.ts
@@ -28,24 +28,37 @@ export async function runNativeRun(
 export async function getPlatformTargets(
   platformName: string,
 ): Promise<PlatformTarget[]> {
+  const errors = [];
   try {
     const output = await runNativeRun([platformName, '--list', '--json']);
     const parsedOutput = JSON.parse(output);
-
-    return [
-      ...parsedOutput.devices.map((t: any) => ({ ...t, virtual: false })),
-      ...parsedOutput.virtualDevices.map((t: any) => ({ ...t, virtual: true })),
-    ];
+    if (parsedOutput.devices?.[0] || parsedOutput.virtualDevices?.[0]) {
+      return [
+        ...parsedOutput.devices.map((t: any) => ({ ...t, virtual: false })),
+        ...parsedOutput.virtualDevices.map((t: any) => ({
+          ...t,
+          virtual: true,
+        })),
+      ];
+    } else {
+      parsedOutput.errors.map((e: any) => {
+        errors.push(e);
+      });
+    }
   } catch (e) {
     const err = JSON.parse(e);
-    const errMsg = `${c.strong('native-run')} failed with error ${c.strong(
-      err.code,
-    )}: ${err.error}
-
-    \tMore details for this error may be available online: ${c.strong(
-      'https://github.com/ionic-team/native-run/wiki/Android-Errors',
-    )}
-    `;
-    throw errMsg;
+    errors.push(err);
   }
+  const plural = errors.length > 1 ? 's' : '';
+  const errMsg = `${c.strong('native-run')} failed with error${plural}\n
+  ${errors
+    .map((e: any) => {
+      return `\t${c.strong(e.code)}: ${e.error}`;
+    })
+    .join('\n')}
+  \n\tMore details for this error${plural} may be available online: ${c.strong(
+    'https://github.com/ionic-team/native-run/wiki/Android-Errors',
+  )}
+  `;
+  throw errMsg;
 }

--- a/cli/src/util/native-run.ts
+++ b/cli/src/util/native-run.ts
@@ -32,7 +32,7 @@ export async function getPlatformTargets(
   try {
     const output = await runNativeRun([platformName, '--list', '--json']);
     const parsedOutput = JSON.parse(output);
-    if (parsedOutput.devices?.[0] || parsedOutput.virtualDevices?.[0]) {
+    if (parsedOutput.devices.length || parsedOutput.virtualDevices.length) {
       return [
         ...parsedOutput.devices.map((t: any) => ({ ...t, virtual: false })),
         ...parsedOutput.virtualDevices.map((t: any) => ({


### PR DESCRIPTION
At the moment if native-run didn't find any device or emulator, run just silently fail.

This PR changes the behavior to throw the errors (can be more than one) that native-run provided.