### PR TITLE
fix(android): added ServerPath object and building options for load from portals (#6005)

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/ServerPath.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/ServerPath.java
@@ -1,0 +1,25 @@
+package com.getcapacitor;
+
+public class ServerPath {
+
+    public enum PathType {
+        BASE_PATH,
+        ASSET_PATH
+    }
+
+    private final PathType type;
+    private final String path;
+
+    public ServerPath(PathType type, String path) {
+        this.type = type;
+        this.path = path;
+    }
+
+    public PathType getType() {
+        return type;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}


### PR DESCRIPTION
4.x port of merged 3.x code https://github.com/ionic-team/capacitor/pull/6005

Adds a ServerPath object and mechanics for Portals and live updates to load directly instead of after the webview has already loaded. Fixes issue with observable flash or Page Not Found error before content loading.