### PR TITLE
chore(android): Silence deprecation warnings from CapacitorWebView

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -30,6 +30,7 @@ public class CapacitorWebView extends WebView {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean dispatchKeyEvent(KeyEvent event) {
         if (event.getAction() == KeyEvent.ACTION_MULTIPLE) {
             evaluateJavascript("document.activeElement.value = document.activeElement.value + '" + event.getCharacters() + "';", null);


### PR DESCRIPTION
docs say `KeyEvent.ACTION_MULTIPLE` and `event.getCharacters()` are deprecated and no longer used, but I've verified they are still used on SDK 32, so silence the warnings.