### PR TITLE
feat(ios): Add Bundler support

### DIFF
--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -110,7 +110,7 @@ export interface IOSConfig extends PlatformConfig {
   readonly cordovaPluginsDir: string;
   readonly cordovaPluginsDirAbs: string;
   readonly minVersion: string;
-  readonly podPath: string;
+  readonly podPath: Promise<string>;
   readonly scheme: string;
   readonly webDir: Promise<string>;
   readonly webDirAbs: Promise<string>;

--- a/cli/src/ios/doctor.ts
+++ b/cli/src/ios/doctor.ts
@@ -4,7 +4,7 @@ import { fatal } from '../errors';
 import { logSuccess } from '../log';
 import { isInstalled } from '../util/subprocess';
 
-import { checkCocoaPods } from './common';
+import { checkBundler, checkCocoaPods } from './common';
 
 export async function doctorIOS(config: Config): Promise<void> {
   // DOCTOR ideas for iOS:
@@ -20,7 +20,7 @@ export async function doctorIOS(config: Config): Promise<void> {
   // check if www folder is empty (index.html does not exist)
   try {
     await check([
-      () => checkCocoaPods(config),
+      () => checkBundler(config) || checkCocoaPods(config),
       () => checkWebDir(config),
       checkXcode,
     ]);

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -27,8 +27,9 @@ import { fatal, isFatal } from '../errors';
 import { addIOS } from '../ios/add';
 import {
   editProjectSettingsIOS,
-  checkIOSPackage,
+  checkBundler,
   checkCocoaPods,
+  checkIOSPackage,
 } from '../ios/common';
 import { logger, logSuccess, output } from '../log';
 
@@ -140,7 +141,10 @@ function printNextSteps(platformName: string) {
 
 function addChecks(config: Config, platformName: string): CheckFunction[] {
   if (platformName === config.ios.name) {
-    return [() => checkIOSPackage(config), () => checkCocoaPods(config)];
+    return [
+      () => checkIOSPackage(config),
+      () => checkBundler(config) || checkCocoaPods(config),
+    ];
   } else if (platformName === config.android.name) {
     return [() => checkAndroidPackage(config)];
   } else if (platformName === config.web.name) {

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -12,7 +12,7 @@ import {
 import type { CheckFunction } from '../common';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
-import { checkCocoaPods } from '../ios/common';
+import { checkBundler, checkCocoaPods } from '../ios/common';
 import { updateIOS } from '../ios/update';
 import { logger } from '../log';
 import { allSerial } from '../util/promise';
@@ -66,7 +66,7 @@ export function updateChecks(
   const checks: CheckFunction[] = [];
   for (const platformName of platforms) {
     if (platformName === config.ios.name) {
-      checks.push(() => checkCocoaPods(config));
+      checks.push(() => checkBundler(config) || checkCocoaPods(config));
     } else if (platformName === config.android.name) {
       continue;
     } else if (platformName === config.web.name) {


### PR DESCRIPTION
Bundler isolates RubGems dependencies from the host operating system and creates a consistent environment. Gem dependencies can be pinned to exact versions by using a `Gemfile`. CocoaPods is modeled after Bundler.

This ensures all developers and CI machines use the same CocoaPods version. It's also conveniently used to install CocoaPods plugins, e.g. `cocoapods-art`, or additional iOS development tools, such as `xcpretty`.

Multiple cases are now handled correctly. If a `Gemfile` is found:

 - At the Git repository root, in case of a multi-app project
 - At or below the app directory, in case of a single-app project

Then:

 1. Use Bundler to install RubyGems, including CocoaPods:
   1. If Bundler is outdated, update first by executing
      `gem install bundler`
   2. If RubyGems bundle is outdated, update first by executing
      `bundle install`
   3. Install CocoaPods and other gems by executing
      `bundle exec pod install`

Or, just like before, if:

 4. CocoaPods is available on PATH, execute `pod install`
 5. Neither global CocoaPods nor Gemfile are found
    Skip CocoaPods install entirely

Implements #5177

# Remarks
The following screenshots demonstrate the CLI output and actions that now occur (in reverse order but with increasing coolness):

### Case 5
<img width="629" alt="Screenshot 2021-11-04 at 10 25 04" src="https://user-images.githubusercontent.com/115275/140293680-4a7dd203-2e9f-4a4c-9947-8bf35c050460.png">

### Case 4
<img width="604" alt="Screenshot 2021-11-04 at 10 25 53" src="https://user-images.githubusercontent.com/115275/140293722-1e3659d1-9ce2-44de-b007-01797d798ea8.png">

### Case 1.2 and 1.3
<img width="518" alt="Screenshot 2021-11-04 at 10 24 32" src="https://user-images.githubusercontent.com/115275/140293794-5879f8ed-03bb-41cf-a9ec-534455ffaab6.png">

### Case 1.1 and 1.3
<img width="530" alt="Screenshot 2021-11-04 at 09 40 26" src="https://user-images.githubusercontent.com/115275/140293862-8ab8c0db-e472-4b8d-8af2-c6a61e4de69d.png">

