### PR TITLE
chore(ci): Change script to publish from 3.x branch

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -12,7 +12,7 @@ jobs:
           node-version: 14.x
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # needed to enable fetching the latest commit from origin/portals-dev otherwise it will fail because the refspecs have not been fetched
+          fetch-depth: 0 # needed to enable fetching the latest commit from origin/3.x otherwise it will fail because the refspecs have not been fetched
           ref: native-publish
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -12,7 +12,6 @@ jobs:
           node-version: 14.x
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # needed to enable fetching the latest commit from origin/3.x otherwise it will fail because the refspecs have not been fetched
           ref: native-publish
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -1,6 +1,5 @@
 require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-portals_dev_head = `git rev-parse origin/3.x`.strip
 Pod::Spec.new do |s|
   s.name = 'Capacitor'
   s.version = package['version']
@@ -10,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://capacitorjs.com/'
   s.ios.deployment_target  = '12.0'
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
-  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :commit => portals_dev_head }
+  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => package['version'] }
   s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.module_map = 'ios/Capacitor/Capacitor/Capacitor.modulemap'
   s.resources = ['ios/Capacitor/Capacitor/assets/native-bridge.js']

--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -1,6 +1,6 @@
 require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-portals_dev_head = `git rev-parse origin/portals-dev`.strip
+portals_dev_head = `git rev-parse origin/3.x`.strip
 Pod::Spec.new do |s|
   s.name = 'Capacitor'
   s.version = package['version']


### PR DESCRIPTION
After [CapWebView is added to 3.x branch](https://github.com/ionic-team/capacitor/pull/5730), native-publish will need to pick the code from there instead of from portals-dev 