### PR TITLE
Service worker injection workaround

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -327,10 +327,14 @@ public class WebViewLocalServer {
                 String url = request.getUrl().toString();
                 Map<String, String> headers = request.getRequestHeaders();
                 boolean isHtmlText = false;
-                for (Map.Entry<String, String> header : headers.entrySet()) {
-                    if (header.getKey().equalsIgnoreCase("Accept") && header.getValue().toLowerCase().contains("text/html")) {
-                        isHtmlText = true;
-                        break;
+                if (url.contains(".html")) {
+                    isHtmlText = true;
+                } else {
+                    for (Map.Entry<String, String> header : headers.entrySet()) {
+                        if (header.getKey().equalsIgnoreCase("Accept") && header.getValue().toLowerCase().contains("text/html")) {
+                            isHtmlText = true;
+                            break;
+                        }
                     }
                 }
                 if (isHtmlText) {


### PR DESCRIPTION
Requests from service workers use "Accept: */*" so checking for "text/html" in Accept header can't work. As a workaround, add check if proxy request URL contains ".html" and treat it as HTML if it does. This is the same as what handleLocalRequest does to identify HTML files.

See https://github.com/ionic-team/capacitor/issues/5278