### PR TITLE
fix(android): Allow web geolocation if only COARSE_LOCATION is granted

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -7,6 +7,7 @@ import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.view.View;
@@ -280,7 +281,13 @@ public class BridgeWebChromeClient extends WebChromeClient {
                     if (isGranted) {
                         callback.invoke(origin, true, false);
                     } else {
-                        callback.invoke(origin, false, false);
+                        final String[] coarsePermission = { Manifest.permission.ACCESS_COARSE_LOCATION };
+                        // TODO replace with Build.VERSION_CODES.S once we target SDK 31
+                        if (Build.VERSION.SDK_INT >= 31 && PermissionHelper.hasPermissions(bridge.getContext(), coarsePermission)) {
+                            callback.invoke(origin, true, false);
+                        }  else {
+                            callback.invoke(origin, false, false);
+                        }
                     }
                 };
             permissionLauncher.launch(geoPermissions);

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -285,7 +285,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
                         // TODO replace with Build.VERSION_CODES.S once we target SDK 31
                         if (Build.VERSION.SDK_INT >= 31 && PermissionHelper.hasPermissions(bridge.getContext(), coarsePermission)) {
                             callback.invoke(origin, true, false);
-                        }  else {
+                        } else {
                             callback.invoke(origin, false, false);
                         }
                     }


### PR DESCRIPTION
On Android 12 accepting only ACCESS_COARSE_LOCATION permission should be considered as granted, at the moment we consider it rejected as ACCESS_FINE_LOCATION is rejected.

Sadly web geolocation still doesn't get the coordinates after this change if the user chooses the "Approximate" option, it times out instead of getting a permission error message.

I've [reported it to chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1269362).

