### PR TITLE
Fix multiple wildcard processing

### DIFF
--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.swift
@@ -52,7 +52,7 @@ extension InstanceConfiguration {
             return false
         }
         // remove any wildcard segments
-        for wildcard in patternComponents.enumerated().filter({ $0.element == "*" }) {
+        for wildcard in patternComponents.enumerated().reversed().filter({ $0.element == "*" }) {
             hostComponents.remove(at: wildcard.offset)
             patternComponents.remove(at: wildcard.offset)
         }

--- a/ios/Capacitor/CapacitorTests/ConfigurationTests.swift
+++ b/ios/Capacitor/CapacitorTests/ConfigurationTests.swift
@@ -153,6 +153,8 @@ class ConfigurationTests: XCTestCase {
         XCTAssertTrue(configuration.shouldAllowNavigation(to: "test.capacitorjs.com"))
         XCTAssertTrue(configuration.shouldAllowNavigation(to: "192.168.0.1"))
         XCTAssertTrue(configuration.shouldAllowNavigation(to: "subdomain.test.ionicframework.com"))
+        XCTAssertTrue(configuration.shouldAllowNavigation(to: "wildcard1.wildcard2.example.com"))
+        XCTAssertFalse(configuration.shouldAllowNavigation(to: "wildcard1.example.com"))
         XCTAssertFalse(configuration.shouldAllowNavigation(to: "google.com"))
         XCTAssertFalse(configuration.shouldAllowNavigation(to: "192.168.0.2"))
         XCTAssertFalse(configuration.shouldAllowNavigation(to: "ionicframework.com"))

--- a/ios/Capacitor/TestsHostApp/configurations/server.json
+++ b/ios/Capacitor/TestsHostApp/configurations/server.json
@@ -11,7 +11,7 @@
   "loggingBehavior": "production",
   "server": {
   	"iosScheme": "override",
-  	"allowNavigation": ["*.capacitorjs.com", "ionic.io", "192.168.0.1", "subdomain.*.ionicframework.com"],
+  	"allowNavigation": ["*.capacitorjs.com", "ionic.io", "192.168.0.1", "subdomain.*.ionicframework.com", "*.*.example.com"],
   	"hostname": "myhost",
   	"url": "http://192.168.100.1:2057"
   },


### PR DESCRIPTION
At the moment allowed hosts with multiple wildcards are processed in-correctly
For example
Pattern: `*.*.example.com`
Host: `test1.test2.example.com`

Iteration 1 wildcard.offset is 0
Pattern becomes: `*.example.com`
Host becomes: `test2.example.com`

Iteration 2 wildcard.offset is 1
Pattern becomes: `*.com`
Host becomes:  `test2.com`

The correct outcomes would be
Pattern: `example.com`
Host: `example.com`

Reversing the direction of iteration fixes this, as removing the item at index 1 first is safe and doesn't effect the next step of removing the item at index 0.