### PR TITLE
fix(android): save activity result launcher calls

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -690,6 +690,10 @@ public class Bridge {
         return pluginCallForLastActivity;
     }
 
+    void setPluginCallForLastActivity(PluginCall pluginCallForLastActivity) {
+        this.pluginCallForLastActivity = pluginCallForLastActivity;
+    }
+
     /**
      * Release a retained call
      * @param call a call to release
@@ -786,13 +790,11 @@ public class Bridge {
         String lastPluginId = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_ID_KEY);
         String lastPluginCallMethod = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_CALL_METHOD_NAME_KEY);
         String lastOptionsJson = savedInstanceState.getString(BUNDLE_PLUGIN_CALL_OPTIONS_SAVED_KEY);
-
         if (lastPluginId != null) {
             // If we have JSON blob saved, create a new plugin call with the original options
             if (lastOptionsJson != null) {
                 try {
                     JSObject options = new JSObject(lastOptionsJson);
-
                     pluginCallForLastActivity =
                         new PluginCall(msgHandler, lastPluginId, PluginCall.CALLBACK_ID_DANGLING, lastPluginCallMethod, options);
                 } catch (JSONException ex) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -790,6 +790,7 @@ public class Bridge {
         String lastPluginId = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_ID_KEY);
         String lastPluginCallMethod = savedInstanceState.getString(BUNDLE_LAST_PLUGIN_CALL_METHOD_NAME_KEY);
         String lastOptionsJson = savedInstanceState.getString(BUNDLE_PLUGIN_CALL_OPTIONS_SAVED_KEY);
+
         if (lastPluginId != null) {
             // If we have JSON blob saved, create a new plugin call with the original options
             if (lastOptionsJson != null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -796,6 +796,7 @@ public class Bridge {
             if (lastOptionsJson != null) {
                 try {
                     JSObject options = new JSObject(lastOptionsJson);
+
                     pluginCallForLastActivity =
                         new PluginCall(msgHandler, lastPluginId, PluginCall.CALLBACK_ID_DANGLING, lastPluginCallMethod, options);
                 } catch (JSONException ex) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -894,15 +894,14 @@ public class Plugin {
      * @return a new {@link Bundle} with fields set from the options of the last saved {@link PluginCall}
      */
     protected Bundle saveInstanceState() {
-        PluginCall savedCall = bridge.getSavedCall(lastPluginCallId);;
-
+        PluginCall savedCall = bridge.getSavedCall(lastPluginCallId);
         if (savedCall == null) {
             return null;
         }
 
         Bundle ret = new Bundle();
-        JSObject callData = savedCall.getData();
 
+        JSObject callData = savedCall.getData();
         if (callData != null) {
             ret.putString(BUNDLE_PERSISTED_OPTIONS_JSON_KEY, callData.toString());
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -175,7 +175,7 @@ public class Plugin {
             // return when null since call was rejected in getLauncherOrReject
             return;
         }
-
+        bridge.setPluginCallForLastActivity(call);
         lastPluginCallId = call.getCallbackId();
         bridge.saveCall(call);
         activityResultLauncher.launch(intent);
@@ -894,7 +894,7 @@ public class Plugin {
      * @return a new {@link Bundle} with fields set from the options of the last saved {@link PluginCall}
      */
     protected Bundle saveInstanceState() {
-        PluginCall savedCall = getSavedCall();
+        PluginCall savedCall = bridge.getSavedCall(lastPluginCallId);;
 
         if (savedCall == null) {
             return null;

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -895,6 +895,7 @@ public class Plugin {
      */
     protected Bundle saveInstanceState() {
         PluginCall savedCall = bridge.getSavedCall(lastPluginCallId);
+
         if (savedCall == null) {
             return null;
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -901,8 +901,8 @@ public class Plugin {
         }
 
         Bundle ret = new Bundle();
-
         JSObject callData = savedCall.getData();
+
         if (callData != null) {
             ret.putString(BUNDLE_PERSISTED_OPTIONS_JSON_KEY, callData.toString());
         }


### PR DESCRIPTION
When using activity result launchers, the call is not being saved, so if the app dies, the `appRestoredResult` event won't be fired

Also `getSavedCall()` is deprecated and not returning the proper value, switched to `bridge.getSavedCall(lastPluginCallId);`

closes https://github.com/ionic-team/capacitor/issues/5003