### PR TITLE
fix(cli): Add onesignal-cordova-plugin to the static list again

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -519,7 +519,11 @@ export function getIncompatibleCordovaPlugins(platform: string): string[] {
 }
 
 export function needsStaticPod(plugin: Plugin, config: Config): boolean {
-  let pluginList = ['phonegap-plugin-push', '@batch.com/cordova-plugin'];
+  let pluginList = [
+    'phonegap-plugin-push',
+    '@batch.com/cordova-plugin',
+    'onesignal-cordova-plugin',
+  ];
   if (config.app.extConfig?.cordova?.staticPlugins) {
     pluginList = pluginList.concat(
       config.app.extConfig?.cordova?.staticPlugins,


### PR DESCRIPTION
version 3 is automatically put in the static list because it uses the pods tag with `use-frameworks="true"`, but version 2 is not, so add it to the hardcoded list.
