### PR TITLE
fix(android): Support cordova-android 10

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
@@ -1,7 +1,8 @@
 package com.getcapacitor.cordova;
 
-import android.app.Activity;
 import android.util.Pair;
+import androidx.appcompat.app.AppCompatActivity;
+
 import java.util.concurrent.Executors;
 import org.apache.cordova.CordovaInterfaceImpl;
 import org.apache.cordova.CordovaPlugin;
@@ -9,7 +10,7 @@ import org.json.JSONException;
 
 public class MockCordovaInterfaceImpl extends CordovaInterfaceImpl {
 
-    public MockCordovaInterfaceImpl(Activity activity) {
+    public MockCordovaInterfaceImpl(AppCompatActivity activity) {
         super(activity, Executors.newCachedThreadPool());
     }
 


### PR DESCRIPTION
cordova-android 10 changed the CordovaInterfaceImpl constructor to use AppCompatActivity instead of Activity, since our activity is already AppCompatActivity we can change the MockCordovaInterfaceImpl constructor without breaking support of older cordova-android versions.