### PR TITLE
feat(cli): Option to inline JS source maps during sync

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -85,8 +85,8 @@ export function runProgram(config: Config): void {
     )
     .option(
       '--inline',
-      "Optional: if true, all source maps will be inlined for easier debugging on mobile devices",
-      false
+      'Optional: if true, all source maps will be inlined for easier debugging on mobile devices',
+      false,
     )
     .action(
       wrapAction(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -83,12 +83,17 @@ export function runProgram(config: Config): void {
       '--deployment',
       "Optional: if provided, Podfile.lock won't be deleted and pod install will use --deployment option",
     )
+    .option(
+      '--inline',
+      "Optional: if true, all source maps will be lined for easier debugging on mobile devices",
+      false
+    )
     .action(
       wrapAction(
-        telemetryAction(config, async (platform, { deployment }) => {
+        telemetryAction(config, async (platform, { deployment, inline }) => {
           checkExternalConfig(config.app);
           const { syncCommand } = await import('./tasks/sync');
-          await syncCommand(config, platform, deployment);
+          await syncCommand(config, platform, deployment, inline);
         }),
       ),
     );

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -85,7 +85,7 @@ export function runProgram(config: Config): void {
     )
     .option(
       '--inline',
-      "Optional: if true, all source maps will be lined for easier debugging on mobile devices",
+      "Optional: if true, all source maps will be inlined for easier debugging on mobile devices",
       false
     )
     .action(

--- a/cli/src/tasks/add.ts
+++ b/cli/src/tasks/add.ts
@@ -104,7 +104,7 @@ export async function addCommand(
       await editPlatforms(config, platformName);
 
       if (await pathExists(config.app.webDirAbs)) {
-        await sync(config, platformName, false);
+        await sync(config, platformName, false, false);
         if (platformName === config.android.name) {
           await runTask('Syncing Gradle', async () => {
             return createLocalProperties(config.android.platformDirAbs);

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -80,7 +80,7 @@ export async function runCommand(
 
     try {
       if (options.sync) {
-        await sync(config, platformName, false);
+        await sync(config, platformName, false, true);
       }
 
       await run(config, platformName, options);

--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -9,6 +9,22 @@ import { join, extname } from 'path';
 import type { Config } from '../definitions';
 import { logger } from '../log';
 
+
+function findJSAssetsDir(buildDir: string): string {
+    const reactJSDir = "/static/js";
+    const vueJSDir = "/js";    
+
+    if (existsSync(buildDir + reactJSDir)) {
+        return reactJSDir;
+    }
+
+    if (existsSync(buildDir + vueJSDir)) {
+        return vueJSDir;
+    }
+
+    return "/";
+}
+
 export async function inlineSourceMaps(
   config: Config,
   platformName: string,
@@ -16,21 +32,18 @@ export async function inlineSourceMaps(
   let buildDir = '';
 
   if (platformName == config.ios.name) {
-    logger.info(
-      `inlining sourcemaps for ${platformName} - ${await config.ios.webDirAbs}`,
-    );
     buildDir = await config.ios.webDirAbs;
   }
 
-  if (platformName == config.android.name) {
-    logger.info(
-      `inlining sourcemaps for ${platformName} - ${await config.android.webDirAbs}`,
-    );
+  if (platformName == config.android.name) {    
     buildDir = await config.android.webDirAbs;
   }
 
   if (buildDir) {
-    buildDir += "/static/js"
+    logger.info("Inlining sourcemaps")
+    let jsAssetsDir = findJSAssetsDir(buildDir);
+    buildDir += jsAssetsDir;
+
     const files = readdirSync(buildDir);
     files.forEach(file => {
       const mapFile = join(buildDir, `${file}.map`);

--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -1,0 +1,51 @@
+import {
+  readdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+} from '@ionic/utils-fs';
+import { join, extname } from 'path';
+import type { Config } from '../definitions';
+import { logger } from '../log';
+
+export async function inlineSourceMaps(
+  config: Config,
+  platformName: string,
+): Promise<void> {
+  let buildDir = '';
+
+  if (platformName == config.ios.name) {
+    logger.info(
+      `inlining sourcemaps for ${platformName} - ${await config.ios.webDirAbs}`,
+    );
+    buildDir = await config.ios.webDirAbs;
+  }
+
+  if (platformName == config.android.name) {
+    logger.info(
+      `inlining sourcemaps for ${platformName} - ${await config.android.webDirAbs}`,
+    );
+    buildDir = await config.android.webDirAbs;
+  }
+
+  if (buildDir) {
+    buildDir += "/static/js"
+    const files = readdirSync(buildDir);
+    files.forEach(file => {
+      const mapFile = join(buildDir, `${file}.map`);
+      if (extname(file) === '.js' && existsSync(mapFile)) {
+        const targetFile = join(buildDir, file);
+        const bufMap = readFileSync(mapFile).toString('base64');
+        const bufFile = readFileSync(targetFile, 'utf8');
+        const result = bufFile.replace(
+          `sourceMappingURL=${file}.map`,
+          'sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+            bufMap,
+        );
+        writeFileSync(targetFile, result);
+        unlinkSync(mapFile);
+      }
+    });
+  }
+}

--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -6,23 +6,23 @@ import {
   unlinkSync,
 } from '@ionic/utils-fs';
 import { join, extname } from 'path';
+
 import type { Config } from '../definitions';
 import { logger } from '../log';
 
-
 function findJSAssetsDir(buildDir: string): string {
-    const reactJSDir = "/static/js";
-    const vueJSDir = "/js";    
+  const reactJSDir = '/static/js';
+  const vueJSDir = '/js';
 
-    if (existsSync(buildDir + reactJSDir)) {
-        return reactJSDir;
-    }
+  if (existsSync(buildDir + reactJSDir)) {
+    return reactJSDir;
+  }
 
-    if (existsSync(buildDir + vueJSDir)) {
-        return vueJSDir;
-    }
+  if (existsSync(buildDir + vueJSDir)) {
+    return vueJSDir;
+  }
 
-    return "/";
+  return '/';
 }
 
 export async function inlineSourceMaps(
@@ -35,13 +35,13 @@ export async function inlineSourceMaps(
     buildDir = await config.ios.webDirAbs;
   }
 
-  if (platformName == config.android.name) {    
+  if (platformName == config.android.name) {
     buildDir = await config.android.webDirAbs;
   }
 
   if (buildDir) {
-    logger.info("Inlining sourcemaps")
-    let jsAssetsDir = findJSAssetsDir(buildDir);
+    logger.info('Inlining sourcemaps');
+    const jsAssetsDir = findJSAssetsDir(buildDir);
     buildDir += jsAssetsDir;
 
     const files = readdirSync(buildDir);

--- a/cli/src/tasks/sourcemaps.ts
+++ b/cli/src/tasks/sourcemaps.ts
@@ -11,16 +11,15 @@ import { join, extname } from 'path';
 import type { Config } from '../definitions';
 import { logger } from '../log';
 
-
 function walkDirectory(dirPath: string) {
   const files = readdirSync(dirPath);
   files.forEach(file => {
     const targetFile = join(dirPath, file);
     if (existsSync(targetFile) && lstatSync(targetFile).isDirectory()) {
       walkDirectory(targetFile);
-    } else {      
-      const mapFile = join(dirPath, `${file}.map`)
-      if (extname(file) === '.js' && existsSync(mapFile)) {        
+    } else {
+      const mapFile = join(dirPath, `${file}.map`);
+      if (extname(file) === '.js' && existsSync(mapFile)) {
         const bufMap = readFileSync(mapFile).toString('base64');
         const bufFile = readFileSync(targetFile, 'utf8');
         const result = bufFile.replace(

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -12,7 +12,7 @@ import { logger } from '../log';
 import { allSerial } from '../util/promise';
 
 import { copy, copyCommand } from './copy';
-import { inlineSourceMaps } from "./sourcemaps";
+import { inlineSourceMaps } from './sourcemaps';
 import { update, updateChecks, updateCommand } from './update';
 
 /**
@@ -22,7 +22,7 @@ export async function syncCommand(
   config: Config,
   selectedPlatformName: string,
   deployment: boolean,
-  inline: boolean
+  inline: boolean,
 ): Promise<void> {
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     try {
@@ -62,7 +62,7 @@ export async function sync(
   config: Config,
   platformName: string,
   deployment: boolean,
-  inline: boolean
+  inline: boolean,
 ): Promise<void> {
   await runPlatformHook(
     config,
@@ -75,7 +75,7 @@ export async function sync(
     await copy(config, platformName);
     if (inline) {
       await inlineSourceMaps(config, platformName);
-    }    
+    }
   } catch (e) {
     logger.error(e.stack ?? e);
   }

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -12,6 +12,7 @@ import { logger } from '../log';
 import { allSerial } from '../util/promise';
 
 import { copy, copyCommand } from './copy';
+import { inlineSourceMaps } from "./sourcemaps";
 import { update, updateChecks, updateCommand } from './update';
 
 /**
@@ -70,6 +71,7 @@ export async function sync(
 
   try {
     await copy(config, platformName);
+    await inlineSourceMaps(config, platformName);
   } catch (e) {
     logger.error(e.stack ?? e);
   }

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -22,6 +22,7 @@ export async function syncCommand(
   config: Config,
   selectedPlatformName: string,
   deployment: boolean,
+  inline: boolean
 ): Promise<void> {
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     try {
@@ -41,7 +42,7 @@ export async function syncCommand(
       ]);
       await allSerial(
         platforms.map(
-          platformName => () => sync(config, platformName, deployment),
+          platformName => () => sync(config, platformName, deployment, inline),
         ),
       );
       const now = +new Date();
@@ -61,6 +62,7 @@ export async function sync(
   config: Config,
   platformName: string,
   deployment: boolean,
+  inline: boolean
 ): Promise<void> {
   await runPlatformHook(
     config,
@@ -71,7 +73,9 @@ export async function sync(
 
   try {
     await copy(config, platformName);
-    await inlineSourceMaps(config, platformName);
+    if (inline) {
+      await inlineSourceMaps(config, platformName);
+    }    
   } catch (e) {
     logger.error(e.stack ?? e);
   }


### PR DESCRIPTION
Adds an option to the `sync` command , `--inline`, which will, after syncing, inline all JS source maps for easier debugging on mobile devices.