### PR TITLE
fix (http) : use setValue instead of addValue on iOS setRequestHeaders

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -111,7 +111,7 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
     public func setRequestHeaders(_ headers: [String: String]) {
         headers.keys.forEach { (key: String) in
             let value = headers[key]
-            request.addValue(value!, forHTTPHeaderField: key)
+            request.setValue(value!, forHTTPHeaderField: key)
             self.headers[key] = value
         }
     }


### PR DESCRIPTION
As explain [here](https://github.com/capacitor-community/http/issues/261), there is a problem with accept-language header on iOS because of [this](https://github.com/ionic-team/capacitor/blob/main/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift#L21).