### PR TITLE
fix(android): set WebViewClient on the WebView

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1299,6 +1299,7 @@ public class Bridge {
 
     public void setWebViewClient(BridgeWebViewClient client) {
         this.webViewClient = client;
+        webView.setWebViewClient(client);
     }
 
     List<WebViewListener> getWebViewListeners() {


### PR DESCRIPTION
This sets the WebViewClient on the WebView too as if setWebViewClient is being called after the app initialization it had no effect setting it only on the bridge.

closes https://github.com/ionic-team/capacitor/issues/5419