### PR TITLE
#5266 Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x ./android/gradlew
       - name: Grant execute permission for publishing script


### PR DESCRIPTION
#5266 Update the GitHub action setup-java from adopt to zulu of the OpenJDK.

The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/