### PR TITLE
refactor(android): Remove Android .N <= buildtools check

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -337,9 +337,8 @@ public class BridgeWebChromeClient extends WebChromeClient {
         // On Android M and lower the VIDEO_CAPTURE_INTENT (e.g.: intent.getData())
         // returns a file:// URI instead of the expected content:// URI.
         // So we disable it for now because it requires a bit more work
-        boolean isVideoCaptureSupported = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N;
         boolean shown = false;
-        if (isVideo && isVideoCaptureSupported) {
+        if (isVideo) {
             shown = showVideoCapturePicker(filePathCallback);
         } else {
             shown = showImageCapturePicker(filePathCallback);


### PR DESCRIPTION
 because Capacitor 3 does not support those versions as they are wildly out of date.
 
 Fixes #4865 