### PR TITLE
chore(android): Fix deprecation warnings on cordova compat code

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/CapacitorCordovaCookieManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/CapacitorCordovaCookieManager.java
@@ -12,7 +12,6 @@ class CapacitorCordovaCookieManager implements ICordovaCookieManager {
     public CapacitorCordovaCookieManager(WebView webview) {
         webView = webview;
         cookieManager = CookieManager.getInstance();
-        CookieManager.setAcceptFileSchemeCookies(true);
         cookieManager.setAcceptThirdPartyCookies(webView, true);
     }
 
@@ -33,7 +32,7 @@ class CapacitorCordovaCookieManager implements ICordovaCookieManager {
 
     @Override
     public void clearCookies() {
-        cookieManager.removeAllCookie();
+        cookieManager.removeAllCookies(null);
     }
 
     @Override

--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -112,6 +112,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
     @Override
     public void clearCache() {}
 
+    @Deprecated
     @Override
     public void clearCache(boolean b) {}
 
@@ -181,6 +182,7 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
         this.pluginManager.onDestroy();
     }
 
+    @Deprecated
     @Override
     public void sendJavascript(String statememt) {
         nativeToJsMessageQueue.addJavaScript(statememt);
@@ -198,14 +200,17 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
     @Override
     public void showWebPage(String url, boolean openExternal, boolean clearHistory, Map<String, Object> params) {}
 
+    @Deprecated
     @Override
     public boolean isCustomViewShowing() {
         return false;
     }
 
+    @Deprecated
     @Override
     public void showCustomView(View view, WebChromeClient.CustomViewCallback callback) {}
 
+    @Deprecated
     @Override
     public void hideCustomView() {}
 


### PR DESCRIPTION
Add @Deprecated to the cordova methods that also have the @Deprecated 
replace `cookieManager.removeAllCookie();` with `cookieManager.removeAllCookies(null);` as it's the non deprecated alternative.
Remove `CookieManager.setAcceptFileSchemeCookies(true);` since Capacitor doesn't load from file urls it's not needed and it's deprecated.