### PR TITLE
feat(android): Allow overriding web chrome client

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -107,6 +107,7 @@ public class Bridge {
     private CordovaWebView cordovaWebView;
     private CordovaPreferences preferences;
     private BridgeWebViewClient webViewClient;
+    private BridgeWebChromeClient webChromeClient;
     private App app;
 
     // Our MessageHandler for sending and receiving data to the WebView
@@ -182,6 +183,7 @@ public class Bridge {
         this.fragment = fragment;
         this.webView = webView;
         this.webViewClient = new BridgeWebViewClient(this);
+        this.webChromeClient = new BridgeWebChromeClient(this);
         this.initialPlugins = initialPlugins;
         this.cordovaInterface = cordovaInterface;
         this.preferences = preferences;
@@ -277,7 +279,7 @@ public class Bridge {
 
         Logger.debug("Loading app at " + appUrl);
 
-        webView.setWebChromeClient(new BridgeWebChromeClient(this));
+        webView.setWebChromeClient(this.webChromeClient);
         webView.setWebViewClient(this.webViewClient);
 
         if (!isDeployDisabled() && !isNewBinary()) {
@@ -1317,6 +1319,14 @@ public class Bridge {
     public void setWebViewClient(BridgeWebViewClient client) {
         this.webViewClient = client;
         webView.setWebViewClient(client);
+    }
+
+    public BridgeWebChromeClient getWebChromeClient() {
+        return this.webChromeClient;
+    }
+
+    public void setWebChromeClient(BridgeWebChromeClient client) {
+        this.webChromeClient = client;
     }
 
     List<WebViewListener> getWebViewListeners() {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -279,6 +279,7 @@ public class Bridge {
 
         Logger.debug("Loading app at " + appUrl);
 
+        this.webChromeClient.register();
         webView.setWebChromeClient(this.webChromeClient);
         webView.setWebViewClient(this.webViewClient);
 

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -60,7 +60,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     /**
      * Calls registerForActivityResult on the bridge. You can only call this once.
      */
-    public register() {
+    public void register() {
         ActivityResultCallback<Map<String, Boolean>> permissionCallback = (Map<String, Boolean> isGranted) -> {
             if (permissionListener != null) {
                 boolean granted = true;

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -55,7 +55,12 @@ public class BridgeWebChromeClient extends WebChromeClient {
 
     public BridgeWebChromeClient(Bridge bridge) {
         this.bridge = bridge;
+    }
 
+    /**
+     * Calls registerForActivityResult on the bridge. You can only call this once.
+     */
+    public register() {
         ActivityResultCallback<Map<String, Boolean>> permissionCallback = (Map<String, Boolean> isGranted) -> {
             if (permissionListener != null) {
                 boolean granted = true;


### PR DESCRIPTION
Currently it is not possible to override the WebChromeClient of the Bridge. With this change, it becomes possible to override the web chrome client in plugins (the same way this currently is possible for the web view client). This is required if you want to add more custom behaviour in a Capacitor app and need to have a reference to the WebChromeClient.