### PR TITLE
fix(cli): Don't error if there are no scripts

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -164,7 +164,7 @@ export async function runPlatformHook(
 ): Promise<void> {
   const { spawn } = await import('child_process');
   const pkg = await readJSON(join(platformDir, 'package.json'));
-  const cmd = pkg.scripts[hook];
+  const cmd = pkg.scripts?.[hook];
 
   if (!cmd) {
     return;


### PR DESCRIPTION
the hook check was failing if there was no scripts field in package.json