### PR TITLE
fix(core): cordova events not firing

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -37,8 +37,6 @@ const nativeBridge = (function (exports) {
             return filePath;
         };
         const initEvents = (win, cap) => {
-            const doc = win.document;
-            const cordova = win.cordova;
             cap.addListener = (pluginName, eventName, callback) => {
                 const callbackId = cap.nativeCallback(pluginName, 'addListener', {
                     eventName: eventName,
@@ -58,6 +56,7 @@ const nativeBridge = (function (exports) {
                 }, callback);
             };
             cap.createEvent = (eventName, eventData) => {
+                const doc = win.document;
                 if (doc) {
                     const ev = doc.createEvent('Events');
                     ev.initEvent(eventName, false, false);
@@ -74,6 +73,8 @@ const nativeBridge = (function (exports) {
                 return null;
             };
             cap.triggerEvent = (eventName, target, eventData) => {
+                const doc = win.document;
+                const cordova = win.cordova;
                 eventData = eventData || {};
                 const ev = cap.createEvent(eventName, eventData);
                 if (ev) {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -48,9 +48,6 @@ const initBridge = (w: any): void => {
   };
 
   const initEvents = (win: WindowCapacitor, cap: CapacitorInstance) => {
-    const doc = win.document;
-    const cordova = win.cordova;
-
     cap.addListener = (pluginName, eventName, callback) => {
       const callbackId = cap.nativeCallback(
         pluginName,
@@ -81,6 +78,7 @@ const initBridge = (w: any): void => {
     };
 
     cap.createEvent = (eventName, eventData) => {
+      const doc = win.document;
       if (doc) {
         const ev = doc.createEvent('Events');
         ev.initEvent(eventName, false, false);
@@ -98,6 +96,8 @@ const initBridge = (w: any): void => {
     };
 
     cap.triggerEvent = (eventName, target, eventData) => {
+      const doc = win.document;
+      const cordova = win.cordova;
       eventData = eventData || {};
       const ev = cap.createEvent(eventName, eventData);
 

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -37,8 +37,6 @@ const nativeBridge = (function (exports) {
             return filePath;
         };
         const initEvents = (win, cap) => {
-            const doc = win.document;
-            const cordova = win.cordova;
             cap.addListener = (pluginName, eventName, callback) => {
                 const callbackId = cap.nativeCallback(pluginName, 'addListener', {
                     eventName: eventName,
@@ -58,6 +56,7 @@ const nativeBridge = (function (exports) {
                 }, callback);
             };
             cap.createEvent = (eventName, eventData) => {
+                const doc = win.document;
                 if (doc) {
                     const ev = doc.createEvent('Events');
                     ev.initEvent(eventName, false, false);
@@ -74,6 +73,8 @@ const nativeBridge = (function (exports) {
                 return null;
             };
             cap.triggerEvent = (eventName, target, eventData) => {
+                const doc = win.document;
+                const cordova = win.cordova;
                 eventData = eventData || {};
                 const ev = cap.createEvent(eventName, eventData);
                 if (ev) {


### PR DESCRIPTION
When the events are initialized cordova is still undefined as it gets injected later, so we are setting the undefined to a const, then, when you try to fire a cordova event, the cordova const is undefined and will fail to fire.

By moving the cordova const initialization to when it's going to be used it will contain the real `window.cordova` and won't be undefined.

Also moved the window.document just in case.

closes https://github.com/ionic-team/capacitor/issues/4713