### PR TITLE
fix(android): restrict android run command to configured flavour

### DIFF
--- a/cli/src/android/run.ts
+++ b/cli/src/android/run.ts
@@ -19,7 +19,8 @@ export async function runAndroid(
     selectedTarget,
   );
 
-  const gradleArgs = ['assembleDebug'];
+  const arg = `assemble${config.android?.flavor || ''}Debug`;
+  const gradleArgs = [arg];
 
   debug('Invoking ./gradlew with args: %O', gradleArgs);
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -227,6 +227,7 @@ async function loadAndroidConfig(
   const resDir = `${srcMainDir}/res`;
   let apkPath = `${appDir}/build/outputs/apk/`;
   let flavorPrefix = '';
+  const flavor = extConfig.android?.flavor || '';
   if (extConfig.android?.flavor) {
     apkPath = `${apkPath}/${extConfig.android?.flavor}`;
     flavorPrefix = `-${extConfig.android?.flavor}`;
@@ -259,6 +260,7 @@ async function loadAndroidConfig(
     apkName,
     buildOutputDir,
     buildOutputDirAbs: resolve(platformDirAbs, buildOutputDir),
+    flavor
   };
 }
 

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -260,7 +260,7 @@ async function loadAndroidConfig(
     apkName,
     buildOutputDir,
     buildOutputDirAbs: resolve(platformDirAbs, buildOutputDir),
-    flavor
+    flavor,
   };
 }
 

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -90,6 +90,7 @@ export interface AndroidConfig extends PlatformConfig {
   readonly buildOutputDir: string;
   readonly buildOutputDirAbs: string;
   readonly apkName: string;
+  readonly flavor: string;
 }
 
 export interface IOSConfig extends PlatformConfig {


### PR DESCRIPTION
Solves request: https://github.com/ionic-team/capacitor/issues/5252

Live reload should now work with any `productFlavor`.
