### PR TITLE
Replace the jcenter repository in all build.gradle files with mavenCentral

### DIFF
--- a/android-template/build.gradle
+++ b/android-template/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -20,7 +20,7 @@ apply from: "variables.gradle"
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -55,7 +55,6 @@ android {
 repositories {
     google()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -6,7 +6,7 @@ ext {
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -35,7 +35,6 @@ android {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     flatDir{
         dirs 'src/main/libs', 'libs'
     }


### PR DESCRIPTION
Building android projects currently is encompassed with a deprecation warning in the console about jcenter:
`WARNING:: Please remove usages of 'jcenter()' Maven repository from your build scripts and migrate your build to other Maven repositories.` (also see [JCenter end of service](http://developer.android.com/r/tools/jcenter-end-of-service)).

This PR replaces the references to `jcenter()` with `mavenCentral()`.