### PR TITLE
fix(android): open external links in browser

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -351,7 +351,7 @@ public class Bridge {
             }
         }
 
-        if (!url.toString().contains(appUrl) && !appAllowNavigationMask.matches(url.getHost())) {
+        if (!url.toString().startsWith(appUrl) && !appAllowNavigationMask.matches(url.getHost())) {
             try {
                 Intent openIntent = new Intent(Intent.ACTION_VIEW, url);
                 getContext().startActivity(openIntent);


### PR DESCRIPTION
If the url the user wants to open contains the app url it's being navigated instead of being open in the browser because the url check was checking "contains". Using "startsWith" solves the problem.

closes https://github.com/ionic-team/capacitor/issues/5786