### PR TITLE
fix(android): move initialFocus on webview into config

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -447,7 +447,10 @@ public class Bridge {
             Logger.debug("WebView background color not applied");
         }
 
-        webView.requestFocusFromTouch();
+        if (config.isInitialFocus()) {
+            webView.requestFocusFromTouch();
+        }
+
         WebView.setWebContentsDebuggingEnabled(this.config.isWebContentsDebuggingEnabled());
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -40,6 +40,7 @@ public class CapConfig {
     private boolean captureInput = false;
     private boolean webContentsDebuggingEnabled = false;
     private boolean loggingEnabled = true;
+    private boolean initialFocus = true;
 
     // Embedded
     private String startPath;
@@ -116,6 +117,7 @@ public class CapConfig {
         this.captureInput = builder.captureInput;
         this.webContentsDebuggingEnabled = builder.webContentsDebuggingEnabled;
         this.loggingEnabled = builder.loggingEnabled;
+        this.initialFocus = builder.initialFocus;
 
         // Embedded
         this.startPath = builder.startPath;
@@ -187,6 +189,8 @@ public class CapConfig {
                 loggingEnabled = isDebug;
         }
 
+        initialFocus = JSONUtils.getBoolean(configJSON, "android.initialFocus", initialFocus);
+
         // Plugins
         pluginsConfiguration = deserializePluginsConfig(JSONUtils.getObject(configJSON, "plugins"));
     }
@@ -241,6 +245,10 @@ public class CapConfig {
 
     public boolean isLoggingEnabled() {
         return loggingEnabled;
+    }
+
+    public boolean isInitialFocus() {
+        return initialFocus;
     }
 
     public PluginConfig getPluginConfiguration(String pluginId) {
@@ -398,6 +406,7 @@ public class CapConfig {
         private boolean captureInput = false;
         private Boolean webContentsDebuggingEnabled = null;
         private boolean loggingEnabled = true;
+        private boolean initialFocus = false;
 
         // Embedded
         private String startPath = null;
@@ -494,6 +503,11 @@ public class CapConfig {
 
         public Builder setLoggingEnabled(boolean enabled) {
             this.loggingEnabled = enabled;
+            return this;
+        }
+
+        public Builder setInitialFocus(boolean focus) {
+            this.initialFocus = focus;
             return this;
         }
     }


### PR DESCRIPTION
Moves the initial focus action of the webview on Android into a config flag which is `true` by default for Capacitor proper, and `false` by default for programmatic setup (i.e: Portals) where we may not want the webview to have the initial focus.

This line causes some problems on Portals apps by causing the webview to be selected when a page loads, and this may not be desired. With it being a config property, a developer could still enable it at any time if preferred. Portals apps will be configured to set this property to false by default.