### PR TITLE
chore: Move jcenter dependency under mavenCentral

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -54,8 +54,8 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
+    jcenter()
 }
 
 dependencies {

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -34,8 +34,8 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
+    jcenter()
     flatDir{
         dirs 'src/main/libs', 'libs'
     }


### PR DESCRIPTION
We have jcenter on top of mavenCentral in a few places, but considering recent connectivity problems on jcenter I think it's best to move mavenCentral up