### PR TITLE
fix(cli): await sync on add to avoid telemetry hang

### DIFF
--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -104,7 +104,7 @@ export async function addCommand(
       await editPlatforms(config, platformName);
 
       if (await pathExists(config.app.webDirAbs)) {
-        sync(config, platformName, false);
+        await sync(config, platformName, false);
       } else {
         logger.warn(
           `${c.success(c.strong('sync'))} could not run--missing ${c.strong(


### PR DESCRIPTION
telemetry hangs on add command because it prompts while sync is being run and the message get lost in the sync logs, await for sync so telemetry is prompt after sync finish