### PR TITLE
fix(android): Publish proguard-rules.pro on npm

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,6 +16,7 @@
     "capacitor/build.gradle",
     "capacitor/lint-baseline.xml",
     "capacitor/lint.xml",
+    "capacitor/proguard-rules.pro",
     "capacitor/src/main/"
   ],
   "scripts": {


### PR DESCRIPTION
we have a proguard-rules.pro file but it's not being included in the npm package, this PR includes the file in the files array so it gets published

closes https://github.com/ionic-team/capacitor/issues/5606