### PR TITLE
feat(ios): Add `setServerBasePath(_:)` to CAPBridgeProtocol (#5860)

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeProtocol.swift
@@ -70,6 +70,7 @@ import WebKit
     // MARK: - Paths, Files, Assets
     func localURL(fromWebURL webURL: URL?) -> URL?
     func portablePath(fromLocalURL localURL: URL?) -> URL?
+    func setServerBasePath(_ path: String)
 
     // MARK: - View Presentation
     func showAlertWith(title: String, message: String, buttonTitle: String)

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -258,16 +258,10 @@ extension CAPBridgeViewController {
     }
 
     @objc public func setServerBasePath(path: String) {
-        let url = URL(fileURLWithPath: path, isDirectory: true)
-        guard let capBridge = capacitorBridge, FileManager.default.fileExists(atPath: url.path) else {
-            return
-        }
-        capBridge.config = capBridge.config.updatingAppLocation(url)
-        capBridge.webViewAssetHandler.setAssetPath(url.path)
-        if let url = capacitorBridge?.config.serverURL {
-            DispatchQueue.main.async { [weak self] in
-                _ = self?.webView?.load(URLRequest(url: url))
-            }
+        guard let capBridge = capacitorBridge else { return }
+        capBridge.setServerBasePath(path)
+        DispatchQueue.main.async { [weak self] in
+            _ = self?.webView?.load(URLRequest(url: capBridge.config.serverURL))
         }
     }
 }

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -156,6 +156,13 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         statusBarAnimation = animation
     }
 
+    public func setServerBasePath(_ path: String) {
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        config = config.updatingAppLocation(url)
+        webViewAssetHandler.setAssetPath(url.path)
+    }
+
     // MARK: - Static Methods
 
     /**


### PR DESCRIPTION
Backports `setServerBasePath(_:)` to 3.x