### PR TITLE
fix(android): prevent input file crash if accept has .

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -414,7 +414,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         if (fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }
-        if (fileChooserParams.getAcceptTypes().length > 1) {
+        if (fileChooserParams.getAcceptTypes().length > 1 || intent.getType().startsWith(".")) {
             String[] validTypes = getValidTypes(fileChooserParams.getAcceptTypes());
             intent.putExtra(Intent.EXTRA_MIME_TYPES, validTypes);
             if (intent.getType().startsWith(".")) {


### PR DESCRIPTION
we were handing it for when the accept has multiple values with . but not a single value with . 

there is a bug on the intent android creates that puts an invalid type when the accept has a . on it, it's really an android bug, but we workaround it by setting the type to one of the validated ones.

closes https://github.com/ionic-team/capacitor/issues/5358