### PR TITLE
feat(cli): Add hooks to call into npm scripts when capacitor commands run

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -158,6 +158,7 @@ export async function wait(time: number): Promise<void> {
 
 export async function runPlatformHook(
   config: Config,
+  platformName: string,
   platformDir: string,
   hook: string,
 ): Promise<void> {
@@ -179,6 +180,7 @@ export async function runPlatformHook(
         CAPACITOR_ROOT_DIR: config.app.rootDir,
         CAPACITOR_WEB_DIR: config.app.webDirAbs,
         CAPACITOR_CONFIG: JSON.stringify(config.app.extConfig),
+        CAPACITOR_PLATFORM_NAME: platformName,
         ...process.env,
       },
     });

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -40,7 +40,12 @@ export async function addCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:add');
+      await runPlatformHook(
+        config,
+        selectedPlatformName,
+        platformDir,
+        'capacitor:add',
+      );
     } else {
       let msg = `Platform ${c.input(selectedPlatformName)} not found.`;
 

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -40,7 +40,7 @@ export async function addCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, platformDir, 'capacitor:add');
+      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:add');
     } else {
       let msg = `Platform ${c.input(selectedPlatformName)} not found.`;
 

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -28,7 +28,12 @@ export async function copyCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:copy');
+      await runPlatformHook(
+        config,
+        selectedPlatformName,
+        platformDir,
+        'capacitor:copy',
+      );
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }
@@ -58,7 +63,12 @@ export async function copy(
       throw result;
     }
 
-    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:copy:before');
+    await runPlatformHook(
+      config,
+      platformName,
+      config.app.rootDir,
+      'capacitor:copy:before',
+    );
 
     if (platformName === config.ios.name) {
       await copyWebDir(config, await config.ios.webDirAbs);
@@ -77,7 +87,12 @@ export async function copy(
       throw `Platform ${platformName} is not valid.`;
     }
   });
-  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:copy:after');
+  await runPlatformHook(
+    config,
+    platformName,
+    config.app.rootDir,
+    'capacitor:copy:after',
+  );
 }
 
 async function copyCapacitorConfig(config: Config, nativeAbsDir: string) {

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -28,7 +28,7 @@ export async function copyCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, platformDir, 'capacitor:copy');
+      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:copy');
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }
@@ -58,6 +58,8 @@ export async function copy(
       throw result;
     }
 
+    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:copy:before');
+
     if (platformName === config.ios.name) {
       await copyWebDir(config, await config.ios.webDirAbs);
       await copyCapacitorConfig(config, config.ios.nativeTargetDirAbs);
@@ -75,6 +77,7 @@ export async function copy(
       throw `Platform ${platformName} is not valid.`;
     }
   });
+  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:copy:after');
 }
 
 async function copyCapacitorConfig(config: Config, nativeAbsDir: string) {

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -20,7 +20,7 @@ export async function openCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, platformDir, 'capacitor:open');
+      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:open');
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }

--- a/cli/src/tasks/open.ts
+++ b/cli/src/tasks/open.ts
@@ -20,7 +20,12 @@ export async function openCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:open');
+      await runPlatformHook(
+        config,
+        selectedPlatformName,
+        platformDir,
+        'capacitor:open',
+      );
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -32,7 +32,12 @@ export async function runCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:run');
+      await runPlatformHook(
+        config,
+        selectedPlatformName,
+        platformDir,
+        'capacitor:run',
+      );
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -32,7 +32,7 @@ export async function runCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, platformDir, 'capacitor:run');
+      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:run');
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -3,7 +3,7 @@ import {
   checkPackage,
   checkWebDir,
   selectPlatforms,
-  isValidPlatform,
+  isValidPlatform, runPlatformHook
 } from '../common';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
@@ -60,10 +60,14 @@ export async function sync(
   platformName: string,
   deployment: boolean,
 ): Promise<void> {
+  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:sync:before');
+
   try {
     await copy(config, platformName);
   } catch (e) {
     logger.error(e.stack ?? e);
   }
   await update(config, platformName, deployment);
+
+  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:sync:after');
 }

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -3,7 +3,8 @@ import {
   checkPackage,
   checkWebDir,
   selectPlatforms,
-  isValidPlatform, runPlatformHook
+  isValidPlatform,
+  runPlatformHook,
 } from '../common';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
@@ -60,7 +61,12 @@ export async function sync(
   platformName: string,
   deployment: boolean,
 ): Promise<void> {
-  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:sync:before');
+  await runPlatformHook(
+    config,
+    platformName,
+    config.app.rootDir,
+    'capacitor:sync:before',
+  );
 
   try {
     await copy(config, platformName);
@@ -69,5 +75,10 @@ export async function sync(
   }
   await update(config, platformName, deployment);
 
-  await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:sync:after');
+  await runPlatformHook(
+    config,
+    platformName,
+    config.app.rootDir,
+    'capacitor:sync:after',
+  );
 }

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -25,7 +25,12 @@ export async function updateCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:update');
+      await runPlatformHook(
+        config,
+        selectedPlatformName,
+        platformDir,
+        'capacitor:update',
+      );
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }
@@ -79,7 +84,12 @@ export async function update(
   deployment: boolean,
 ): Promise<void> {
   await runTask(c.success(c.strong(`update ${platformName}`)), async () => {
-    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:update:before');
+    await runPlatformHook(
+      config,
+      platformName,
+      config.app.rootDir,
+      'capacitor:update:before',
+    );
 
     if (platformName === config.ios.name) {
       await updateIOS(config, deployment);
@@ -87,6 +97,11 @@ export async function update(
       await updateAndroid(config);
     }
 
-    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:update:after');
+    await runPlatformHook(
+      config,
+      platformName,
+      config.app.rootDir,
+      'capacitor:update:after',
+    );
   });
 }

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -25,7 +25,7 @@ export async function updateCommand(
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
-      await runPlatformHook(config, platformDir, 'capacitor:update');
+      await runPlatformHook(config, selectedPlatformName, platformDir, 'capacitor:update');
     } else {
       logger.error(`Platform ${c.input(selectedPlatformName)} not found.`);
     }
@@ -79,10 +79,14 @@ export async function update(
   deployment: boolean,
 ): Promise<void> {
   await runTask(c.success(c.strong(`update ${platformName}`)), async () => {
+    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:update:before');
+
     if (platformName === config.ios.name) {
       await updateIOS(config, deployment);
     } else if (platformName === config.android.name) {
       await updateAndroid(config);
     }
+
+    await runPlatformHook(config, platformName, config.app.rootDir, 'capacitor:update:after');
   });
 }


### PR DESCRIPTION
As my other PR #4536 is still pending, this would be another way for me to make my android Build work in Appflow.

## Changes in this PR:

- The existing method `runPlatformHook` was extended with a new Environment Variable: **CAPACITOR_PLATFORM_NAME**
- The same Method is used to trigger the following hooks from `package.json:`
    - `capacitor:sync:before`
    - `capacitor:sync:after`
    - `capacitor:copy:before`
    - `capacitor:copy:after`
    - `capacitor:update:before`
    - `capacitor:update:after`

closes #3593