### PR TITLE
chore(android): Add deprecated annotation to shouldOverrideUrlLoading

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -28,6 +28,7 @@ public class BridgeWebViewClient extends WebViewClient {
         return bridge.launchIntent(url);
     }
 
+    @Deprecated
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         return bridge.launchIntent(Uri.parse(url));


### PR DESCRIPTION
`public boolean shouldOverrideUrlLoading(WebView view, String url)` is deprecated on Android 24+, add @Deprecated annotation to silence the warning.