### PR TITLE
fix(cli): Don't add google-services plugin if missing

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -460,7 +460,7 @@ async function updateBuildGradle(
 ) {
   // In build.gradle add dependencies:
   // classpath 'com.android.tools.build:gradle:7.2.1'
-  // classpath 'com.google.gms:google-services:4.3.10'
+  // classpath 'com.google.gms:google-services:4.3.13'
   const txt = readFile(filename);
   if (!txt) {
     return;
@@ -474,13 +474,7 @@ async function updateBuildGradle(
   let replaced = txt;
 
   for (const dep of Object.keys(neededDeps)) {
-    if (!replaced.includes(`classpath '${dep}`)) {
-      replaced = txt.replace(
-        'dependencies {',
-        `dependencies {\n        classpath '${dep}:${neededDeps[dep]}'`,
-      );
-    } else {
-      // Update
+    if (replaced.includes(`classpath '${dep}`)) {
       replaced = setAllStringIn(
         replaced,
         `classpath '${dep}:`,


### PR DESCRIPTION
If `com.google.gms:google-services` plugin is not present we shouldn't add it since users might have removed it on purpose, also adding it when it's not present causes https://github.com/ionic-team/capacitor/issues/5824

closes https://github.com/ionic-team/capacitor/issues/5824