### PR TITLE
chore(cli): Update cordova plugins default kotlin versions

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -294,12 +294,9 @@ export async function handleCordovaPluginsGradle(
     'build.gradle',
   );
   const kotlinNeeded = await kotlinNeededCheck(config, cordovaPlugins);
-  const isKotlinVersionInVariablesGradle = (
-    await getVariablesGradleFile(config)
-  ).includes('kotlin_version');
   const kotlinVersionString =
     config.app.extConfig.cordova?.preferences?.GradlePluginKotlinVersion ??
-    '1.4.32';
+    '1.7.0';
   const frameworksArray: any[] = [];
   let prefsArray: any[] = [];
   const applyArray: any[] = [];
@@ -352,15 +349,15 @@ export async function handleCordovaPluginsGradle(
   if (kotlinNeeded) {
     buildGradle = buildGradle.replace(
       /(buildscript\s{\n(\t|\s{4})repositories\s{\n((\t{2}|\s{8}).+\n)+(\t|\s{4})}\n(\t|\s{4})dependencies\s{\n(\t{2}|\s{8}).+)\n((\t|\s{4})}\n}\n)/,
-      `$1\n        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:` +
-        (isKotlinVersionInVariablesGradle
-          ? '$kotlin_version'
-          : kotlinVersionString) +
-        `"\n$8`,
+      `$1\n        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"\n$8`,
     );
     buildGradle = buildGradle.replace(
       /(ext\s{)/,
-      `$1\n    kotlin_version = project.hasProperty('kotlin_version') ? rootProject.ext.kotlin_version : '${kotlinVersionString}'\n    androidxCoreKTXVersion = project.hasProperty('androidxCoreKTXVersion') ? rootProject.ext.androidxCoreKTXVersion : '1.6.0'`,
+      `$1\n    androidxCoreKTXVersion = project.hasProperty('androidxCoreKTXVersion') ? rootProject.ext.androidxCoreKTXVersion : '1.8.0'`,
+    );
+    buildGradle = buildGradle.replace(
+      /(buildscript\s{)/,
+      `$1\n    ext.kotlin_version = project.hasProperty('kotlin_version') ? rootProject.ext.kotlin_version : '${kotlinVersionString}'`,
     );
     buildGradle = buildGradle.replace(
       /(apply\splugin:\s'com\.android\.library')/,


### PR DESCRIPTION
updates default kotlin version to 1.7.0 and core-ktx to 1.8.0

also update the kotlin_version variable setting logic to be done in the buildscript so we can always use the `$kotlin_version` variable in the dependency by declaring a new `ext.kotlin_version` if it doesn't exist