### PR TITLE
fix: Add SalesforceMobileSDK-CordovaPlugin to iOS incompatible list

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -493,7 +493,11 @@ export function getIncompatibleCordovaPlugins(platform: string): string[] {
     'cordova-support-google-services',
   ];
   if (platform === 'ios') {
-    pluginList.push('cordova-plugin-statusbar', '@ionic-enterprise/statusbar');
+    pluginList.push(
+      'cordova-plugin-statusbar',
+      '@ionic-enterprise/statusbar',
+      'SalesforceMobileSDK-CordovaPlugin',
+    );
   }
   if (platform === 'android') {
     pluginList.push('cordova-plugin-compat');


### PR DESCRIPTION
see https://github.com/ionic-team/capacitor/issues/4949