### PR TITLE
chore(cli): make migrator use gradle 7.4.2-all

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -631,7 +631,7 @@ async function updateGradleWrapper(filename: string) {
     'distributionUrl=',
     '\n',
     // eslint-disable-next-line no-useless-escape
-    `https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip`,
+    `https\\://services.gradle.org/distributions/gradle-7.4.2-all.zip`,
   );
   writeFileSync(filename, replaced, 'utf-8');
 }


### PR DESCRIPTION
In android-template we use gradle 7.4.2-all, while the migrator uses 7.4.2-bin.
Also `https\://services.gradle.org/distributions/gradle-7.4.2-all.zip` is being written as `https://services.gradle.org/distributions/gradle-7.4.2-all.zip`, so add an extra \ so it gets written as `https\://services.gradle.org/distributions/gradle-7.4.2-all.zip` to match the template (the url still works, so not a big issue, but for consistency.