### PR TITLE
fix(cli): Put cordova git pod dependencies in Podfile

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -165,6 +165,28 @@ async function generatePodFile(
   const cordovaPlugins = plugins.filter(
     p => getPluginType(p, platform) === PluginType.Cordova,
   );
+  cordovaPlugins.map(async p => {
+    const podspecs = getPlatformElement(p, platform, 'podspec');
+    podspecs.map((podspec: any) => {
+      podspec.pods.map((pPods: any) => {
+        pPods.pod.map((pod: any) => {
+          if (pod.$.git) {
+            let gitRef = '';
+            if (pod.$.tag) {
+              gitRef = `, :tag => '${pod.$.tag}'`;
+            } else if (pod.$.branch) {
+              gitRef = `, :branch => '${pod.$.branch}'`;
+            } else if (pod.$.commit) {
+              gitRef = `, :commit => '${pod.$.commit}'`;
+            }
+            pods.push(
+              `  pod '${pod.$.name}', :git => '${pod.$.git}'${gitRef}\n`,
+            );
+          }
+        });
+      });
+    });
+  });
   const noPodPlugins = cordovaPlugins.filter(filterNoPods);
   if (noPodPlugins.length > 0) {
     pods.push(


### PR DESCRIPTION
Some Cordova plugins are using pod dependencies directly from GitHub, as they don't have a version we just add a dependency in the podspec, but if it's not published in CocoaPods repo Capacitor won't find it.

This PR will read pod entries in plugin.xml and if they are git references it will put them in the users Podfile with the other Capacitor dependencies so it can be found.

closes https://github.com/ionic-team/capacitor/issues/4867