### PR TITLE
Give option to skip sync on add 

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -59,6 +59,7 @@ export async function loadConfig(): Promise<Config> {
       },
       ...conf,
       bundledWebRuntime: conf.extConfig.bundledWebRuntime ?? false,
+      skipSyncOnAdd: conf.extConfig.skipSyncOnAdd ?? false,
     },
   };
 

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -42,6 +42,17 @@ export interface CapacitorConfig {
   bundledWebRuntime?: boolean;
 
   /**
+   * Whether to skip doing a `cap sync` during `cap add`
+   *
+   * Sometimes you may not wish to perform a `cap sync` when adding a platform. e.g. if you're using
+   * private plugins that may cause the `cap sync` to fail.
+   *
+   * @since 3.0.0
+   * @default false
+   */
+   skipSyncOnAdd?: boolean;
+
+  /**
    * Hide or show the native logs for iOS and Android.
    *
    * @since 2.1.0

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -68,6 +68,7 @@ export interface AppConfig {
    * module imports, set this to "true" and import "capacitor.js" manually.
    */
   readonly bundledWebRuntime: boolean;
+  readonly skipSyncOnAdd: boolean;
 }
 
 export interface AndroidConfig extends PlatformConfig {

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -156,6 +156,14 @@ async function editPlatforms(config: Config, platformName: string) {
   }
 }
 
+function shouldSync(config: Config, platformName: string) {
+  // Don't sync if we're adding the iOS platform not on a mac
+  if (config.app.skipSyncOnAdd || (config.cli.os !== OS.Mac && platformName === 'ios')) {
+    return false;
+  }
+  return true;
+}
+
 function webWarning() {
   logger.error(
     `Not adding platform ${c.strong('web')}.\n` +


### PR DESCRIPTION
The same as #4384 but without merge conflicts.

Here at the BBC, we've used Capacitor 2 to released both Cbeebies Playtime Island and Cbeebies Storytime to the Android Play store, iOS app store, Amazon Appstore and Amazon Kids+ store! We are really pleased with the resulting technology stack and it's help us deliver more for less.

We are really keen to help contribute to open source.

This small change means we can move from Capacitor 2 to Capacitor 3 - so much good stuff we want to use: a bug fix for Android deeplinks; lovely new plugin API! Really want to keep up to date with your awesome changes.

## Change

This adds a new option to Capacitor's config called skipSyncOnAdd. If set to true, it will not do a cap sync during the cap add stage. false by default to retain original behaviour.

## Use Case

When doing a cap add, Capacitor also does a cap sync internally. Configuring add to skip sync allows for manipulation of the files between adding and syncing. This allows for increased automation and flexibility for Capacitor projects.