### PR TITLE
chore(android-template): Add coordinatorlayout dependency

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -32,6 +32,7 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"


### PR DESCRIPTION
We have the dependency inside capacitor/android, but for some users it's not picking it correctly.
Since we use CoordinatorLayout in the default template we should include the dependency instead of relying on it being declared in capacitor/android

closes https://github.com/ionic-team/capacitor/issues/5437