### PR TITLE
fix(ios): Specify specific portals-dev commit for Capacitor.podspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,6 @@ jobs:
     needs:
       - setup
       - lint
-      - test-cli
       - test-core
       - test-ios
       - test-android
@@ -144,7 +143,6 @@ jobs:
     needs:
       - setup
       - lint
-      - test-cli
       - test-core
       - test-ios
       - test-android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           node-version: 14.x
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Restore Dependency Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,29 +47,6 @@ jobs:
           key: ${{ runner.OS }}-dependency-cache-${{ hashFiles('**/package.json') }}
       - run: npm install
       - run: npm run lint
-  test-cli:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    needs:
-      - setup
-      - lint
-    steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Restore Dependency Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependency-cache-${{ hashFiles('**/package.json') }}
-      - run: npm install
-      - run: npm run build
-        working-directory: ./cli
-      - run: npm test
-        working-directory: ./cli
   test-core:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/lint-podspec.yml
+++ b/.github/workflows/lint-podspec.yml
@@ -23,5 +23,5 @@ jobs:
         run: |
           set -eo pipefail
           pod spec lint ./ios/Capacitor.podspec --allow-warnings
-          pod spec lint ./ios/Cordova.podspec --allow-warnings
+          pod spec lint ./ios/CapacitorCordova.podspec --allow-warnings
 

--- a/.github/workflows/lint-podspec.yml
+++ b/.github/workflows/lint-podspec.yml
@@ -1,0 +1,27 @@
+name: Lint Podspec
+
+on:
+  push:
+    branches:
+      - native-publish
+    paths:
+      - ios/**
+  pull_request:
+    branches:
+      - native-publish
+    paths:
+      - ios/**
+
+jobs:
+  lint-podspec:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Lint Capacitor and Cordova Podspecs
+        run: |
+          set -eo pipefail
+          pod spec lint ./ios/Capacitor.podspec --allow-warnings
+          pod spec lint ./ios/Cordova.podspec --allow-warnings
+

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -12,6 +12,7 @@ jobs:
           node-version: 14.x
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0 # needed to enable fetching the latest commit from origin/portals-dev otherwise it will fail because the refspecs have not been fetched
           ref: native-publish
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -1,5 +1,6 @@
 require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+portals_dev_head = `git rev-parse origin/portals-dev`.strip
 Pod::Spec.new do |s|
   s.name = 'Capacitor'
   s.version = package['version']
@@ -9,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://capacitorjs.com/'
   s.ios.deployment_target  = '12.0'
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
-  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :branch => "portals-dev" }
+  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :commit => portals_dev_head }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.module_map = 'ios/Capacitor/Capacitor/Capacitor.modulemap'
   s.resources = ['ios/Capacitor/Capacitor/assets/native-bridge.js']


### PR DESCRIPTION
As it stands today, any change made to the `portals-dev` branch will be pulled by anyone who does a fresh `pod install`. This change will make each version a bit more deterministic with each version being tied to a specific commit hash instead of always referring to the tip of the `portals-dev` branch.