### PR TITLE
fix(android): Set WEBVIEW_SERVER_URL before injecting native-bridge

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -48,6 +48,8 @@ class JSInjector {
         return (
             globalJS +
             "\n\n" +
+            localUrlJS +
+            "\n\n" +
             bridgeJS +
             "\n\n" +
             pluginJS +
@@ -56,9 +58,7 @@ class JSInjector {
             "\n\n" +
             cordovaPluginsFileJS +
             "\n\n" +
-            cordovaPluginsJS +
-            "\n\n" +
-            localUrlJS
+            cordovaPluginsJS
         );
     }
 


### PR DESCRIPTION
According to the [docs](https://capacitorjs.com/docs/basics/utilities#convertfilesrc) `Capacitor.convertFileSrc` should return an URL starting with `http://localhost` on android, but instead this part is missing and something like `/_capacitor_file_/path/to/device/file` is returned. `convertFileSrc` gets the host part from `webviewServerUrl`, which is set when native-bridge is loaded:

https://github.com/ionic-team/capacitor/blob/ca4e3b62dba6a40e593a1404ba2fe2b416a4ac14/core/native-bridge.ts#L356-L357

Because of the injection order, `win.WEBVIEW_SERVER_URL` has not been set yet when this line is executed. This PR fixes that by injecting the part that sets `WEBVIEW_SERVER_URL` before native-bridge.