### PR TITLE
Fix update command when using custom iOS project name

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -277,7 +277,7 @@ async function loadIOSConfig(
   const nativeProjectDirAbs = resolve(platformDirAbs, nativeProjectDir);
   const nativeTargetDir = `${nativeProjectDir}/App`;
   const nativeTargetDirAbs = resolve(platformDirAbs, nativeTargetDir);
-  const nativeXcodeProjDir = `${nativeProjectDir}/App.xcodeproj`;
+  const nativeXcodeProjDir = `${nativeProjectDir}/${scheme}.xcodeproj`;
   const nativeXcodeProjDirAbs = resolve(platformDirAbs, nativeXcodeProjDir);
   const nativeXcodeWorkspaceDirAbs = lazy(() =>
     determineXcodeWorkspaceDirAbs(nativeProjectDirAbs),


### PR DESCRIPTION
The steps for renaming the iOS app https://capacitorjs.com/docs/ios/configuration#renaming-your-app cause the `cap sync ios`  to fail with:
```
✖ update ios - failed!
[error] Command line invocation:
        /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj clean

        User defaults from command line:
        IDEPackageSupportUseBuiltinSCM = YES

        2022-09-16 23:55:10.098 xcodebuild[44343:3003925] Writing error result bundle to
        /var/folders/7s/9cx4q_5d1sq_8x9nl557s1fm0000gn/T/ResultBundle_2022-16-09_23-55-0010.xcresult
        xcodebuild: error: 'App.xcodeproj' does not exist.
```

Looks like this spot still has the hardcoded `App` project name