### PR TITLE
fix(android): make openUrl create a new activity

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/App.java
@@ -105,6 +105,7 @@ public class App extends Plugin {
     JSObject ret = new JSObject();
     final PackageManager manager = getContext().getPackageManager();
     Intent launchIntent = new Intent(Intent.ACTION_VIEW);
+    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     launchIntent.setData(Uri.parse(url));
 
     try {


### PR DESCRIPTION
When openUrl opens other webview app it opens the other webview app inside itself. My PR fix this behaviour.