### PR TITLE
chore(ci): Remove unused action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependency-cache-${{ hashFiles('**/package.json') }}
-      - name: Get Package Version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-        with:
-          path: core/
   lint:
     runs-on: macos-latest
     timeout-minutes: 30


### PR DESCRIPTION
I don't see the action result being used anywhere and it's failing because it changed the branch from master to main, so better remove it as it's not being used