### PR TITLE
fix: Scheme in config file if User rename the Project

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -277,7 +277,7 @@ async function loadIOSConfig(
   const nativeProjectDirAbs = resolve(platformDirAbs, nativeProjectDir);
   const nativeTargetDir = `${nativeProjectDir}/App`;
   const nativeTargetDirAbs = resolve(platformDirAbs, nativeTargetDir);
-  const nativeXcodeProjDir = `${nativeProjectDir}/App.xcodeproj`;
+  const nativeXcodeProjDir = `${nativeProjectDir}/${scheme}.xcodeproj`;
   const nativeXcodeProjDirAbs = resolve(platformDirAbs, nativeXcodeProjDir);
   const nativeXcodeWorkspaceDirAbs = lazy(() =>
     determineXcodeWorkspaceDirAbs(nativeProjectDirAbs),


### PR DESCRIPTION
I have came across to this problem after renaming the Project in Xcode.

```
const nativeXcodeProjDir = `${nativeProjectDir}/App.xcodeproj`;`
```

Shouldn't it be like that?
```
const nativeXcodeProjDir = `${nativeProjectDir}/${scheme}.xcodeproj`;
```