### PR TITLE
chore(cli): Put new variables at the end

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -271,10 +271,10 @@ export async function migrateCommand(config: Config): Promise<void> {
                   );
                   if (file) {
                     file = file.replace(
-                      'ext {',
-                      `ext {\n    ${variable} = '${variablesAndClasspaths.variables[
+                      '}',
+                      `    ${variable} = '${variablesAndClasspaths.variables[
                         variable
-                      ].toString()}'`,
+                      ].toString()}'\n}`,
                     );
                     writeFileSync(
                       join(config.android.platformDirAbs, 'variables.gradle'),


### PR DESCRIPTION
New variables should be put at the end of the file instead of at the beginning, the beginning should be "reserved" for SDK related variables as those are more important.