### PR TITLE
fix(cli): create only static pod if needed

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -505,6 +505,15 @@ export function getIncompatibleCordovaPlugins(platform: string): string[] {
   return pluginList;
 }
 
+export function needsStaticPod(plugin: Plugin): boolean {
+  const pluginList = [
+    'phonegap-plugin-push',
+    '@havesource/cordova-plugin-push',
+    'cordova-plugin-firebasex',
+  ];
+  return pluginList.includes(plugin.id);
+}
+
 export async function getCordovaPreferences(config: Config): Promise<any> {
   const configXml = join(config.app.rootDir, 'config.xml');
   let cordova: any = {};


### PR DESCRIPTION
At the moment we are creating a static pod for all plugins that have pod dependencies because some of them required to be static (specially push related).

This PR put plugins with pod dependencies in the regular plugins pod, and only create the static pod for the ones that are known to require a static pod (phonegap-plugin-push, @havesource/cordova-plugin-push and cordova-plugin-firebasex at the moment, we will need to add more to the list in the future as users start to report them.




closes https://github.com/ionic-team/capacitor/issues/4958