### PR TITLE
fix(ios): Avoid CDVScreenOrientationDelegate umbrella header warning

### DIFF
--- a/ios/Capacitor/Capacitor/Capacitor.modulemap
+++ b/ios/Capacitor/Capacitor/Capacitor.modulemap
@@ -1,7 +1,8 @@
 framework module Capacitor {
   umbrella header "Capacitor.h"
   exclude header "CAPBridgedJSTypes.h"
-  
+  exclude header "CAPBridgeViewController+CDVScreenOrientationDelegate.h"
+
   export *
   module * { export * }
 }


### PR DESCRIPTION
Exclude the CDVScreenOrientationDelegate header from swift to avoid the warning