### PR TITLE
Reset regexp

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -135,13 +135,15 @@ async function findAndroidPluginClassesInPlugin(
   const entries = await Promise.all(
     srcFiles.map(async (srcFile): Promise<PluginsJsonEntry | undefined> => {
       const srcFileContents = await readFile(srcFile, { encoding: 'utf-8' });
+      classRegex.lastIndex = 0;
       const classMatch = classRegex.exec(srcFileContents);
 
       if (classMatch) {
         const className = classMatch[1];
 
         debug('Searching %O for package by %O regex', srcFile, packageRegex);
-
+        
+        packageRegex.lastIndex = 0;
         const packageMatch = packageRegex.exec(
           srcFileContents.substring(0, classMatch.index),
         );


### PR DESCRIPTION
Reset multiline regexp for multiple ussage.

Currently `update` cannot detect multiple plugins.