### PR TITLE
fix(cli): sync gradle from android folder

### DIFF
--- a/cli/src/android/add.ts
+++ b/cli/src/android/add.ts
@@ -18,13 +18,11 @@ export async function addAndroid(config: Config): Promise<void> {
       );
     },
   );
-
-  await runTask('Syncing Gradle', async () => {
-    return createLocalProperties(config.android.platformDirAbs);
-  });
 }
 
-async function createLocalProperties(platformDir: string) {
+export async function createLocalProperties(
+  platformDir: string,
+): Promise<void> {
   const defaultAndroidPath = join(homedir(), 'Library/Android/sdk');
   if (await pathExists(defaultAndroidPath)) {
     const localSettings = `
@@ -57,5 +55,7 @@ sdk.dir=${defaultAndroidPath}
 }
 
 async function gradleSync(platformDir: string) {
-  await runCommand(`${platformDir}/gradlew`, []);
+  await runCommand(`./gradlew`, [], {
+    cwd: platformDir,
+  });
 }

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -105,9 +105,11 @@ export async function addCommand(
 
       if (await pathExists(config.app.webDirAbs)) {
         await sync(config, platformName, false);
-        await runTask('Syncing Gradle', async () => {
-          return createLocalProperties(config.android.platformDirAbs);
-        });
+        if (platformName === config.android.name) {
+          await runTask('Syncing Gradle', async () => {
+            return createLocalProperties(config.android.platformDirAbs);
+          });
+        }
       } else {
         logger.warn(
           `${c.success(c.strong('sync'))} could not run--missing ${c.strong(

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -1,7 +1,7 @@
 import { pathExists } from '@ionic/utils-fs';
 import { prettyPath } from '@ionic/utils-terminal';
 
-import { addAndroid } from '../android/add';
+import { addAndroid, createLocalProperties } from '../android/add';
 import {
   editProjectSettingsAndroid,
   checkAndroidPackage,
@@ -105,6 +105,9 @@ export async function addCommand(
 
       if (await pathExists(config.app.webDirAbs)) {
         await sync(config, platformName, false);
+        await runTask('Syncing Gradle', async () => {
+          return createLocalProperties(config.android.platformDirAbs);
+        });
       } else {
         logger.warn(
           `${c.success(c.strong('sync'))} could not run--missing ${c.strong(


### PR DESCRIPTION
At the moment we are running gradle sync from the root folder, which no longer works on Gradle 7
Change the command to run from android folder
And as it needs some generated gradle files to exist, that are generated by capacitor sync, move the gradle sync after capacitor sync.

closes https://github.com/ionic-team/capacitor/issues/5229