### PR TITLE
fix(android): Don't inject map files into capacitor script

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -86,7 +86,9 @@ public class JSExport {
             String[] content = context.getAssets().list(path);
             if (content.length > 0) {
                 for (String file : content) {
-                    builder.append(getFilesContent(context, path + "/" + file));
+                    if (!file.endsWith(".map")) {
+                        builder.append(getFilesContent(context, path + "/" + file));
+                    }
                 }
             } else {
                 return readFile(context.getAssets(), path);


### PR DESCRIPTION
Capacitor injects cordova plugin files into a script tag in the index.html, but if the plugin provides a .map file, such as sentry plugin, the map is not proper js and breaks the injection, making Capacitor and the plugins to not work.

closes https://github.com/ionic-team/capacitor/issues/4891