### PR TITLE
chore: Make sync peer deps script use ^

### DIFF
--- a/scripts/sync-peer-dependencies.mjs
+++ b/scripts/sync-peer-dependencies.mjs
@@ -12,7 +12,7 @@ execute(async () => {
   const corePkg = pkgs.find(p => p.name === '@capacitor/core');
   const { major, minor, prerelease } = semver.parse(corePkg.version);
 
-  const range = `~${major}.${minor}.0${
+  const range = `^${major}.${minor}.0${
     prerelease.length > 0 ? `-${prerelease.join('.')}` : ''
   }`;
 


### PR DESCRIPTION
Having ~ in the peer dependencies is making it hard to update on npm 7, make the script that set the version change to ^