### PR TITLE
chore(cli): Replace Dark theme with DayNight theme

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -295,9 +295,12 @@ export async function migrateCommand(config: Config): Promise<void> {
         rimraf.sync(join(config.android.appDirAbs, 'build'));
 
         // add new splashscreen
-        await runTask('Migrate to Android 12 Splashscreen and apply DayNight theme.', () => {
-          return addNewSplashScreen(config);
-        });
+        await runTask(
+          'Migrate to Android 12 Splashscreen and apply DayNight theme.',
+          () => {
+            return addNewSplashScreen(config);
+          },
+        );
       }
 
       // Run Cap Sync

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -295,7 +295,7 @@ export async function migrateCommand(config: Config): Promise<void> {
         rimraf.sync(join(config.android.appDirAbs, 'build'));
 
         // add new splashscreen
-        await runTask('Migrate to Android 12 Splashscreen.', () => {
+        await runTask('Migrate to Android 12 Splashscreen and apply DayNight theme.', () => {
           return addNewSplashScreen(config);
         });
       }
@@ -911,6 +911,12 @@ async function addNewSplashScreen(config: Config) {
   stylesXml = stylesXml.replace(
     `name="Theme.SplashScreenLaunch"`,
     `name="AppTheme.NoActionBarLaunch"`,
+  );
+
+  // Apply DayNight theme
+  stylesXml = stylesXml.replace(
+    `parent="Theme.AppCompat.NoActionBar"`,
+    `parent="Theme.AppCompat.DayNight.NoActionBar"`,
   );
 
   writeFileSync(stylePath, stylesXml);


### PR DESCRIPTION
The migrator is missing[ the change ](https://capacitorjs.com/docs/updating/4-0#optional-use-a-daynight-theme)of the app theme to DayNight 

I've put the code in the same place the splash theme is changed to avoid reading the file again