### PR TITLE
fix(core): handle toJSON() in plugin objects

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -198,6 +198,8 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
             // https://github.com/facebook/react/issues/20030
             case '$$typeof':
               return undefined;
+            case 'toJSON':
+              return () => ({});
             case 'addListener':
               return pluginHeader ? addListenerNative : addListener;
             case 'removeListener':


### PR DESCRIPTION
In Capacitor 2, calling `JSON.stringify(Plugin)` would return an empty object. In Capacitor 3 it tries to call a native toJSON method, which doesn't exist, and throws an error.

This PR handles the toJSON call in core to make it return an empty object as it used to.

closes https://github.com/ionic-team/capacitor/issues/4814
closes https://github.com/ionic-team/capacitor/issues/4820