### PR TITLE
fix(ios): Present js alert on top of the presented VC

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -174,7 +174,7 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
             return
         }
 
-        if let presentedVC = viewController.presentedViewController {
+        if let presentedVC = viewController.presentedViewController, !presentedVC.isBeingDismissed {
             viewController = presentedVC
         }
 

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -169,8 +169,13 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
     // MARK: - WKUIDelegate
 
     public func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
-        guard let viewController = bridge?.viewController else {
+        guard var viewController = bridge?.viewController else {
+            completionHandler()
             return
+        }
+
+        if let presentedVC = viewController.presentedViewController {
+            viewController = presentedVC
         }
 
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)


### PR DESCRIPTION
related to https://github.com/ionic-team/capacitor-plugins/issues/713

If a js alert is used while the capacitor view controller is presenting another view (in 713 it's a native alert), the app crash because the js alert is not being presented

This PR changes the behavior to detect if another view controller is being presented and present the js alert on top of that view controller instead of in the capacitor view controller.

Not sure if this could be considered a breaking change since at the moment the js alert is not being presented. An alternative would be to not try to present the js alert if capacitor view controller is presenting another view controller, that should also avoid the crash.