### PR TITLE
fix(cli): Don't error on ios sync on non macOS

### DIFF
--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -85,3 +85,14 @@ export async function editProjectSettingsIOS(config: Config): Promise<void> {
   await writeFile(plistPath, plistContent, { encoding: 'utf-8' });
   await writeFile(pbxPath, pbxContent, { encoding: 'utf-8' });
 }
+
+export function shouldPodInstall(
+  config: Config,
+  platformName: string,
+): boolean {
+  // Don't run pod install or xcodebuild if not on macOS
+  if (config.cli.os !== OS.Mac && platformName === 'ios') {
+    return false;
+  }
+  return true;
+}

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -21,7 +21,6 @@ import {
   getProjectPlatformDirectory,
 } from '../common';
 import type { CheckFunction } from '../common';
-import { OS } from '../definitions';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
 import { addIOS } from '../ios/add';
@@ -92,16 +91,14 @@ export async function addCommand(
       await doAdd(config, platformName);
       await editPlatforms(config, platformName);
 
-      if (shouldSync(config, platformName)) {
-        if (await pathExists(config.app.webDirAbs)) {
-          sync(config, platformName, false);
-        } else {
-          logger.warn(
-            `${c.success(c.strong('sync'))} could not run--missing ${c.strong(
-              config.app.webDir,
-            )} directory.`,
-          );
-        }
+      if (await pathExists(config.app.webDirAbs)) {
+        sync(config, platformName, false);
+      } else {
+        logger.warn(
+          `${c.success(c.strong('sync'))} could not run--missing ${c.strong(
+            config.app.webDir,
+          )} directory.`,
+        );
       }
 
       printNextSteps(platformName);
@@ -152,14 +149,6 @@ async function editPlatforms(config: Config, platformName: string) {
   } else if (platformName === config.android.name) {
     await editProjectSettingsAndroid(config);
   }
-}
-
-function shouldSync(config: Config, platformName: string) {
-  // Don't sync if we're adding the iOS platform not on a mac
-  if (config.cli.os !== OS.Mac && platformName === 'ios') {
-    return false;
-  }
-  return true;
 }
 
 function webWarning() {


### PR DESCRIPTION
If sync is run on windows or linux, just skip the pod install step instead of erroring

closes https://github.com/ionic-team/capacitor/issues/4717