### PR TITLE
fix(android): Avoid ConcurrentModificationException on notifyListeners

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -30,7 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.json.JSONException;
 
 /**


### PR DESCRIPTION
Despite we are not modifying the list, for some reason it causes ConcurrentModificationException, so change notifyListeners to iterate over a copy of the listeners list.

closes https://github.com/ionic-team/capacitor/issues/4797