### PR TITLE
feat(android-template): Use Android 12 splash API

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
+    implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android-template/app/src/main/res/values/styles.xml
+++ b/android-template/app/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
     </style>
 
 
-    <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
+    <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
     </style>
 </resources>

--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -7,6 +7,7 @@ ext {
     androidxCoordinatorLayoutVersion = '1.2.0'
     androidxCoreVersion = '1.8.0'
     androidxFragmentVersion = '1.4.1'
+    coreSplashScreenVersion = '1.0.0-rc01'
     junitVersion = '4.13.2'
     androidxJunitVersion = '1.1.3'
     androidxEspressoCoreVersion = '3.4.0'


### PR DESCRIPTION
We are making Android 12 splash API the default, so the template needs to be updated to use it out of the box

splash API PR https://github.com/ionic-team/capacitor-plugins/pull/1011