### PR TITLE
fix(android): Integer conversion of compileSdk/minSdk/targetSdk

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -42,10 +42,10 @@ if (System.getenv("CAP_PUBLISH") == "true") {
 
 android {
     namespace "com.getcapacitor.android"
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion as Integer : 33
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion as Integer : 22
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion as Integer : 33
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -19,8 +19,8 @@ android {
     namespace "capacitor.cordova.android.plugins"
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion as Integer : 22
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion as Integer : 33
         versionCode 1
         versionName "1.0"
     }
@@ -46,7 +46,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
     // SUB-PROJECT DEPENDENCIES START
-    
+
     // SUB-PROJECT DEPENDENCIES END
 }
 


### PR DESCRIPTION
Gradle properties are always parsed as strings from `gradle.properties`. While Gradle Groovy can utilize the `ext` Gradle plugin directly, Gradle Kotlin DSL projects have to specify properties in `gradle.properties`. Convert those to integers as required by Android Gradle Plugin (AGP). This won't affect projects that still use Gradle Groovy.

Resolves #5194