### PR TITLE
chore(android-template): Add androidxWebkitVersion variable

### DIFF
--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -8,6 +8,7 @@ ext {
     androidxCoreVersion = '1.8.0'
     androidxFragmentVersion = '1.4.1'
     coreSplashScreenVersion = '1.0.0-rc01'
+    androidxWebkitVersion = '1.4.0'
     junitVersion = '4.13.2'
     androidxJunitVersion = '1.1.3'
     androidxEspressoCoreVersion = '3.4.0'


### PR DESCRIPTION
In https://github.com/ionic-team/capacitor/pull/5427 a new androidxWebkitVersion variable was used, so should be included in the variables.gradle with the default value.