### PR TITLE
fix: android darkmode

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -188,6 +188,12 @@ public class BridgeActivity extends AppCompatActivity {
         this.bridge.onDetachedFromWindow();
     }
 
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        this.setDarkMode();
+    }
+
     /**
      * Handles permission request results.
      *

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -151,7 +151,6 @@ public class BridgeActivity extends AppCompatActivity {
         super.onResume();
         bridge.getApp().fireStatusChange(true);
         this.bridge.onResume();
-        this.setDarkMode();
         Logger.debug("App resumed");
     }
 
@@ -186,12 +185,6 @@ public class BridgeActivity extends AppCompatActivity {
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         this.bridge.onDetachedFromWindow();
-    }
-
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-        this.setDarkMode();
     }
 
     /**
@@ -262,7 +255,7 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-
+        this.setDarkMode();
         if (this.bridge == null) {
             return;
         }


### PR DESCRIPTION
Related to discussion here : https://github.com/ionic-team/capacitor/discussions/1978
Dark mode don't work in android.
i added the fix recommended in this comment https://github.com/ionic-team/capacitor/discussions/1978#discussioncomment-708439

i added it to `onConfigurationChanged ` as well for quick menu darkmode change.
As @robingenz showed me the way https://github.com/ionic-team/capacitor/discussions/1978#discussioncomment-2295205