### PR TITLE
Android range requests

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -124,7 +124,7 @@ public class WebViewLocalServer {
         }
 
         public Map<String, String> getResponseHeaders() {
-            return responseHeaders;
+            return new HashMap(responseHeaders);
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -213,6 +213,10 @@ public class WebViewLocalServer {
                 String[] parts = rangeString.split("=");
                 String[] streamParts = parts[1].split("-");
                 String fromRange = streamParts[0];
+                int bytesToSkip = Integer.parseInt(fromRange);
+                if (bytesToSkip > 0) {
+                    responseStream.skip(bytesToSkip);
+                }
                 int range = totalRange - 1;
                 if (streamParts.length > 1) {
                     range = Integer.parseInt(streamParts[1]);


### PR DESCRIPTION
This PR addresses issue #2978, which seems to be a problem carried over from the cordova plugin: ionic-team/cordova-plugin-ionic-webview/issues/453

The issue is with [`PathHandler`](android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java), where the `responseHeaders` map is shared between threads, causing simultaneous requests to return the same `Content-Length` to the browser in case of range requests. See the illustration in ionic-team/cordova-plugin-ionic-webview/issues/453 (the same issue is present Capacitor).

This PR proposes to return a copy of the map on each invocation.

Furhermore, it introduces skipping of the initial part of the file in case of a range request not starting from zero. This brings the Android implementation better in line with its iOS counterpart, see  https://github.com/ionic-team/capacitor/blob/3d4433b505252d263784ec0fafc72a9b7cd8591e/ios/Capacitor/Capacitor/WebViewAssetHandler.swift#L51