### PR TITLE
chore(cli): Add config files to native templates gitignore

### DIFF
--- a/android-template/.gitignore
+++ b/android-template/.gitignore
@@ -94,3 +94,8 @@ capacitor-cordova-android-plugins
 
 # Copied web assets
 app/src/main/assets/public
+
+# Generated Config files
+app/src/main/assets/capacitor.config.json
+app/src/main/assets/capacitor.plugins.json
+app/src/main/res/xml/config.xml

--- a/ios-template/.gitignore
+++ b/ios-template/.gitignore
@@ -7,3 +7,7 @@ xcuserdata
 
 # Cordova plugins for Capacitor
 capacitor-cordova-ios-plugins
+
+# Generated Config files
+App/App/capacitor.config.json
+App/App/config.xml


### PR DESCRIPTION
I've also added the config.xml and for android the capacitor.plugins.json file since those are also auto generated by copy/sync commands.

closes https://github.com/ionic-team/capacitor/issues/4626