### PR TITLE
fix(cli): Also update preferences plugin if present

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -36,6 +36,7 @@ const plugins = [
   '@capacitor/local-notifications',
   '@capacitor/motion',
   '@capacitor/network',
+  '@capacitor/preferences',
   '@capacitor/push-notifications',
   '@capacitor/screen-reader',
   '@capacitor/share',


### PR DESCRIPTION
If the app was already using capacitor 4 beta and already migrated to using preferences plugin instead of storage plugin, the migrator won't update the preferences dependency to ^4.0.0, add it to the list so it gets updated.