### PR TITLE
Added different background colors for light/dark mode

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -536,7 +536,16 @@ public class Bridge {
             settings.setUserAgentString(overrideUserAgent);
         }
 
-        String backgroundColor = this.config.getBackgroundColor();
+        int currentNightMode =
+                getContext().getResources().getConfiguration().uiMode &
+                        Configuration.UI_MODE_NIGHT_MASK;
+
+        String backgroundColor = null;
+        if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
+            backgroundColor = this.config.getDarkBackgroundColor();
+        } else {
+            backgroundColor = this.config.getLightBackgroundColor();
+        }
         try {
             if (backgroundColor != null) {
                 webView.setBackgroundColor(WebColor.parseColor(backgroundColor));

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -39,7 +39,8 @@ public class CapConfig {
     // Android Config
     private String overriddenUserAgentString;
     private String appendedUserAgentString;
-    private String backgroundColor;
+    private String lightBackgroundColor;
+    private String darkBackgroundColor;
     private boolean allowMixedContent = false;
     private boolean captureInput = false;
     private boolean webContentsDebuggingEnabled = false;
@@ -122,7 +123,8 @@ public class CapConfig {
         // Android Config
         this.overriddenUserAgentString = builder.overriddenUserAgentString;
         this.appendedUserAgentString = builder.appendedUserAgentString;
-        this.backgroundColor = builder.backgroundColor;
+        this.lightBackgroundColor = builder.lightBackgroundColor;
+        this.darkBackgroundColor = builder.darkBackgroundColor;
         this.allowMixedContent = builder.allowMixedContent;
         this.captureInput = builder.captureInput;
         this.webContentsDebuggingEnabled = builder.webContentsDebuggingEnabled;
@@ -176,8 +178,10 @@ public class CapConfig {
             JSONUtils.getString(configJSON, "android.overrideUserAgent", JSONUtils.getString(configJSON, "overrideUserAgent", null));
         appendedUserAgentString =
             JSONUtils.getString(configJSON, "android.appendUserAgent", JSONUtils.getString(configJSON, "appendUserAgent", null));
-        backgroundColor =
-            JSONUtils.getString(configJSON, "android.backgroundColor", JSONUtils.getString(configJSON, "backgroundColor", null));
+        lightBackgroundColor =
+                JSONUtils.getString(configJSON, "android.backgroundColor.light", JSONUtils.getString(configJSON, "backgroundColor.light", null));
+        darkBackgroundColor =
+                JSONUtils.getString(configJSON, "android.backgroundColor.dark", JSONUtils.getString(configJSON, "backgroundColor.dark", null));
         allowMixedContent =
             JSONUtils.getBoolean(
                 configJSON,
@@ -260,8 +264,12 @@ public class CapConfig {
         return appendedUserAgentString;
     }
 
-    public String getBackgroundColor() {
-        return backgroundColor;
+    public String getLightBackgroundColor() {
+        return lightBackgroundColor;
+    }
+
+    public String getDarkBackgroundColor() {
+        return darkBackgroundColor;
     }
 
     public boolean isMixedContentAllowed() {
@@ -444,7 +452,8 @@ public class CapConfig {
         // Android Config Values
         private String overriddenUserAgentString;
         private String appendedUserAgentString;
-        private String backgroundColor;
+        private String lightBackgroundColor;
+        private String darkBackgroundColor;
         private boolean allowMixedContent = false;
         private boolean captureInput = false;
         private Boolean webContentsDebuggingEnabled = null;
@@ -530,8 +539,13 @@ public class CapConfig {
             return this;
         }
 
-        public Builder setBackgroundColor(String backgroundColor) {
-            this.backgroundColor = backgroundColor;
+        public Builder setLightBackgroundColor(String backgroundColor) {
+            this.lightBackgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder setDarkBackgroundColor(String backgroundColor) {
+            this.darkBackgroundColor = backgroundColor;
             return this;
         }
 

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -51,7 +51,7 @@ public class ConfigBuildingTest {
                     .setOverriddenUserAgentString("test-user-agent")
                     .setAppendedUserAgentString("test-append")
                     .setWebContentsDebuggingEnabled(true)
-                    .setBackgroundColor("red")
+                    .setLightBackgroundColor("red")
                     .setPluginsConfiguration(pluginConfig)
                     .setServerUrl("http://www.google.com")
                     .create();
@@ -71,7 +71,7 @@ public class ConfigBuildingTest {
         assertEquals("test-user-agent", config.getOverriddenUserAgentString());
         assertEquals("test-append", config.getAppendedUserAgentString());
         assertTrue(config.isWebContentsDebuggingEnabled());
-        assertEquals("red", config.getBackgroundColor());
+        assertEquals("red", config.getLightBackgroundColor());
         assertEquals("http://www.google.com", config.getServerUrl());
     }
 

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigReadingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigReadingTest.java
@@ -46,7 +46,8 @@ public class ConfigReadingTest {
 
             CapConfig config = CapConfig.loadDefault(context);
             assertEquals("not a real domain", config.getServerUrl());
-            assertNull(config.getBackgroundColor());
+            assertNull(config.getLightBackgroundColor());
+            assertNull(config.getDarkBackgroundColor());
             assertFalse(config.isLoggingEnabled());
         } catch (IOException e) {
             fail();
@@ -61,7 +62,8 @@ public class ConfigReadingTest {
             CapConfig config = CapConfig.loadDefault(context);
             assertEquals("level 1 override", config.getOverriddenUserAgentString());
             assertEquals("level 1 append", config.getAppendedUserAgentString());
-            assertEquals("#ffffff", config.getBackgroundColor());
+            assertEquals("#ffffff", config.getLightBackgroundColor());
+            assertEquals("#000000", config.getDarkBackgroundColor());
             assertFalse(config.isLoggingEnabled());
             assertEquals(1, config.getPluginConfiguration("SplashScreen").getInt("launchShowDuration", 0));
         } catch (IOException e) {
@@ -77,7 +79,8 @@ public class ConfigReadingTest {
             CapConfig config = CapConfig.loadDefault(context);
             assertEquals("level 2 override", config.getOverriddenUserAgentString());
             assertEquals("level 2 append", config.getAppendedUserAgentString());
-            assertEquals("#000000", config.getBackgroundColor());
+            assertEquals("#000000", config.getLightBackgroundColor());
+            assertEquals("#ffffff", config.getDarkBackgroundColor());
             assertFalse(config.isLoggingEnabled());
         } catch (IOException e) {
             fail();

--- a/android/capacitor/src/test/resources/configs/flat.json
+++ b/android/capacitor/src/test/resources/configs/flat.json
@@ -6,7 +6,10 @@
   "webDir": "build",
   "overrideUserAgent": "level 1 override",
   "appendUserAgent": "level 1 append",
-  "backgroundColor": "#ffffff",
+  "backgroundColor": {
+    "light": "#ffffff",
+    "dark": "#000000"
+  },
   "hideLogs": true,
   "plugins": {
     "SplashScreen": {

--- a/android/capacitor/src/test/resources/configs/hierarchy.json
+++ b/android/capacitor/src/test/resources/configs/hierarchy.json
@@ -11,7 +11,10 @@
   "android": {
     "overrideUserAgent": "level 2 override",
     "appendUserAgent": "level 2 append",
-    "backgroundColor": "#000000",
+    "backgroundColor": {
+      "light": "#000000",
+      "dark": "#ffffff"
+    },
     "hideLogs": false,
     "allowsLinkPreview": false,
     "scrollEnabled": false,

--- a/cli/src/colors.ts
+++ b/cli/src/colors.ts
@@ -1,6 +1,11 @@
 import type { Colors } from '@ionic/cli-framework-output';
 import kleur from 'kleur';
 
+export interface LightAndDark {
+  light: string;
+  dark: string;
+}
+
 export const strong = kleur.bold;
 export const weak = kleur.dim;
 export const input = kleur.cyan;

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -1,3 +1,5 @@
+import { LightAndDark } from "./colors";
+
 export interface CapacitorConfig {
   /**
    * The unique identifier of your packaged app.
@@ -88,7 +90,7 @@ export interface CapacitorConfig {
    *
    * @since 1.1.0
    */
-  backgroundColor?: string;
+  backgroundColor?: LightAndDark;
 
   android?: {
     /**
@@ -126,7 +128,7 @@ export interface CapacitorConfig {
      *
      * @since 1.1.0
      */
-    backgroundColor?: string;
+    backgroundColor?: LightAndDark;
 
     /**
      * Enable mixed content in the Capacitor Web View for Android.
@@ -274,7 +276,7 @@ export interface CapacitorConfig {
      *
      * @since 1.1.0
      */
-    backgroundColor?: string;
+    backgroundColor?: LightAndDark;
 
     /**
      * Configure the scroll view's content inset adjustment behavior.

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -297,14 +297,25 @@ extension CAPBridgeViewController {
         if let overrideUserAgent = configuration.overridenUserAgentString {
             aWebView.customUserAgent = overrideUserAgent
         }
-        if let backgroundColor = configuration.backgroundColor {
-            aWebView.backgroundColor = backgroundColor
-            aWebView.scrollView.backgroundColor = backgroundColor
+        
+        var bColor: UIColor? = nil
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            if let backgroundColor = configuration.darkBackgroundColor {
+                bColor = backgroundColor
+            }
         } else {
-            // Use the system background colors if background is not set by user
-            aWebView.backgroundColor = UIColor.systemBackground
-            aWebView.scrollView.backgroundColor = UIColor.systemBackground
+            if let backgroundColor = configuration.lightBackgroundColor {
+                bColor = backgroundColor
+            }
         }
+        
+        if bColor == nil {
+            bColor = UIColor.systemBackground
+        }
+        
+        aWebView.backgroundColor = bColor
+        aWebView.scrollView.backgroundColor = bColor
+        
         aWebView.capacitor.setKeyboardShouldRequireUserInteraction(false)
         // set our ivar
         webView = aWebView

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
@@ -9,7 +9,8 @@ NS_SWIFT_NAME(InstanceConfiguration)
 @interface CAPInstanceConfiguration: NSObject
 @property (nonatomic, readonly, nullable) NSString *appendedUserAgentString;
 @property (nonatomic, readonly, nullable) NSString *overridenUserAgentString;
-@property (nonatomic, readonly, nullable) UIColor *backgroundColor;
+@property (nonatomic, readonly, nullable) UIColor *lightBackgroundColor;
+@property (nonatomic, readonly, nullable) UIColor *darkBackgroundColor;
 @property (nonatomic, readonly, nonnull) NSArray<NSString*> *allowedNavigationHostnames;
 @property (nonatomic, readonly, nonnull) NSURL *localURL;
 @property (nonatomic, readonly, nonnull) NSURL *serverURL;

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -15,7 +15,8 @@
         // now copy the simple properties
         _appendedUserAgentString = descriptor.appendedUserAgentString;
         _overridenUserAgentString = descriptor.overridenUserAgentString;
-        _backgroundColor = descriptor.backgroundColor;
+        _lightBackgroundColor = descriptor.lightBackgroundColor;
+        _darkBackgroundColor = descriptor.darkBackgroundColor;
         _allowedNavigationHostnames = descriptor.allowedNavigationHostnames;
         switch (descriptor.loggingBehavior) {
             case CAPInstanceLoggingBehaviorProduction:
@@ -57,7 +58,8 @@
     if (self = [super init]) {
         _appendedUserAgentString = [[configuration appendedUserAgentString] copy];
         _overridenUserAgentString = [[configuration overridenUserAgentString] copy];
-        _backgroundColor = configuration.backgroundColor;
+        _lightBackgroundColor = configuration.lightBackgroundColor;
+        _darkBackgroundColor = configuration.darkBackgroundColor;
         _allowedNavigationHostnames = [[configuration allowedNavigationHostnames] copy];
         _localURL = [[configuration localURL] copy];
         _serverURL = [[configuration serverURL] copy];

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -39,10 +39,15 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, copy, nullable) NSString *overridenUserAgentString;
 /**
- @brief The background color to set on the web view where content is not visible.
+ @brief The background color to set on the web view where content is not visible when phone is in light mode.
  @discussion Set by @c backgroundColor in the configuration file.
  */
-@property (nonatomic, retain, nullable) UIColor *backgroundColor;
+@property (nonatomic, retain, nullable) UIColor *lightBackgroundColor;
+/**
+ @brief The background color to set on the web view where content is not visible when fone is in dark mode.
+ @discussion Set by @c backgroundColor in the configuration file.
+ */
+@property (nonatomic, retain, nullable) UIColor *darkBackgroundColor;
 /**
  @brief Hostnames to which the web view is allowed to navigate without opening an external browser.
  @discussion Set by @c allowNavigation in the configuration file.

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -80,9 +80,13 @@ internal extension InstanceDescriptor {
             if let agentString = (config[keyPath: "ios.overrideUserAgent"] as? String) ?? (config[keyPath: "overrideUserAgent"] as? String) {
                 overridenUserAgentString = agentString
             }
-            if let colorString = (config[keyPath: "ios.backgroundColor"] as? String) ?? (config[keyPath: "backgroundColor"] as? String),
+            if let colorString = (config[keyPath: "ios.backgroundColor.light"] as? String) ?? (config[keyPath: "backgroundColor.light"] as? String),
                let color = UIColor.capacitor.color(fromHex: colorString) {
-                backgroundColor = color
+                lightBackgroundColor = color
+            }
+            if let colorString = (config[keyPath: "ios.backgroundColor.dark"] as? String) ?? (config[keyPath: "backgroundColor.dark"] as? String),
+               let color = UIColor.capacitor.color(fromHex: colorString) {
+                darkBackgroundColor = color
             }
             if let allowNav = config[keyPath: "server.allowNavigation"] as? [String] {
                 allowedNavigationHostnames = allowNav

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -158,17 +158,25 @@ extension CAPWebView {
         if let overrideUserAgent = configuration.overridenUserAgentString {
             webView.customUserAgent = overrideUserAgent
         }
-
-        if let backgroundColor = configuration.backgroundColor {
-            self.backgroundColor = backgroundColor
-            webView.backgroundColor = backgroundColor
-            webView.scrollView.backgroundColor = backgroundColor
+        
+        var bColor: UIColor? = nil
+        if UITraitCollection.current.userInterfaceStyle == .dark {
+            if let backgroundColor = configuration.darkBackgroundColor {
+                bColor = backgroundColor
+            }
         } else {
-            // Use the system background colors if background is not set by user
-            self.backgroundColor = UIColor.systemBackground
-            webView.backgroundColor = UIColor.systemBackground
-            webView.scrollView.backgroundColor = UIColor.systemBackground
+            if let backgroundColor = configuration.lightBackgroundColor {
+                bColor = backgroundColor
+            }
         }
+        
+        if bColor == nil {
+            bColor = UIColor.systemBackground
+        }
+
+        self.backgroundColor = bColor
+        webView.backgroundColor = bColor
+        webView.scrollView.backgroundColor = bColor
 
         // set our delegates
         webView.uiDelegate = delegationHandler


### PR DESCRIPTION
This adds the ability to specify different background colors for the WebView depending on whether the device is in light or dark mode. The app I'm developing has different splash screens for light vs. dark mode, so without this separation, the screen will flash a different color in between when the splash screen disappears and when the app appears. Based on what I've seen online, I think a lot of people could benefit from this.

These changes are fully tested on physical iOS and Android devices.