### PR TITLE
fix(android): Avoid handling responses in WebViewLocalServer (#4240, #5394)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -267,7 +267,7 @@ public class Bridge {
         final boolean html5mode = this.config.isHTML5Mode();
 
         // Start the local web server
-        localServer = new WebViewLocalServer(context, this, getJSInjector(), authorities, html5mode);
+        localServer = new WebViewLocalServer(context, this, authorities, html5mode);
         localServer.hostAssets(DEFAULT_WEB_ASSET_DIR);
 
         Logger.debug("Loading app at " + appUrl);
@@ -509,6 +509,11 @@ public class Bridge {
 
     public void reset() {
         savedCalls = new HashMap<>();
+
+        JSInjector jsInjector = getJSInjector();
+        if (jsInjector != null) {
+            webView.evaluateJavascript(jsInjector.getScriptString(), result -> {});
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #4240
Fixes #5394

The PR should fix the Android redirect issue.
More importantly, it fixes this issue without destroying the native bridge on redirects.

It actually also fixes this issue for me:
https://github.com/ionic-team/capacitor/issues/5394

It is inspired by this comment:
https://github.com/ionic-team/capacitor/pull/4437#issuecomment-1081300621

I do not know a lot about the codebase, so I am not sure if the workaround I proposed is suitable, but it works without issues for me; I used it for implementing single sign on with Keycloak.