### PR TITLE
fix(cli): correctly show EACCES error on run

### DIFF
--- a/cli/src/util/subprocess.ts
+++ b/cli/src/util/subprocess.ts
@@ -16,7 +16,13 @@ export async function runCommand(
   } catch (e) {
     if (e instanceof SubprocessError) {
       // old behavior of just throwing the stdout/stderr strings
-      throw e.output ? e.output : e.code;
+      throw e.output
+        ? e.output
+        : e.code
+        ? e.code
+        : e.error
+        ? e.error.message
+        : 'Unknown error';
     }
 
     throw e;


### PR DESCRIPTION
I was looking into an issue that provided this sample app https://github.com/RaphaelWoude/ionic-capacitor-example
Running `npx cap run android` on it was showing a strange error message.

It was caused because both `e.output` and `e.code` were undefined.

It's probably a bug on `@ionic/utils-subprocess` not properly building the `SubprocessError` for the EACCES error, but since I know nothing about that package and don't want to break things, I've patched our handler to throw the error message if present or an unknown error.

