### PR TITLE
fix(android): Avoid crash on input file

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -406,6 +406,9 @@ public class BridgeWebChromeClient extends WebChromeClient {
         if (fileChooserParams.getAcceptTypes().length > 1) {
             String[] validTypes = getValidTypes(fileChooserParams.getAcceptTypes());
             intent.putExtra(Intent.EXTRA_MIME_TYPES, validTypes);
+            if (intent.getType().startsWith(".")) {
+                intent.setType(validTypes[0]);
+            }
         }
         try {
             activityListener =


### PR DESCRIPTION
if you have an input file like `<input type="file" accept=".png,.jpg">`, android creates an intent with `.png` type, which is not a proper value and causes an activity not found which leads to a crash.

This PR checks the type and replaces it with the proper mime.