### PR TITLE
Added different background colors for light/dark mode

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -21,6 +21,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContract;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import com.getcapacitor.android.R;
@@ -438,7 +439,17 @@ public class Bridge {
             settings.setUserAgentString(overrideUserAgent);
         }
 
-        String backgroundColor = this.config.getBackgroundColor();
+        int currentNightMode =
+                getContext().getResources().getConfiguration().uiMode &
+                        Configuration.UI_MODE_NIGHT_MASK;
+
+        String backgroundColor = null;
+        if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
+            backgroundColor = this.config.getDarkBackgroundColor();
+        } else {
+            backgroundColor = this.config.getLightBackgroundColor();
+        }
+
         try {
             if (backgroundColor != null) {
                 webView.setBackgroundColor(WebColor.parseColor(backgroundColor));

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -35,7 +35,8 @@ public class CapConfig {
     // Android Config
     private String overriddenUserAgentString;
     private String appendedUserAgentString;
-    private String backgroundColor;
+    private String lightBackgroundColor;
+    private String darkBackgroundColor;
     private boolean allowMixedContent = false;
     private boolean captureInput = false;
     private boolean webContentsDebuggingEnabled = false;
@@ -112,7 +113,8 @@ public class CapConfig {
         // Android Config
         this.overriddenUserAgentString = builder.overriddenUserAgentString;
         this.appendedUserAgentString = builder.appendedUserAgentString;
-        this.backgroundColor = builder.backgroundColor;
+        this.lightBackgroundColor = builder.lightBackgroundColor;
+        this.darkBackgroundColor = builder.darkBackgroundColor;
         this.allowMixedContent = builder.allowMixedContent;
         this.captureInput = builder.captureInput;
         this.webContentsDebuggingEnabled = builder.webContentsDebuggingEnabled;
@@ -158,8 +160,10 @@ public class CapConfig {
             JSONUtils.getString(configJSON, "android.overrideUserAgent", JSONUtils.getString(configJSON, "overrideUserAgent", null));
         appendedUserAgentString =
             JSONUtils.getString(configJSON, "android.appendUserAgent", JSONUtils.getString(configJSON, "appendUserAgent", null));
-        backgroundColor =
-            JSONUtils.getString(configJSON, "android.backgroundColor", JSONUtils.getString(configJSON, "backgroundColor", null));
+        lightBackgroundColor =
+            JSONUtils.getString(configJSON, "android.backgroundColor.light", JSONUtils.getString(configJSON, "backgroundColor.light", null));
+        darkBackgroundColor =
+                JSONUtils.getString(configJSON, "android.backgroundColor.dark", JSONUtils.getString(configJSON, "backgroundColor.dark", null));
         allowMixedContent =
             JSONUtils.getBoolean(
                 configJSON,
@@ -227,8 +231,12 @@ public class CapConfig {
         return appendedUserAgentString;
     }
 
-    public String getBackgroundColor() {
-        return backgroundColor;
+    public String getLightBackgroundColor() {
+        return lightBackgroundColor;
+    }
+
+    public String getDarkBackgroundColor() {
+        return darkBackgroundColor;
     }
 
     public boolean isMixedContentAllowed() {
@@ -401,7 +409,8 @@ public class CapConfig {
         // Android Config Values
         private String overriddenUserAgentString;
         private String appendedUserAgentString;
-        private String backgroundColor;
+        private String lightBackgroundColor;
+        private String darkBackgroundColor;
         private boolean allowMixedContent = false;
         private boolean captureInput = false;
         private Boolean webContentsDebuggingEnabled = null;
@@ -481,8 +490,13 @@ public class CapConfig {
             return this;
         }
 
-        public Builder setBackgroundColor(String backgroundColor) {
-            this.backgroundColor = backgroundColor;
+        public Builder setLightBackgroundColor(String backgroundColor) {
+            this.lightBackgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder setDarkBackgroundColor(String backgroundColor) {
+            this.darkBackgroundColor = backgroundColor;
             return this;
         }
 

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -51,7 +51,7 @@ public class ConfigBuildingTest {
                     .setOverriddenUserAgentString("test-user-agent")
                     .setAppendedUserAgentString("test-append")
                     .setWebContentsDebuggingEnabled(true)
-                    .setBackgroundColor("red")
+                    .setLightBackgroundColor("red")
                     .setPluginsConfiguration(pluginConfig)
                     .setServerUrl("http://www.google.com")
                     .create();

--- a/cli/src/colors.ts
+++ b/cli/src/colors.ts
@@ -8,6 +8,11 @@ export const success = kleur.green;
 export const failure = kleur.red;
 export const ancillary = kleur.cyan;
 
+export interface LightAndDark {
+  light: string;
+  dark: string;
+}
+
 const COLORS: Colors = {
   strong,
   weak,

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -1,3 +1,5 @@
+import { LightAndDark } from "./colors";
+
 export interface CapacitorConfig {
   /**
    * The unique identifier of your packaged app.
@@ -88,7 +90,7 @@ export interface CapacitorConfig {
    *
    * @since 1.1.0
    */
-  backgroundColor?: string;
+  backgroundColor?: LightAndDark;
 
   android?: {
     /**
@@ -126,7 +128,7 @@ export interface CapacitorConfig {
      *
      * @since 1.1.0
      */
-    backgroundColor?: string;
+    backgroundColor?: LightAndDark;
 
     /**
      * Enable mixed content in the Capacitor Web View for Android.
@@ -264,7 +266,7 @@ export interface CapacitorConfig {
      *
      * @since 1.1.0
      */
-    backgroundColor?: string;
+    backgroundColor?: LightAndDark;
 
     /**
      * Configure the scroll view's content inset adjustment behavior.

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -292,10 +292,25 @@ extension CAPBridgeViewController {
         if let overrideUserAgent = configuration.overridenUserAgentString {
             aWebView.customUserAgent = overrideUserAgent
         }
-        if let backgroundColor = configuration.backgroundColor {
-            aWebView.backgroundColor = backgroundColor
-            aWebView.scrollView.backgroundColor = backgroundColor
-        } else if #available(iOS 13, *) {
+        
+        var backgroundSet = false
+        if #available(iOS 13.0, *), UITraitCollection.current.userInterfaceStyle == .dark {
+            if let backgroundColor = configuration.darkBackgroundColor {
+                print("dark")
+                backgroundSet = true
+                aWebView.backgroundColor = backgroundColor
+                aWebView.scrollView.backgroundColor = backgroundColor
+            }
+        } else {
+            if let backgroundColor = configuration.lightBackgroundColor {
+                print("light")
+                backgroundSet = true
+                aWebView.backgroundColor = backgroundColor
+                aWebView.scrollView.backgroundColor = backgroundColor
+            }
+        }
+        
+        if #available(iOS 13.0, *), !backgroundSet {
             // Use the system background colors if background is not set by user
             aWebView.backgroundColor = UIColor.systemBackground
             aWebView.scrollView.backgroundColor = UIColor.systemBackground

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
@@ -9,7 +9,8 @@ NS_SWIFT_NAME(InstanceConfiguration)
 @interface CAPInstanceConfiguration: NSObject
 @property (nonatomic, readonly, nullable) NSString *appendedUserAgentString;
 @property (nonatomic, readonly, nullable) NSString *overridenUserAgentString;
-@property (nonatomic, readonly, nullable) UIColor *backgroundColor;
+@property (nonatomic, readonly, nullable) UIColor *lightBackgroundColor;
+@property (nonatomic, readonly, nullable) UIColor *darkBackgroundColor;
 @property (nonatomic, readonly, nonnull) NSArray<NSString*> *allowedNavigationHostnames;
 @property (nonatomic, readonly, nonnull) NSURL *localURL;
 @property (nonatomic, readonly, nonnull) NSURL *serverURL;

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -15,7 +15,8 @@
         // now copy the simple properties
         _appendedUserAgentString = descriptor.appendedUserAgentString;
         _overridenUserAgentString = descriptor.overridenUserAgentString;
-        _backgroundColor = descriptor.backgroundColor;
+        _lightBackgroundColor = descriptor.lightBackgroundColor;
+        _darkBackgroundColor = descriptor.darkBackgroundColor;
         _allowedNavigationHostnames = descriptor.allowedNavigationHostnames;
         switch (descriptor.loggingBehavior) {
             case CAPInstanceLoggingBehaviorProduction:
@@ -55,7 +56,8 @@
     if (self = [super init]) {
         _appendedUserAgentString = [[configuration appendedUserAgentString] copy];
         _overridenUserAgentString = [[configuration overridenUserAgentString] copy];
-        _backgroundColor = configuration.backgroundColor;
+        _lightBackgroundColor = configuration.lightBackgroundColor;
+        _darkBackgroundColor = configuration.darkBackgroundColor;
         _allowedNavigationHostnames = [[configuration allowedNavigationHostnames] copy];
         _localURL = [[configuration localURL] copy];
         _serverURL = [[configuration serverURL] copy];

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -39,10 +39,15 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, copy, nullable) NSString *overridenUserAgentString;
 /**
- @brief The background color to set on the web view where content is not visible.
+ @brief The background color to set on the web view where content is not visible when phone is in light mode.
  @discussion Set by @c backgroundColor in the configuration file.
  */
-@property (nonatomic, retain, nullable) UIColor *backgroundColor;
+@property (nonatomic, retain, nullable) UIColor *lightBackgroundColor;
+/**
+ @brief The background color to set on the web view where content is not visible when fone is in dark mode.
+ @discussion Set by @c backgroundColor in the configuration file.
+ */
+@property (nonatomic, retain, nullable) UIColor *darkBackgroundColor;
 /**
  @brief Hostnames to which the web view is allowed to navigate without opening an external browser.
  @discussion Set by @c allowNavigation in the configuration file.

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -80,9 +80,15 @@ internal extension InstanceDescriptor {
             if let agentString = (config[keyPath: "ios.overrideUserAgent"] as? String) ?? (config[keyPath: "overrideUserAgent"] as? String) {
                 overridenUserAgentString = agentString
             }
-            if let colorString = (config[keyPath: "ios.backgroundColor"] as? String) ?? (config[keyPath: "backgroundColor"] as? String),
+            if let colorString = (config[keyPath: "ios.backgroundColor.light"] as? String) ?? (config[keyPath: "backgroundColor.light"] as? String),
                let color = UIColor.capacitor.color(fromHex: colorString) {
-                backgroundColor = color
+                print(color)
+                lightBackgroundColor = color
+            }
+            if let colorString = (config[keyPath: "ios.backgroundColor.dark"] as? String) ?? (config[keyPath: "backgroundColor.dark"] as? String),
+               let color = UIColor.capacitor.color(fromHex: colorString) {
+                print(color)
+                darkBackgroundColor = color
             }
             if let allowNav = config[keyPath: "server.allowNavigation"] as? [String] {
                 allowedNavigationHostnames = allowNav

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -158,12 +158,27 @@ extension CAPWebView {
         if let overrideUserAgent = configuration.overridenUserAgentString {
             webView.customUserAgent = overrideUserAgent
         }
+        
+        var backgroundSet = false
+        if #available(iOS 13.0, *), UITraitCollection.current.userInterfaceStyle == .dark {
+            if let backgroundColor = configuration.darkBackgroundColor {
+                print("dark1")
+                backgroundSet = true
+                self.backgroundColor = backgroundColor
+                webView.backgroundColor = backgroundColor
+                webView.scrollView.backgroundColor = backgroundColor
+            }
+        } else {
+            if let backgroundColor = configuration.lightBackgroundColor {
+                print("light1")
+                backgroundSet = true
+                self.backgroundColor = backgroundColor
+                webView.backgroundColor = backgroundColor
+                webView.scrollView.backgroundColor = backgroundColor
+            }
+        }
 
-        if let backgroundColor = configuration.backgroundColor {
-            self.backgroundColor = backgroundColor
-            webView.backgroundColor = backgroundColor
-            webView.scrollView.backgroundColor = backgroundColor
-        } else if #available(iOS 13, *) {
+        if #available(iOS 13.0, *), !backgroundSet {
             // Use the system background colors if background is not set by user
             self.backgroundColor = UIColor.systemBackground
             webView.backgroundColor = UIColor.systemBackground


### PR DESCRIPTION
This adds the ability to specify different background colors for the webview depending on whether the device is in light or dark mode. The app I'm developing has different splash screens for light vs. dark mode, so without this separation, the screen will flash a different color in between when the splash screen disappears and when the app appears. Based on what I've seen online, I think a lot of people could benefit from this.

This is a breaking change, so I'm guessing y'all probably don't want it in 3.x. I just put it here because my app is in prod and I need this change, but I can't use 4.x until it's out. However, let me know where you'd like this change or what changes you'd like to see to it. I'm happy to change anything if y'all need me to do that.

These changes are fully tested on physical iOS and Android devices.