### PR TITLE
fix(android/Bridge): `server.url` overrides `localUrl`

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -216,7 +216,6 @@ public class Bridge {
                 URL appUrlObject = new URL(appUrlConfig);
                 authorities.add(appUrlObject.getAuthority());
             } catch (Exception ex) {}
-            localUrl = appUrlConfig;
             appUrl = appUrlConfig;
         } else {
             appUrl = localUrl;

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -187,7 +187,7 @@ public class WebViewLocalServer {
     }
 
     private boolean isMainUrl(Uri loadingUrl) {
-        return (bridge.getServerUrl() == null && loadingUrl.getHost().equalsIgnoreCase(bridge.getHost()));
+        return loadingUrl.getHost().equalsIgnoreCase(bridge.getHost());
     }
 
     private boolean isAllowedUrl(Uri loadingUrl) {


### PR DESCRIPTION
I suspect that `localUrl` in the Android `Bridge` should not get overridden with the value of `server.url` from `capacitor.config.json`. AFAICT it's also not getting overridden in the iOS implementation.

Unless I am mistaken, setting `server.url` breaks the following code:

https://github.com/ionic-team/capacitor/blob/33e9b342790ddedfb654c589ffde18b101d4cd98/android/capacitor/src/main/java/com/getcapacitor/Bridge.java#L776

https://github.com/ionic-team/capacitor/blob/1451ec850a9ef73267a032638e73f1fc440647b9/core/native-bridge.ts#L341-L345

https://github.com/ionic-team/capacitor/blob/1451ec850a9ef73267a032638e73f1fc440647b9/core/native-bridge.ts#L29-L48

---

Relatedly, it appears as if the logic in [`WebViewLocalServer#shouldInterceptRequest:L176`](https://github.com/ionic-team/capacitor/blob/33e9b342790ddedfb654c589ffde18b101d4cd98/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java#L176) has a bug as well. When the `server.url` is set in the `capacitor.config.json`, it's impossible to navigate to `localUrl` (`"http://localhost/"`), while the same _is_ possible for iOS.

https://github.com/ionic-team/capacitor/blob/33e9b342790ddedfb654c589ffde18b101d4cd98/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java#L157-L195

I think the correct fix is removing `bridge.getServerUrl() == null` in `isMainUrl`:

https://github.com/ionic-team/capacitor/blob/33e9b342790ddedfb654c589ffde18b101d4cd98/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java#L189-L191