### PR TITLE
chore(cli): Register enterprise-specific platforms

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -341,6 +341,16 @@ export async function isValidCommunityPlatform(
   return (await getKnownCommunityPlatforms()).includes(platform);
 }
 
+export async function getKnownEnterprisePlatforms(): Promise<string[]> {
+  return ['windows'];
+}
+
+export async function isValidEnterprisePlatform(
+  platform: string,
+): Promise<boolean> {
+  return (await getKnownEnterprisePlatforms()).includes(platform);
+}
+
 export async function promptForPlatform(
   platforms: string[],
   promptMessage: string,
@@ -501,6 +511,16 @@ export function resolvePlatform(
 
     if (community) {
       return dirname(community);
+    }
+
+    const enterprise = resolveNode(
+      config.app.rootDir,
+      `@ionic-enterprise/capacitor-${platform}`,
+      'package.json',
+    );
+
+    if (enterprise) {
+      return dirname(enterprise);
     }
   }
 

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -19,6 +19,7 @@ import {
   isValidCommunityPlatform,
   promptForPlatform,
   getProjectPlatformDirectory,
+  isValidEnterprisePlatform,
 } from '../common';
 import type { CheckFunction } from '../common';
 import type { Config } from '../definitions';
@@ -53,6 +54,12 @@ export async function addCommand(
         msg += `\nTry installing ${c.strong(
           `@capacitor-community/${selectedPlatformName}`,
         )} and adding the platform again.`;
+      }
+
+      if (await isValidEnterprisePlatform(selectedPlatformName)) {
+        msg +=
+          `\nThis is an enterprise platform and @ionic-enterprise/capacitor-${selectedPlatformName} is not installed.\n` +
+          `To learn how to use this platform, visit https://ionic.io/docs/${selectedPlatformName}`;
       }
 
       logger.error(msg);


### PR DESCRIPTION
Track `@ionic-enterprise` platforms in the CLI. I _think_ this is all that will be necessary in this repo to integrate with the win stuff now that it's all in a separate platform.