### PR TITLE
fix(cli): avoid srcFiles is not iterable on kotlinNeededCheck

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -392,10 +392,12 @@ async function kotlinNeededCheck(config: Config, cordovaPlugins: Plugin[]) {
   ) {
     for (const plugin of cordovaPlugins) {
       const androidPlatform = getPluginPlatform(plugin, platform);
-      const srcFiles = androidPlatform['source-file'];
-      for (const srcFile of srcFiles) {
-        if (/^.*\.kt$/.test(srcFile['$'].src)) {
-          return true;
+      const sourceFiles = androidPlatform['source-file'];
+      if (sourceFiles) {
+        for (const srcFile of sourceFiles) {
+          if (/^.*\.kt$/.test(srcFile['$'].src)) {
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
if the cordova plugin doesn't have any source files (i.e. es6-promise-plugin)