### PR TITLE
fix(cli): make migrator also update plugin variables

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -290,6 +290,23 @@ export async function migrateCommand(config: Config): Promise<void> {
                 }
               }
             }
+            const pluginVariables: { [key: string]: string } = {
+              firebaseMessagingVersion: '23.0.5',
+              playServicesLocationVersion: '20.0.0',
+              androidxBrowserVersion: '1.4.0',
+              androidxMaterialVersion: '1.6.1',
+              androidxExifInterfaceVersion: '1.3.3',
+            };
+            for (const variable of Object.keys(pluginVariables)) {
+              await updateFile(
+                config,
+                variablesPath,
+                `${variable} = '`,
+                `'`,
+                pluginVariables[variable],
+                true,
+              );
+            }
           })();
         });
 


### PR DESCRIPTION
Capacitor 2 apps had all those plugin variables defined and it's causing issues for users that update the plugins but have the old variable version defined (specially playServicesLocationVersion variable since we use constants that weren't available before that version).
