### PR TITLE
fix(cli): Revert some splash migration errors

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -902,5 +902,16 @@ async function addNewSplashScreen(config: Config) {
     `parent="AppTheme.NoActionBar"`,
     `parent="Theme.SplashScreen"`,
   );
+
+  // revert wrong replaces
+  stylesXml = stylesXml.replace(
+    `name="Theme.SplashScreen"`,
+    `name="AppTheme.NoActionBar"`,
+  );
+  stylesXml = stylesXml.replace(
+    `name="Theme.SplashScreenLaunch"`,
+    `name="AppTheme.NoActionBarLaunch"`,
+  );
+
   writeFileSync(stylePath, stylesXml);
 }


### PR DESCRIPTION
for users that already ran the migrator with a bug on the splash theme changes, this revert those wrong changes.