### PR TITLE
feat: promise with callback plugin method

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -405,7 +405,23 @@ const nativeBridge = (function (exports) {
                                 return err;
                             }, new cap.Exception(''));
                         }
-                        if (typeof storedCall.callback === 'function') {
+                        if (typeof storedCall.callback === 'function' &&
+                            typeof storedCall.resolve === 'function') {
+                            // promise with callback
+                            if (result.success) {
+                                if (result.save) {
+                                    storedCall.callback(result.data);
+                                }
+                                else {
+                                    storedCall.resolve(result.data);
+                                }
+                            }
+                            else {
+                                storedCall.reject(null, result.error);
+                                callbacks.delete(result.callbackId);
+                            }
+                        }
+                        else if (typeof storedCall.callback === 'function') {
                             // callback
                             if (result.success) {
                                 storedCall.callback(result.data);
@@ -451,9 +467,10 @@ const nativeBridge = (function (exports) {
                 }
                 return cap.toNative(pluginName, methodName, options, { callback });
             };
-            cap.nativePromise = (pluginName, methodName, options) => {
+            cap.nativePromise = (pluginName, methodName, options, callback) => {
                 return new Promise((resolve, reject) => {
                     cap.toNative(pluginName, methodName, options, {
+                        callback: callback,
                         resolve: resolve,
                         reject: reject,
                     });

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -145,7 +145,7 @@ public class JSExport {
         args.add(CATCHALL_OPTIONS_PARAM);
 
         String returnType = method.getReturnType();
-        if (returnType.equals(PluginMethod.RETURN_CALLBACK)) {
+        if (!returnType.equals(PluginMethod.RETURN_NONE)) {
             args.add(CALLBACK_PARAM);
         }
 
@@ -166,7 +166,15 @@ public class JSExport {
                 break;
             case PluginMethod.RETURN_PROMISE:
                 lines.add(
-                    "return w.Capacitor.nativePromise('" + plugin.getId() + "', '" + method.getName() + "', " + CATCHALL_OPTIONS_PARAM + ")"
+                    "return w.Capacitor.nativePromise('" +
+                    plugin.getId() +
+                    "', '" +
+                    method.getName() +
+                    "', " +
+                    CATCHALL_OPTIONS_PARAM +
+                    ", " +
+                    CALLBACK_PARAM +
+                    ")"
                 );
                 break;
             case PluginMethod.RETURN_CALLBACK:

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -481,7 +481,22 @@ const initBridge = (w: any): void => {
             }, new cap.Exception(''));
           }
 
-          if (typeof storedCall.callback === 'function') {
+          if (
+            typeof storedCall.callback === 'function' &&
+            typeof storedCall.resolve === 'function'
+          ) {
+            // promise with callback
+            if (result.success) {
+              if (result.save) {
+                storedCall.callback(result.data);
+              } else {
+                storedCall.resolve(result.data);
+              }
+            } else {
+              storedCall.reject(null, result.error);
+              callbacks.delete(result.callbackId);
+            }
+          } else if (typeof storedCall.callback === 'function') {
             // callback
             if (result.success) {
               storedCall.callback(result.data);
@@ -531,9 +546,10 @@ const initBridge = (w: any): void => {
       return cap.toNative(pluginName, methodName, options, { callback });
     };
 
-    cap.nativePromise = (pluginName, methodName, options) => {
+    cap.nativePromise = (pluginName, methodName, options, callback) => {
       return new Promise((resolve, reject) => {
         cap.toNative(pluginName, methodName, options, {
+          callback: callback,
           resolve: resolve,
           reject: reject,
         });

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -1,4 +1,4 @@
-import type {
+﻿import type {
   CapacitorGlobal,
   PluginCallback,
   PluginResultData,
@@ -74,6 +74,7 @@ export interface CapacitorInstance extends CapacitorGlobal {
     pluginName: string,
     methodName: string,
     options?: O,
+    callback?: PluginCallback,
   ) => Promise<R>;
 
   /**

--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -121,8 +121,8 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
         const methodHeader = pluginHeader?.methods.find(m => prop === m.name);
         if (methodHeader) {
           if (methodHeader.rtype === 'promise') {
-            return (options: any) =>
-              cap.nativePromise(pluginName, prop.toString(), options);
+            return (options: any, callback: any) =>
+              cap.nativePromise(pluginName, prop.toString(), options, callback);
           } else {
             return (options: any, callback: any) =>
               cap.nativeCallback(

--- a/ios/Capacitor/Capacitor/JSExport.swift
+++ b/ios/Capacitor/Capacitor/JSExport.swift
@@ -126,7 +126,7 @@ internal class JSExport {
         paramList.append(catchallOptionsParameter)
 
         // Automatically add the _callback param if returning data through a callback
-        if returnType == CAPPluginReturnCallback {
+        if returnType != CAPPluginReturnNone {
             paramList.append(callbackParameter)
         }
 
@@ -151,7 +151,7 @@ internal class JSExport {
 
             // ...using a promise
             lines.append("""
-                    return w.Capacitor.nativePromise('\(pluginClassName)', '\(methodName)', \(argObjectString));
+                    return w.Capacitor.nativePromise('\(pluginClassName)', '\(methodName)', \(argObjectString), \(callbackParameter));
                     """)
         } else if returnType == CAPPluginReturnCallback {
             // ...using a callback

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -405,7 +405,23 @@ const nativeBridge = (function (exports) {
                                 return err;
                             }, new cap.Exception(''));
                         }
-                        if (typeof storedCall.callback === 'function') {
+                        if (typeof storedCall.callback === 'function' &&
+                            typeof storedCall.resolve === 'function') {
+                            // promise with callback
+                            if (result.success) {
+                                if (result.save) {
+                                    storedCall.callback(result.data);
+                                }
+                                else {
+                                    storedCall.resolve(result.data);
+                                }
+                            }
+                            else {
+                                storedCall.reject(null, result.error);
+                                callbacks.delete(result.callbackId);
+                            }
+                        }
+                        else if (typeof storedCall.callback === 'function') {
                             // callback
                             if (result.success) {
                                 storedCall.callback(result.data);
@@ -451,9 +467,10 @@ const nativeBridge = (function (exports) {
                 }
                 return cap.toNative(pluginName, methodName, options, { callback });
             };
-            cap.nativePromise = (pluginName, methodName, options) => {
+            cap.nativePromise = (pluginName, methodName, options, callback) => {
                 return new Promise((resolve, reject) => {
                     cap.toNative(pluginName, methodName, options, {
+                        callback: callback,
                         resolve: resolve,
                         reject: reject,
                     });


### PR DESCRIPTION
### Description
Fixes #5618
Allows to add a callback function to a plugin method which returns a promise. Calling `call.resolve()` on keep alive passes the object to the callback - when a callback was provided. Setting keep alive to false passes the object to the promise and resolves it. `call.reject()` rejects the promise and deletes the saved callback.

This should not be a breaking change to the [value return method type](https://capacitorjs.com/docs/plugins/method-types#value-return) when no callback function is provided to the method or keep alive is never set to true.

#### Android example usage
```java
@CapacitorPlugin(name = "Example")
public class ExamplePlugin extends Plugin {
    @PluginMethod()
    public void example(PluginCall call) {
        String v = call.getString("v");
        call.setKeepAlive(true);
        call.resolve(new JSObject().put("n", 1));
        call.resolve(new JSObject().put("n", 2));
        call.resolve(new JSObject().put("n", 3));
        call.setKeepAlive(false);
        call.resolve(new JSObject().put("i", 42).put("r", v));
    }
}
```

### Platform(s)
- Android
- iOS (untested)