### PR TITLE
chore(cli): Change CocoaPods install link

### DIFF
--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -19,7 +19,7 @@ export async function checkCocoaPods(config: Config): Promise<string | null> {
     return (
       `CocoaPods is not installed.\n` +
       `See this install guide: ${c.strong(
-        'https://guides.cocoapods.org/using/getting-started.html#installation',
+        'https://capacitorjs.com/docs/getting-started/environment-setup#homebrew',
       )}`
     );
   }


### PR DESCRIPTION
If CocoaPods is not installed we link the official CocoaPods install guide that uses gem install, but gem install has some problems on M1 macs, so better use a link to our own page that explains how to install with Homebrew (and also without it)