### PR TITLE
feat(cli): environment config overwrites

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,6 +52,7 @@
     "debug": "^4.3.4",
     "env-paths": "^2.2.0",
     "kleur": "^4.1.4",
+    "lodash.merge": "^4.6.2",
     "native-run": "^1.6.0",
     "open": "^8.4.0",
     "plist": "^3.0.5",
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^26.0.4",
+    "@types/lodash.merge": "^4.6.7",
     "@types/plist": "^3.0.2",
     "@types/prompts": "^2.0.14",
     "@types/rimraf": "^3.0.2",

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -33,12 +33,12 @@ export const CONFIG_FILE_NAME_TS = 'capacitor.config.ts';
 export const CONFIG_FILE_NAME_JS = 'capacitor.config.js';
 export const CONFIG_FILE_NAME_JSON = 'capacitor.config.json';
 
-export async function loadConfig(enviromentName = ''): Promise<Config> {
+export async function loadConfig(environmentName = ''): Promise<Config> {
   const appRootDir = process.cwd();
   const cliRootDir = dirname(__dirname);
   const conf = await loadExtConfig(appRootDir);
-  if (enviromentName.length >= 0) {
-    mergeEnviromentConfigs(conf, enviromentName);
+  if (environmentName.length >= 0) {
+    mergeEnvironmentConfigs(conf, environmentName);
   }
 
   const appId = conf.extConfig.appId ?? '';
@@ -456,8 +456,8 @@ export function checkExternalConfig(config: ExtConfigPairs): void {
   }
 }
 
-function mergeEnviromentConfigs(cfg: ExtConfigPairs, enviromentName: string) {
-  if (cfg.extConfig.enviromentOverrides?.[enviromentName]) {
-    merge(cfg.extConfig, cfg.extConfig.enviromentOverrides[enviromentName]);
+function mergeEnvironmentConfigs(cfg: ExtConfigPairs, environmentName: string) {
+  if (cfg.extConfig.environmentOverrides?.[environmentName]) {
+    merge(cfg.extConfig, cfg.extConfig.environmentOverrides[environmentName]);
   }
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -33,12 +33,6 @@ export const CONFIG_FILE_NAME_TS = 'capacitor.config.ts';
 export const CONFIG_FILE_NAME_JS = 'capacitor.config.js';
 export const CONFIG_FILE_NAME_JSON = 'capacitor.config.json';
 
-function mergeEnviromentConfigs(cfg: ExtConfigPairs, enviromentName: string) {
-  if (cfg.extConfig.enviromentOverrides?.[enviromentName]) {
-    merge(cfg.extConfig, cfg.extConfig.enviromentOverrides[enviromentName])
-  }
-}
-
 export async function loadConfig(enviromentName = ''): Promise<Config> {
   const appRootDir = process.cwd();
   const cliRootDir = dirname(__dirname);
@@ -459,5 +453,11 @@ export function checkExternalConfig(config: ExtConfigPairs): void {
       `The ${c.strong('hideLogs')} configuration option has been deprecated. ` +
         `Please update to use ${c.strong('loggingBehavior')} instead.`,
     );
+  }
+}
+
+function mergeEnviromentConfigs(cfg: ExtConfigPairs, enviromentName: string) {
+  if (cfg.extConfig.enviromentOverrides?.[enviromentName]) {
+    merge(cfg.extConfig, cfg.extConfig.enviromentOverrides[enviromentName]);
   }
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -6,6 +6,7 @@ import {
   writeJSON,
 } from '@ionic/utils-fs';
 import Debug from 'debug';
+import merge from 'lodash.merge';
 import { dirname, extname, join, relative, resolve } from 'path';
 
 import c from './colors';
@@ -32,10 +33,19 @@ export const CONFIG_FILE_NAME_TS = 'capacitor.config.ts';
 export const CONFIG_FILE_NAME_JS = 'capacitor.config.js';
 export const CONFIG_FILE_NAME_JSON = 'capacitor.config.json';
 
-export async function loadConfig(): Promise<Config> {
+function mergeEnviromentConfigs(cfg: ExtConfigPairs, enviromentName: string) {
+  if (cfg.extConfig.enviromentOverrides?.[enviromentName]) {
+    merge(cfg.extConfig, cfg.extConfig.enviromentOverrides[enviromentName])
+  }
+}
+
+export async function loadConfig(enviromentName = ''): Promise<Config> {
   const appRootDir = process.cwd();
   const cliRootDir = dirname(__dirname);
   const conf = await loadExtConfig(appRootDir);
+  if (enviromentName.length >= 0) {
+    mergeEnviromentConfigs(conf, enviromentName);
+  }
 
   const appId = conf.extConfig.appId ?? '';
   const appName = conf.extConfig.appName ?? '';

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -513,12 +513,15 @@ export interface CapacitorConfig {
 
   /**
    * Enviroment Overrides.
-   * 
+   *
    * @since 4.1.0
    */
   enviromentOverrides?: {
-    [enviromentName: string]: Omit<CapacitorConfig, "appId" | "appName" | "webDir" | "enviromentOverrides">
-  }
+    [enviromentName: string]: Omit<
+      CapacitorConfig,
+      'appId' | 'appName' | 'webDir' | 'enviromentOverrides'
+    >;
+  };
 }
 
 export interface Portal {

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -510,6 +510,15 @@ export interface CapacitorConfig {
    * @since 3.0.0
    */
   includePlugins?: string[];
+
+  /**
+   * Enviroment Overrides.
+   * 
+   * @since 4.1.0
+   */
+  enviromentOverrides?: {
+    [enviromentName: string]: Omit<CapacitorConfig, "appId" | "appName" | "webDir" | "enviromentOverrides">
+  }
 }
 
 export interface Portal {

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -512,14 +512,14 @@ export interface CapacitorConfig {
   includePlugins?: string[];
 
   /**
-   * Enviroment Overrides.
+   * Environment Overrides.
    *
    * @since 4.1.0
    */
-  enviromentOverrides?: {
-    [enviromentName: string]: Omit<
+  environmentOverrides?: {
+    [environmentName: string]: Omit<
       CapacitorConfig,
-      'appId' | 'appName' | 'webDir' | 'enviromentOverrides'
+      'appId' | 'appName' | 'webDir' | 'environmentOverrides'
     >;
   };
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,7 +18,7 @@ process.on('message', receive);
 
 export async function run(): Promise<void> {
   try {
-    const configEnvName = (process.env.CAP_CONFIG_ENVIROMENT ?? '') + '';
+    const configEnvName = (process.env.CAP_CONFIG_ENVIRONMENT ?? '') + '';
     const config = await loadConfig(configEnvName);
     runProgram(config);
   } catch (e: any) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,7 +18,8 @@ process.on('message', receive);
 
 export async function run(): Promise<void> {
   try {
-    const config = await loadConfig();
+    const configEnvName = (process.env.CAP_CONFIG_ENVIROMENT ?? '') + '';
+    const config = await loadConfig(configEnvName);
     runProgram(config);
   } catch (e: any) {
     process.exitCode = isFatal(e) ? e.exitCode : 1;


### PR DESCRIPTION
This PR adds the property `environmentOverrides` to `CapacitorConfig` which contains the name of the environment you want to use different config values in, and the config objects you wish to overwrite.

For example if you had a QA specific config you want to differ from your default config it would look like this:
```typescript
import { CapacitorConfig } from '@capacitor/cli';

const config: CapacitorConfig = {
  appId: 'com.capacitorjs.app.testapp',
  appName: 'capacitor-testapp',
  webDir: 'build',
  ios: {
    scheme: 'App',
  },
  android: {
    flavor: 'dev',
  },
  plugins: {
    SplashScreen: {
      launchAutoHide: true,
    },
  },
  environmentOverrides: {
    'qa': {
      plugins: {
        SplashScreen: {
          launchAutoHide: false,
        },
      },
      ios: {
        scheme: 'AppQA',
      },
      android: {
        flavor: 'qa',
      },
    }
  }
};

export default config;
```

Where your android `flavor`, iOS `scheme`, and `SplashScreen` plugin configuration is changed if running in the `qa` environment.

You can set this environment by setting the `CAP_CONFIG_ENVIRONMENT` variable via `dotenv` or `export` ect. for example: `export CAP_CONFIG_ENVIROMENT=qa && npx cap sync`