### PR TITLE
(feat) android: adds support in CapacitorPlugin for handleOnActivityResult

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -993,29 +993,23 @@ public class Bridge {
             return cordovaInterface.onActivityResult(requestCode, resultCode, data);
         }
 
-        CapacitorPlugin pluginAnnotation = plugin.getPluginClass().getAnnotation(CapacitorPlugin.class);
-        if (pluginAnnotation == null) {
-            // deprecated, to be removed
-            PluginCall lastCall = plugin.getInstance().getSavedCall();
+        // deprecated, to be removed
+        PluginCall lastCall = plugin.getInstance().getSavedCall();
 
-            // If we don't have a saved last call (because our app was killed and restarted, for example),
-            // Then we should see if we have any saved plugin call information and generate a new,
-            // "dangling" plugin call (a plugin call that doesn't have a corresponding web callback)
-            // and then send that to the plugin
-            if (lastCall == null && pluginCallForLastActivity != null) {
-                plugin.getInstance().saveCall(pluginCallForLastActivity);
-            }
-
-            plugin.getInstance().handleOnActivityResult(requestCode, resultCode, data);
-
-            // Clear the plugin call we may have re-hydrated on app launch
-            pluginCallForLastActivity = null;
-
-            return true;
-        } else {
-            plugin.getInstance().handleOnActivityResult(requestCode, resultCode, data);
-            return true;
+        // If we don't have a saved last call (because our app was killed and restarted, for example),
+        // Then we should see if we have any saved plugin call information and generate a new,
+        // "dangling" plugin call (a plugin call that doesn't have a corresponding web callback)
+        // and then send that to the plugin
+        if (lastCall == null && pluginCallForLastActivity != null) {
+            plugin.getInstance().saveCall(pluginCallForLastActivity);
         }
+
+        plugin.getInstance().handleOnActivityResult(requestCode, resultCode, data);
+
+        // Clear the plugin call we may have re-hydrated on app launch
+        pluginCallForLastActivity = null;
+
+        return true;
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -548,6 +548,15 @@ public class Bridge {
                     }
                 }
             }
+            else {
+                requestCodes = pluginAnnotation.requestCodes();
+
+                for (int rc : requestCodes) {
+                    if (rc == requestCode) {
+                        return handle;
+                    }
+                }
+            }
         }
         return null;
     }
@@ -1004,7 +1013,8 @@ public class Bridge {
 
             return true;
         } else {
-            return false;
+            plugin.getInstance().handleOnActivityResult(requestCode, resultCode, data);
+            return true;
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -547,8 +547,7 @@ public class Bridge {
                         return handle;
                     }
                 }
-            }
-            else {
+            } else {
                 requestCodes = pluginAnnotation.requestCodes();
 
                 for (int rc : requestCodes) {

--- a/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
@@ -1,5 +1,8 @@
 package com.getcapacitor.annotation;
 
+import android.content.Intent;
+import com.getcapacitor.PluginCall;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -16,7 +19,12 @@ public @interface CapacitorPlugin {
 
     /**
      * Request codes this plugin uses and responds to, in order to tie
-     * Android events back the plugin to handle
+     * Android events back the plugin to handle.
+     *
+     * NOTE: This is a legacy option provided to support third party libraries
+     * not currently implementing the new AndroidX Activity Results API. Plugins
+     * without this limitation should use a registered callback with
+     * {@link com.getcapacitor.Plugin#startActivityForResult(PluginCall, Intent, String)}
      */
     int[] requestCodes() default {};
 

--- a/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
@@ -2,7 +2,6 @@ package com.getcapacitor.annotation;
 
 import android.content.Intent;
 import com.getcapacitor.PluginCall;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 

--- a/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/annotation/CapacitorPlugin.java
@@ -15,6 +15,12 @@ public @interface CapacitorPlugin {
     String name() default "";
 
     /**
+     * Request codes this plugin uses and responds to, in order to tie
+     * Android events back the plugin to handle
+     */
+    int[] requestCodes() default {};
+
+    /**
      * Permissions this plugin needs, in order to make permission requests
      * easy if the plugin only needs basic permission prompting
      */

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -200,7 +200,8 @@ const initBridge = (w: any): void => {
     const seen = new Set();
     return JSON.stringify(value, (_k, v) => {
       if (seen.has(v)) {
-        return '...';
+        if (v === null) return null;
+        else return '...';
       }
       if (typeof v === 'object') {
         seen.add(v);


### PR DESCRIPTION
These proposed changes will allow support for using request codes in the `@CapacitorPlugin` annotation while also calling the `handleOnActivityResult` method in the Plugin as in previous versions of Capacitor.