### PR TITLE
Remove all references to jcenter()

### DIFF
--- a/android-template/build.gradle
+++ b/android-template/build.gradle
@@ -1,10 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -20,7 +19,6 @@ apply from: "variables.gradle"
 allprojects {
     repositories {
         google()
-        jcenter()
     }
 }
 

--- a/android-template/build.gradle
+++ b/android-template/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-
+    
     repositories {
         google()
     }

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -54,7 +54,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
     // SUB-PROJECT DEPENDENCIES START
-
+    
     // SUB-PROJECT DEPENDENCIES END
 }
 

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -6,7 +6,6 @@ ext {
 buildscript {
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -34,7 +33,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
     flatDir{
         dirs 'src/main/libs', 'libs'
@@ -46,7 +44,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "org.apache.cordova:framework:$cordovaAndroidVersion"
     // SUB-PROJECT DEPENDENCIES START
-    
+
     // SUB-PROJECT DEPENDENCIES END
 }
 


### PR DESCRIPTION
All references to should be removed, because they will be non functional in 2 weeks (on 01.02.2022) so I guess better break it now and then fix it an get a release out, than wait it out and in 2 weeks all builds are failing.

https://blog.gradle.org/jcenter-shutdown

Yes, this will probably break the build, but it will break in 2 weeks on it's own anyway, so probably better break the dev branch now and fix it, than break every production build in 2 weeks without a fix.