### PR TITLE
fix(android): Add appcompat to capacitor-cordova-android-plugins module

### DIFF
--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -1,4 +1,5 @@
 ext {
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.2.0'
     cordovaAndroidVersion = project.hasProperty('cordovaAndroidVersion') ? rootProject.ext.cordovaAndroidVersion : '7.0.0'
 }
 
@@ -42,6 +43,7 @@ repositories {
 
 dependencies {
     implementation fileTree(dir: 'src/main/libs', include: ['*.jar'])
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
     // SUB-PROJECT DEPENDENCIES START
     


### PR DESCRIPTION
cordova-android 10 uses appcompat as activity, so if a Capacitor app uses cordova-android 10 and any plugin calls `cordova.getActivity()` or similar method it fails to build because it nows returns an AppCompatActivity instead of a regular Activity.
Adding the appcompat dependency to the plugins module fixes the issue.
