### PR TITLE
fix(cli): Correct Splash theme update

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -898,6 +898,6 @@ async function addNewSplashScreen(config: Config) {
 
   if (!stylesXml) return;
 
-  stylesXml = stylesXml.replace('AppTheme.NoActionBar', 'Theme.SplashScreen');
+  stylesXml = stylesXml.replace(`parent="AppTheme.NoActionBar"`, `parent="Theme.SplashScreen"`);
   writeFileSync(stylePath, stylesXml);
 }


### PR DESCRIPTION
Replacing `AppTheme.NoActionBar` is not working fine because there is a theme with that name and it's being replaced instead of the Theme with `Theme.SplashScreenLaunch`