### PR TITLE
feat(cli): Allow custom android apk path and name for cli run command

### DIFF
--- a/cli/src/android/run.ts
+++ b/cli/src/android/run.ts
@@ -29,7 +29,7 @@ export async function runAndroid(
     }),
   );
 
-  const apkName = 'app-debug.apk';
+  const apkName = config.android.buildOutputApkName;
   const apkPath = resolve(config.android.buildOutputDirAbs, apkName);
 
   const nativeRunArgs = ['android', '--app', apkPath, '--target', target.id];

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -227,7 +227,8 @@ async function loadAndroidConfig(
   const assetsDir = `${srcMainDir}/assets`;
   const webDir = `${assetsDir}/public`;
   const resDir = `${srcMainDir}/res`;
-  const buildOutputDir = `${appDir}/build/outputs/apk/debug`;
+  const buildOutputDir = `${appDir}/${extConfig.android?.buildOutputDirCustom ?? 'build/outputs/apk/debug'}`;
+  const buildOutputApkName = extConfig.android?.buildOutputApkName ?? 'app-debug.apk';
   const cordovaPluginsDir = 'capacitor-cordova-android-plugins';
   const studioPath = lazy(() => determineAndroidStudioPath(cliConfig.os));
 
@@ -253,6 +254,7 @@ async function loadAndroidConfig(
     resDirAbs: resolve(platformDirAbs, resDir),
     buildOutputDir,
     buildOutputDirAbs: resolve(platformDirAbs, buildOutputDir),
+    buildOutputApkName,
   };
 }
 

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -193,6 +193,21 @@ export interface CapacitorConfig {
      * @since 3.0.0
      */
     includePlugins?: string[];
+
+    /**
+     * specify a custom relative build path for android targets.
+     *
+     * @since 3.0.x
+     */
+     buildOutputDirCustom?: string;
+
+    /**
+     * specify a custom apk name for android targets.
+     *
+     * @since 3.0.x
+     */
+     buildOutputApkName?: string;
+
   };
 
   ios?: {

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -89,6 +89,7 @@ export interface AndroidConfig extends PlatformConfig {
   readonly resDirAbs: string;
   readonly buildOutputDir: string;
   readonly buildOutputDirAbs: string;
+  readonly buildOutputApkName: string;
 }
 
 export interface IOSConfig extends PlatformConfig {


### PR DESCRIPTION
Add `buildOutputDirCustom` and `buildOutputApkName` in capacitor config to specify a custom APK path for `npx cap run android` command. This is needed in case the android project has flavors, which implies a build path for the apk that will be different than the regular path.

solves https://github.com/ionic-team/capacitor/issues/4740