### PR TITLE
fix(android): Support for Android 12 / API 31

### DIFF
--- a/android-template/app/src/main/AndroidManifest.xml
+++ b/android-template/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
             android:name="com.getcapacitor.myapp.MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Activities, providers and services have to set the `exported` flag
explicitly to either 'true' or 'false' when the component has an intent
filter.

See https://developer.androi.com/guide/topics/manifest/activity-element#exported