### PR TITLE
feat(cli): supports secure live updates in Portals for Capacitor config

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -554,6 +554,7 @@ export interface PluginsConfig {
   Portals?: {
     shell: Portal;
     apps: Portal[];
+    liveUpdatesKey?: string;
   };
 
   /**

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -98,10 +98,8 @@ export async function copy(
       if (usesCapacitorPortals) {
         await copyFederatedWebDirs(config, await config.ios.webDirAbs);
         if (config.app.extConfig?.plugins?.Portals?.liveUpdatesKey) {
-          const secureLiveUpdatesKeyFile =
-            config.app.extConfig.plugins.Portals.liveUpdatesKey;
           await copySecureLiveUpdatesKey(
-            secureLiveUpdatesKeyFile,
+            config.app.extConfig.plugins.Portals.liveUpdatesKey,
             config.app.rootDir,
             config.ios.nativeTargetDirAbs,
           );
@@ -114,10 +112,8 @@ export async function copy(
         );
       }
       if (usesLiveUpdates && config.app.extConfig?.plugins?.LiveUpdates?.key) {
-        const secureLiveUpdatesKeyFile =
-          config.app.extConfig.plugins.LiveUpdates.key;
         await copySecureLiveUpdatesKey(
-          secureLiveUpdatesKeyFile,
+          config.app.extConfig.plugins.LiveUpdates.key,
           config.app.rootDir,
           config.ios.nativeTargetDirAbs,
         );
@@ -129,10 +125,8 @@ export async function copy(
       if (usesCapacitorPortals) {
         await copyFederatedWebDirs(config, config.android.webDirAbs);
         if (config.app.extConfig?.plugins?.Portals?.liveUpdatesKey) {
-          const secureLiveUpdatesKeyFile =
-            config.app.extConfig.plugins.Portals.liveUpdatesKey;
           await copySecureLiveUpdatesKey(
-            secureLiveUpdatesKeyFile,
+            config.app.extConfig.plugins.Portals.liveUpdatesKey,
             config.app.rootDir,
             config.android.assetsDirAbs,
           );
@@ -145,10 +139,8 @@ export async function copy(
         );
       }
       if (usesLiveUpdates && config.app.extConfig?.plugins?.LiveUpdates?.key) {
-        const secureLiveUpdatesKeyFile =
-          config.app.extConfig.plugins.LiveUpdates.key;
         await copySecureLiveUpdatesKey(
-          secureLiveUpdatesKeyFile,
+          config.app.extConfig.plugins.LiveUpdates.key,
           config.app.rootDir,
           config.android.assetsDirAbs,
         );

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -97,6 +97,15 @@ export async function copy(
     if (platformName === config.ios.name) {
       if (usesCapacitorPortals) {
         await copyFederatedWebDirs(config, await config.ios.webDirAbs);
+        if (config.app.extConfig?.plugins?.Portals?.liveUpdatesKey) {
+          const secureLiveUpdatesKeyFile =
+            config.app.extConfig.plugins.Portals.liveUpdatesKey;
+          await copySecureLiveUpdatesKey(
+            secureLiveUpdatesKeyFile,
+            config.app.rootDir,
+            config.ios.nativeTargetDirAbs,
+          );
+        }
       } else {
         await copyWebDir(
           config,
@@ -104,8 +113,14 @@ export async function copy(
           config.app.webDirAbs,
         );
       }
-      if (usesLiveUpdates) {
-        await copySecureLiveUpdatesKey(config, config.ios.nativeTargetDirAbs);
+      if (usesLiveUpdates && config.app.extConfig?.plugins?.LiveUpdates?.key) {
+        const secureLiveUpdatesKeyFile =
+          config.app.extConfig.plugins.LiveUpdates.key;
+        await copySecureLiveUpdatesKey(
+          secureLiveUpdatesKeyFile,
+          config.app.rootDir,
+          config.ios.nativeTargetDirAbs,
+        );
       }
       await copyCapacitorConfig(config, config.ios.nativeTargetDirAbs);
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
@@ -113,6 +128,15 @@ export async function copy(
     } else if (platformName === config.android.name) {
       if (usesCapacitorPortals) {
         await copyFederatedWebDirs(config, config.android.webDirAbs);
+        if (config.app.extConfig?.plugins?.Portals?.liveUpdatesKey) {
+          const secureLiveUpdatesKeyFile =
+            config.app.extConfig.plugins.Portals.liveUpdatesKey;
+          await copySecureLiveUpdatesKey(
+            secureLiveUpdatesKeyFile,
+            config.app.rootDir,
+            config.android.assetsDirAbs,
+          );
+        }
       } else {
         await copyWebDir(
           config,
@@ -120,8 +144,14 @@ export async function copy(
           config.app.webDirAbs,
         );
       }
-      if (usesLiveUpdates) {
-        await copySecureLiveUpdatesKey(config, config.android.assetsDirAbs);
+      if (usesLiveUpdates && config.app.extConfig?.plugins?.LiveUpdates?.key) {
+        const secureLiveUpdatesKeyFile =
+          config.app.extConfig.plugins.LiveUpdates.key;
+        await copySecureLiveUpdatesKey(
+          secureLiveUpdatesKeyFile,
+          config.app.rootDir,
+          config.android.assetsDirAbs,
+        );
       }
       await copyCapacitorConfig(config, config.android.assetsDirAbs);
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
@@ -229,15 +259,14 @@ function isPortal(config: any): config is Portal {
   );
 }
 
-async function copySecureLiveUpdatesKey(config: Config, nativeAbsDir: string) {
-  if (!config.app.extConfig?.plugins?.LiveUpdates?.key) {
-    return;
-  }
-
-  const secureLiveUpdatesKeyFile = config.app.extConfig.plugins.LiveUpdates.key;
-  const keyAbsFromPath = join(config.app.rootDir, secureLiveUpdatesKeyFile);
+async function copySecureLiveUpdatesKey(
+  secureLiveUpdatesKeyFile: string,
+  rootDir: string,
+  nativeAbsDir: string,
+) {
+  const keyAbsFromPath = join(rootDir, secureLiveUpdatesKeyFile);
   const keyAbsToPath = join(nativeAbsDir, basename(keyAbsFromPath));
-  const keyRelToDir = relative(config.app.rootDir, nativeAbsDir);
+  const keyRelToDir = relative(rootDir, nativeAbsDir);
 
   if (!(await pathExists(keyAbsFromPath))) {
     logger.warn(


### PR DESCRIPTION
Updates the CLI to add the ability to add a liveUpdatesKey to the Portals for Capacitor config which enables support for Secure Live Updates in the Portals for Capacitor plugin.