### PR TITLE
fix(android): Set theme an content view on onCreate

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -22,6 +22,10 @@ public class BridgeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         bridgeBuilder.setInstanceState(savedInstanceState);
+        getApplication().setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
+        setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
+        setTheme(R.style.AppTheme_NoActionBar);
+        setContentView(R.layout.bridge_layout_main);
     }
 
     /**
@@ -63,11 +67,6 @@ public class BridgeActivity extends AppCompatActivity {
     }
 
     private void load() {
-        getApplication().setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
-        setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
-        setTheme(R.style.AppTheme_NoActionBar);
-        setContentView(R.layout.bridge_layout_main);
-
         Logger.debug("Starting BridgeActivity");
 
         bridge = bridgeBuilder.addPlugins(initialPlugins).setConfig(config).create();


### PR DESCRIPTION
In Capacitor 2 the theme and contentView were set in onCreate (because the init method was called on onCreate), now in Capacitor 3 are set on onStart (because init is deprecated), which seems to be too late for the themes to properly work.

closes https://github.com/ionic-team/capacitor/issues/4787