### PR TITLE
chore(ios-template): Remove unused touchesBegan method

### DIFF
--- a/ios-template/App/App/AppDelegate.swift
+++ b/ios-template/App/App/AppDelegate.swift
@@ -46,15 +46,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        super.touchesBegan(touches, with: event)
-
-        let statusBarRect = UIApplication.shared.statusBarFrame
-        guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
-
-        if statusBarRect.contains(touchPoint) {
-            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
-        }
-    }
-
 }


### PR DESCRIPTION
touchesBegan was there for iOS <= 12, removing since we no longer support those versions

closes https://github.com/ionic-team/capacitor/issues/5650