### PR TITLE
fix(core): avoid crash on logging circular objects

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -167,21 +167,6 @@ const nativeBridge = (function (exports) {
             win.Capacitor = cap;
             win.Ionic.WebView = IonicWebView;
         };
-        const safeStringify = (value) => {
-            const seen = new Set();
-            return JSON.stringify(value, (_k, v) => {
-                if (seen.has(v)) {
-                    if (v === null)
-                        return null;
-                    else
-                        return '...';
-                }
-                if (typeof v === 'object') {
-                    seen.add(v);
-                }
-                return v;
-            });
-        };
         const initLogger = (win, cap) => {
             const BRIDGED_CONSOLE_METHODS = [
                 'debug',
@@ -248,7 +233,7 @@ const nativeBridge = (function (exports) {
             const serializeConsoleMessage = (msg) => {
                 if (typeof msg === 'object') {
                     try {
-                        msg = safeStringify(msg);
+                        msg = JSON.stringify(msg);
                     }
                     catch (e) {
                         // ignore
@@ -317,7 +302,7 @@ const nativeBridge = (function (exports) {
                 postToNative = data => {
                     var _a;
                     try {
-                        win.androidBridge.postMessage(safeStringify(data));
+                        win.androidBridge.postMessage(JSON.stringify(data));
                     }
                     catch (e) {
                         (_a = win === null || win === void 0 ? void 0 : win.console) === null || _a === void 0 ? void 0 : _a.error(e);
@@ -348,7 +333,7 @@ const nativeBridge = (function (exports) {
                             url: url,
                             line: lineNo,
                             col: columnNo,
-                            errorObject: safeStringify(err),
+                            errorObject: JSON.stringify(err),
                         },
                     };
                     if (err !== null) {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -196,20 +196,6 @@ const initBridge = (w: any): void => {
     win.Ionic.WebView = IonicWebView;
   };
 
-  const safeStringify = (value: any): string => {
-    const seen = new Set();
-    return JSON.stringify(value, (_k, v) => {
-      if (seen.has(v)) {
-        if (v === null) return null;
-        else return '...';
-      }
-      if (typeof v === 'object') {
-        seen.add(v);
-      }
-      return v;
-    });
-  };
-
   const initLogger = (win: WindowCapacitor, cap: CapacitorInstance) => {
     const BRIDGED_CONSOLE_METHODS: (keyof Console)[] = [
       'debug',
@@ -291,7 +277,7 @@ const initBridge = (w: any): void => {
     const serializeConsoleMessage = (msg: any): string => {
       if (typeof msg === 'object') {
         try {
-          msg = safeStringify(msg);
+          msg = JSON.stringify(msg);
         } catch (e) {
           // ignore
         }
@@ -378,7 +364,7 @@ const initBridge = (w: any): void => {
       // android platform
       postToNative = data => {
         try {
-          win.androidBridge.postMessage(safeStringify(data));
+          win.androidBridge.postMessage(JSON.stringify(data));
         } catch (e) {
           win?.console?.error(e);
         }
@@ -408,7 +394,7 @@ const initBridge = (w: any): void => {
             url: url,
             line: lineNo,
             col: columnNo,
-            errorObject: safeStringify(err),
+            errorObject: JSON.stringify(err),
           },
         };
 

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -167,21 +167,6 @@ const nativeBridge = (function (exports) {
             win.Capacitor = cap;
             win.Ionic.WebView = IonicWebView;
         };
-        const safeStringify = (value) => {
-            const seen = new Set();
-            return JSON.stringify(value, (_k, v) => {
-                if (seen.has(v)) {
-                    if (v === null)
-                        return null;
-                    else
-                        return '...';
-                }
-                if (typeof v === 'object') {
-                    seen.add(v);
-                }
-                return v;
-            });
-        };
         const initLogger = (win, cap) => {
             const BRIDGED_CONSOLE_METHODS = [
                 'debug',
@@ -248,7 +233,7 @@ const nativeBridge = (function (exports) {
             const serializeConsoleMessage = (msg) => {
                 if (typeof msg === 'object') {
                     try {
-                        msg = safeStringify(msg);
+                        msg = JSON.stringify(msg);
                     }
                     catch (e) {
                         // ignore
@@ -317,7 +302,7 @@ const nativeBridge = (function (exports) {
                 postToNative = data => {
                     var _a;
                     try {
-                        win.androidBridge.postMessage(safeStringify(data));
+                        win.androidBridge.postMessage(JSON.stringify(data));
                     }
                     catch (e) {
                         (_a = win === null || win === void 0 ? void 0 : win.console) === null || _a === void 0 ? void 0 : _a.error(e);
@@ -348,7 +333,7 @@ const nativeBridge = (function (exports) {
                             url: url,
                             line: lineNo,
                             col: columnNo,
-                            errorObject: safeStringify(err),
+                            errorObject: JSON.stringify(err),
                         },
                     };
                     if (err !== null) {


### PR DESCRIPTION
`safeStringify` function was added to fix https://github.com/ionic-team/capacitor/issues/4506, but didn't do it properly as there is a [follow up PR](https://github.com/ionic-team/capacitor/pull/4573) that is still unmerged. And also causes a crash on iOS apps if you try to log an object with circular references, see [this issue](https://github.com/ionic-team/capacitor/issues/5178) for more details.

Since [we changed](https://github.com/ionic-team/capacitor/pull/5073) the way the console overwrite works on iOS, looks like the `safeStringify` is not even needed, so this PR removes it. After merged, circular objects that error on `JSON.stringify()` will go back to printing `[object Object]` as they did before the `safeStringify` PR was merged instead of crashing the app.


closes https://github.com/ionic-team/capacitor/issues/5178
closes https://github.com/ionic-team/capacitor/pull/4573