### PR TITLE
fix(cli): Escape appName from invalid characters on add

### DIFF
--- a/cli/src/android/common.ts
+++ b/cli/src/android/common.ts
@@ -71,7 +71,11 @@ export async function editProjectSettingsAndroid(
   config: Config,
 ): Promise<void> {
   const appId = config.app.appId;
-  const appName = config.app.appName;
+  const appName = config.app.appName
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'");
 
   const manifestPath = resolve(
     config.android.srcMainDirAbs,
@@ -140,10 +144,7 @@ export async function editProjectSettingsAndroid(
   const stringsPath = resolve(config.android.resDirAbs, 'values/strings.xml');
   let stringsContent = await readFile(stringsPath, { encoding: 'utf-8' });
   stringsContent = stringsContent.replace(/com.getcapacitor.myapp/g, appId);
-  stringsContent = stringsContent.replace(
-    /My App/g,
-    appName.replace(/'/g, `\\'`),
-  );
+  stringsContent = stringsContent.replace(/My App/g, appName);
 
   await writeFile(stringsPath, stringsContent);
 }

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -64,7 +64,10 @@ export async function resolvePlugin(plugin: Plugin): Promise<Plugin | null> {
  */
 export async function editProjectSettingsIOS(config: Config): Promise<void> {
   const appId = config.app.appId;
-  const appName = config.app.appName;
+  const appName = config.app.appName
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 
   const pbxPath = `${config.ios.nativeXcodeProjDirAbs}/project.pbxproj`;
   const plistPath = resolve(config.ios.nativeTargetDirAbs, 'Info.plist');


### PR DESCRIPTION
on iOS `&`, `<` and `>` can't be used on the app name unless escaped
on Android `&`, `<`, `'` and `"`can't be used on the app name unless escaped
we were already handling `'` on Android, but this PR handles the rest of invalid characters for both iOS and Android

closes https://github.com/ionic-team/capacitor/issues/5322