### PR TITLE
fix(ios): Use `URL(fileURLWithPath:)` instead of `URL(string:)`

### DIFF
--- a/ios/Capacitor/Capacitor/Router.swift
+++ b/ios/Capacitor/Capacitor/Router.swift
@@ -15,10 +15,10 @@ public protocol Router {
 // swiftlint:disable:next type_name
 internal struct _Router: Router {
     func route(for path: String) -> String {
-        let pathUrl = URL(string: path)
+        let pathUrl = URL(fileURLWithPath: path)
        
-        // if the pathUrl is null, then it is an invalid url (meaning it is empty or just plain invalid) then we want to route to /index.html
-        if pathUrl?.pathExtension.isEmpty ?? true {
+        // If there's no path extension it also means the path is empty or a SPA route
+        if pathUrl.pathExtension.isEmpty {
             return "/index.html"
         }
         

--- a/ios/Capacitor/CapacitorTests/RouterTests.swift
+++ b/ios/Capacitor/CapacitorTests/RouterTests.swift
@@ -12,10 +12,6 @@ import XCTest
 class RouterTests: XCTestCase {
     let router = _Router()
     
-    func testRouterReturnsIndexWhenProvidedInvalidPath() {
-        XCTAssertEqual(router.route(for: "/skull.💀"), "/index.html")
-    }
-    
     func testRouterReturnsIndexWhenProvidedEmptyPath() {
         XCTAssertEqual(router.route(for: ""), "/index.html")
     }

--- a/ios/Capacitor/CapacitorTests/RouterTests.swift
+++ b/ios/Capacitor/CapacitorTests/RouterTests.swift
@@ -23,4 +23,8 @@ class RouterTests: XCTestCase {
     func testRouterReturnsPathWhenProvidedValidPath() {
         XCTAssertEqual(router.route(for: "/a/valid/path.ext"), "/a/valid/path.ext")
     }
+    
+    func testRouterReturnsPathWhenProvidedValidPathWithExtensionAndSpaces() {
+        XCTAssertEqual(router.route(for: "/a/valid/file path.ext"), "/a/valid/file path.ext")
+    }
 }


### PR DESCRIPTION
closes #5592