### PR TITLE
WIP: resolve to accept other data types

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -79,6 +79,21 @@ public class MessageHandler {
     }
 
     public void sendResponseMessage(PluginCall call, PluginResult successResult, PluginResult errorResult) {
+        _sendResponseMessage(call, successResult, errorResult);
+    }
+
+    public void sendResponseMessage(PluginCall call, JSObject successResult, PluginResult errorResult) {
+        _sendResponseMessage(call, successResult, errorResult);
+    }
+
+    public void sendResponseMessage(PluginCall call, boolean successResult, PluginResult errorResult) {
+        _sendResponseMessage(call, successResult, errorResult);
+    }
+
+    public void sendResponseMessage(PluginCall call, String successResult, PluginResult errorResult) {
+        _sendResponseMessage(call, successResult, errorResult);
+    }
+    void _sendResponseMessage(PluginCall call, Object successResult, PluginResult errorResult) {
         try {
             PluginResult data = new PluginResult();
             data.put("save", call.isKeptAlive());

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -70,8 +70,7 @@ public class PluginCall {
     }
 
     public void resolve(JSObject data) {
-        PluginResult result = new PluginResult(data);
-        this.msgHandler.sendResponseMessage(this, result, null);
+        this.msgHandler.sendResponseMessage(this, data, null);
     }
 
     public void resolve() {


### PR DESCRIPTION
This is a first attempt to allow `PluginCall.resolve` to accept other data types than `JSObject`.

From what I can see in the native-bridge, it should already handle any value coming "fromNative":

https://github.com/ionic-team/capacitor/blob/main/android/capacitor/src/main/assets/native-bridge.js#L420

So, simply overriding `sendReponseMessage` to accept other values than `PluginResult` seems like it should be enough.

This of course needs further development, but I would like some feedback from the maintainers on whether this approach is reasonable (and so I would proceed) or if this is just a bad idea.#5267 

This should partially fix #1132