### PR TITLE
Fixed file select issue on Android 5.1.1. File explorer is not appearing to select file it only show Dropbox.

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -409,7 +409,9 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     private void showFilePicker(final ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
-        Intent intent = fileChooserParams.createIntent();
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
         if (fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }


### PR DESCRIPTION
While browsing a file on Android 5.1.1 it just allowing to select file from Dropbox and not showing File Explorer in the Popup.  This issue is not appearing on later versions of Android. Creating intent with "ACTION_OPEN_DOCUMENT" and set extra "SHOW_ADVANCED" as true fixes this issue.