### PR TITLE
fix(ios): Use proper native events for cordova events

### DIFF
--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -234,10 +234,10 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
             exportCordovaJS()
             registerCordovaPlugins()
         } else {
-            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
                 self?.triggerDocumentJSEvent(eventName: "resume")
             })
-            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
+            observers.append(NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: OperationQueue.main) { [weak self] (_) in
                 self?.triggerDocumentJSEvent(eventName: "pause")
             })
         }


### PR DESCRIPTION
cordova uses `willEnterForegroundNotification` instead of `didBecomeActiveNotification` for resume event and `didEnterBackgroundNotification` instead of `willResignActiveNotification` for pause event, so this should work the same way