### PR TITLE
fix(android): Prevent crash if activity killed on input file

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -70,7 +70,11 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityLauncher =
             bridge.registerForActivityResult(
                 new ActivityResultContracts.StartActivityForResult(),
-                result -> activityListener.onActivityResult(result)
+                result -> {
+                    if (activityListener != null) {
+                        activityListener.onActivityResult(result);
+                    }
+                }
             );
     }
 


### PR DESCRIPTION
If the app is killed while using an input file is being used, when the user chooses a file the app crashes because the `activityListener` is null as the app was killed.
The file will be lost, but the app won't crash.

Can be tested by setting the "Don't keep activities" option in the developer menu.

closes https://github.com/ionic-team/capacitor/issues/5284