### PR TITLE
fix(ios): error data is optional

### DIFF
--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -57,7 +57,7 @@ extension CAPPluginCall: JSValueContainer {
         errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
     }
 
-    func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallResultData = [:]) {
+    func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallResultData? = nil) {
         errorHandler(CAPPluginCallError(message: message, code: code, error: error, data: data))
     }
 


### PR DESCRIPTION
If no data is passed, error is always returning an empty object, while in Android it doesn't return data.
This set the data to nil as default and makes data optional.