### PR TITLE
feat(ios): Add new iOS 15 Motion permission delegate

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -59,10 +59,7 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
     ) {
         decisionHandler(.grant)
     }
-    #endif
 
-    // TODO: remove once Xcode 12 support is dropped
-    #if compiler(>=5.5)
     @available(iOS 15, *)
     func webView(_ webView: WKWebView,
     requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -47,6 +47,17 @@ internal class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDel
         bridge?.reset()
     }
 
+    // TODO: remove once Xcode 12 support is dropped
+    #if compiler(>=5.5)
+    @available(iOS 15, *)
+    func webView(_ webView: WKWebView,
+    requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+         initiatedByFrame frame: WKFrameInfo,
+          decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        decisionHandler(.grant)
+    }
+    #endif
+
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         // post a notification for any listeners
         NotificationCenter.default.post(name: .capacitorDecidePolicyForNavigationAction, object: navigationAction)


### PR DESCRIPTION
Like https://github.com/ionic-team/capacitor/pull/5196 but for Motion permission.

Requesting motion permission have multiple issues (wrong titles, wrong origin, doesn't remember it was granted and keeps asking every time), with this delegate present and Motion usage description the WKWebView will not present the motion permission prompt, instead will just grant the permission directly.