### PR TITLE
null-check before removing a listener

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -166,7 +166,9 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
         });
 
         if (prop === 'addListener') {
-          (p as any).remove = async () => remove();
+          (p as any).remove = async () => {
+            remove && remove();
+          };
         }
 
         return p;


### PR DESCRIPTION
`remove` would be undefined on calling `PluginListenerHandle#remove` before capacitor initialized. This causes `remove is not a function.` error.

This PR adds null-check before calling `PluginListenerHandle#remove` to avoid the error.