### PR TITLE
chore(android): Remove deprecated init method

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -26,43 +26,14 @@ public class BridgeActivity extends AppCompatActivity {
         setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
         setTheme(R.style.AppTheme_NoActionBar);
         setContentView(R.layout.bridge_layout_main);
-    }
+        PluginManager loader = new PluginManager(getAssets());
 
-    /**
-     * Initializes the Capacitor Bridge with the Activity.
-     * @deprecated It is preferred not to call this method. If it is not called, the bridge is
-     * initialized automatically. If you need to add additional plugins during initialization,
-     * use {@link #registerPlugin(Class)} or {@link #registerPlugins(List)}.
-     *
-     * @param plugins A list of plugins to initialize with Capacitor
-     */
-    @Deprecated
-    protected void init(Bundle savedInstanceState, List<Class<? extends Plugin>> plugins) {
-        this.init(savedInstanceState, plugins, null);
-    }
+        try {
+            bridgeBuilder.addPlugins(loader.loadPluginClasses());
+        } catch (PluginLoadException ex) {
+            Logger.error("Error loading plugins.", ex);
+        }
 
-    /**
-     * Initializes the Capacitor Bridge with the Activity.
-     * @deprecated It is preferred not to call this method. If it is not called, the bridge is
-     * initialized automatically. If you need to add additional plugins during initialization,
-     * use {@link #registerPlugin(Class)} or {@link #registerPlugins(List)}.
-     *
-     * @param plugins A list of plugins to initialize with Capacitor
-     * @param config An instance of a Capacitor Configuration to use. If null, will load from file
-     */
-    @Deprecated
-    protected void init(Bundle savedInstanceState, List<Class<? extends Plugin>> plugins, CapConfig config) {
-        this.initialPlugins = plugins;
-        this.config = config;
-
-        this.load();
-    }
-
-    /**
-     * @deprecated This method should not be called manually.
-     */
-    @Deprecated
-    protected void load(Bundle savedInstanceState) {
         this.load();
     }
 
@@ -96,20 +67,6 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onStart() {
         super.onStart();
-
-        // Preferred behavior: init() was not called, so we construct the bridge with auto-loaded plugins.
-        if (bridge == null) {
-            PluginManager loader = new PluginManager(getAssets());
-
-            try {
-                bridgeBuilder.addPlugins(loader.loadPluginClasses());
-            } catch (PluginLoadException ex) {
-                Logger.error("Error loading plugins.", ex);
-            }
-
-            this.load();
-        }
-
         activityDepth++;
         this.bridge.onStart();
         Logger.debug("App started");


### PR DESCRIPTION
Remove the init and other related deprecated methods from BridgeActivity and move the bridge initialization code to onCreate instead of onStart