### PR TITLE
fix(ios): Prevent Xcode 14 warning on CAPWebView

### DIFF
--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -123,7 +123,7 @@ open class CAPWebView: UIView {
 
 extension CAPWebView {
 
-    open func webViewConfiguration(for instanceConfiguration: InstanceConfiguration) -> WKWebViewConfiguration {
+    public func webViewConfiguration(for instanceConfiguration: InstanceConfiguration) -> WKWebViewConfiguration {
         let webViewConfiguration = WKWebViewConfiguration()
         webViewConfiguration.allowsInlineMediaPlayback = true
         webViewConfiguration.suppressesIncrementalRendering = false


### PR DESCRIPTION
Xcode 14 shows this warning:
> Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead

And proposes to change to public, so I've done that

Closes https://github.com/ionic-team/capacitor/issues/5819