### PR TITLE
fix(cli): prevent error on migrate when devDependencies is missing

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -339,7 +339,7 @@ async function installLatestNPMLibs(runInstall: boolean, config: Config) {
   }
   const pkgJson: any = JSON.parse(pkgJsonFile);
 
-  for (const devDepKey of Object.keys(pkgJson['devDependencies'])) {
+  for (const devDepKey of Object.keys(pkgJson['devDependencies'] || {})) {
     if (libs.includes(devDepKey)) {
       pkgJson['devDependencies'][devDepKey] = coreVersion;
     } else if (plugins.includes(devDepKey)) {


### PR DESCRIPTION
Currently the "cap migrate" command will crash with the error "Failed to migrate: TypeError: Cannot convert undefined or null to object" if you run it in project that has a package.json file without a devDependencies property. This PR fixes this issue.