### PR TITLE
fix(cli): Don't warn about hideLogs on some commands

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -62,8 +62,6 @@ export async function loadConfig(): Promise<Config> {
     },
   };
 
-  checkExternalConfig(conf);
-
   debug('config: %O', config);
 
   return config;
@@ -446,7 +444,7 @@ const config: CapacitorConfig = ${formatJSObject(extConfig)};
 export default config;\n`;
 }
 
-function checkExternalConfig(config: ExtConfigPairs): void {
+export function checkExternalConfig(config: ExtConfigPairs): void {
   if (
     typeof config.extConfig.hideLogs !== 'undefined' ||
     typeof config.extConfig.android?.hideLogs !== 'undefined' ||

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,7 +1,7 @@
 import program from 'commander';
 
 import c from './colors';
-import { loadConfig, checkExternalConfig } from './config';
+import { checkExternalConfig, loadConfig } from './config';
 import type { Config } from './definitions';
 import { fatal, isFatal } from './errors';
 import { receive } from './ipc';
@@ -28,6 +28,7 @@ export async function run(): Promise<void> {
 
 export function runProgram(config: Config): void {
   program.version(config.cli.package.version);
+
   program
     .command('config', { hidden: true })
     .description(`print evaluated Capacitor config`)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,7 +1,7 @@
 import program from 'commander';
 
 import c from './colors';
-import { loadConfig } from './config';
+import { loadConfig, checkExternalConfig } from './config';
 import type { Config } from './definitions';
 import { fatal, isFatal } from './errors';
 import { receive } from './ipc';
@@ -28,7 +28,6 @@ export async function run(): Promise<void> {
 
 export function runProgram(config: Config): void {
   program.version(config.cli.package.version);
-
   program
     .command('config', { hidden: true })
     .description(`print evaluated Capacitor config`)
@@ -86,6 +85,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async (platform, { deployment }) => {
+          checkExternalConfig(config.app);
           const { syncCommand } = await import('./tasks/sync');
           await syncCommand(config, platform, deployment);
         }),
@@ -106,6 +106,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async (platform, { deployment }) => {
+          checkExternalConfig(config.app);
           const { updateCommand } = await import('./tasks/update');
           await updateCommand(config, platform, deployment);
         }),
@@ -118,6 +119,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async platform => {
+          checkExternalConfig(config.app);
           const { copyCommand } = await import('./tasks/copy');
           await copyCommand(config, platform);
         }),
@@ -137,6 +139,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async (platform, { list, target, sync }) => {
+          checkExternalConfig(config.app);
           const { runCommand } = await import('./tasks/run');
           await runCommand(config, platform, { list, target, sync });
         }),
@@ -161,6 +164,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async platform => {
+          checkExternalConfig(config.app);
           const { addCommand } = await import('./tasks/add');
           await addCommand(config, platform);
         }),
@@ -173,6 +177,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async platform => {
+          checkExternalConfig(config.app);
           const { listCommand } = await import('./tasks/list');
           await listCommand(config, platform);
         }),
@@ -185,6 +190,7 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async platform => {
+          checkExternalConfig(config.app);
           const { doctorCommand } = await import('./tasks/doctor');
           await doctorCommand(config, platform);
         }),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -139,7 +139,6 @@ export function runProgram(config: Config): void {
     .action(
       wrapAction(
         telemetryAction(config, async (platform, { list, target, sync }) => {
-          checkExternalConfig(config.app);
           const { runCommand } = await import('./tasks/run');
           await runCommand(config, platform, { list, target, sync });
         }),


### PR DESCRIPTION
At the moment, if the user has hideLogs configuration option, the CLI will show a warning on every command the CLI runs.
For some commands (version, config, run) it's a problem because the output is used by other tooling (like Ionic CLI) and can't be parsed correctly.

This moves the warning from all commands to just a set of them (add, update, copy, sync, doctor, list)