### PR TITLE
feat(ios): Add new iOS15 media capture permission delegate

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -47,7 +47,8 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
         bridge?.reset()
     }
     
-    // This delegates media capture permission requests to the app and also remembers the user’s decision.
+    // TODO: remove once Xcode 12 support is dropped
+    #if compiler(>=5.5)
     @available(iOS 15, *)
     func webView(
         _ webView: WKWebView,

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -46,6 +46,18 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
         // Reset the bridge on each navigation
         bridge?.reset()
     }
+    
+    // This delegates media capture permission requests to the app and also remembers the user’s decision.
+    @available(iOS 15, *)
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.grant)
+    }
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         // post a notification for any listeners

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -59,6 +59,7 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
     ) {
         decisionHandler(.grant)
     }
+    #endif
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         // post a notification for any listeners


### PR DESCRIPTION
Delegates media capture permissions to the app and remembers the user's decision for iOS15.

[https://developer.apple.com/documentation/webkit/wkuidelegate/3763087-webview#discussion](https://developer.apple.com/documentation/webkit/wkuidelegate/3763087-webview#discussion)

Thanks and credits to @7freaks-otte who found the solution. :)
[https://forum.ionicframework.com/t/prevent-for-reprompting-webrtc-webview-permissions-ios15/215240/2?u=samydoesit](https://forum.ionicframework.com/t/prevent-for-reprompting-webrtc-webview-permissions-ios15/215240/2?u=samydoesit)

You can test these changes using my getusermedia demo case when build on Xcode13 -> https://github.com/samydoesit/capacitor-getusermedia-test