### PR TITLE
feat(cli): Allow to configure access origin on cordova config.xml

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -249,15 +249,18 @@ export async function autoGenerateConfig(
     }
   });
 
-  let allowedHostsString: string[] = [];
-  if (config.app.extConfig?.cordova?.allowedHosts) {
-    allowedHostsString = await Promise.all(
-        Object.entries(config.app.extConfig.cordova.allowedHosts).map(
-            async (host): Promise<string> => {
-              return `<access origin="${host}" />`;
-            },
-        ),
+  let accessOriginString: string[] = [];
+  if (config.app.extConfig?.cordova?.accessOrigins) {
+    accessOriginString = await Promise.all(
+      config.app.extConfig.cordova.accessOrigins.map(
+        async (host): Promise<string> => {
+          return `
+  <access origin="${host}" />`;
+        },
+      ),
     );
+  } else {
+    accessOriginString.push(`<access origin="*" />`);
   }
   const pluginEntriesString: string[] = await Promise.all(
     pluginEntries.map(async (item): Promise<string> => {
@@ -278,7 +281,7 @@ export async function autoGenerateConfig(
   }
   const content = `<?xml version='1.0' encoding='utf-8'?>
 <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  ${allowedHostsString.join('')}
+  ${accessOriginString.join('')}
   ${pluginEntriesString.join('')}
   ${pluginPreferencesString.join('')}
 </widget>`;

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -427,9 +427,15 @@ export interface CapacitorConfig {
 
   cordova?: {
     /**
-     * Configure allowed hosts for Cordova plugins.
+     * Populates <access> tags in the config.xml with the origin set to
+     * the values entered here.
+     * If not provided, a single <access origin="*" /> tag gets included.
+     * It only has effect on a few Cordova plugins that respect the whitelist.
+     *
+     * @since 3.3.0
      */
-    allowedHosts?: string[]
+    accessOrigins?: string[];
+
     /**
      * Configure Cordova preferences.
      *


### PR DESCRIPTION
Hey,

i reecognized that the access origins where hard coded here, but i wanted to restrict the access origins because we are using `cordova-plugin-inappbrowser` which therefore can load any url.