### PR TITLE
fix(core): Ensures PII data is not placed in memory if LogBehavior is set to none

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -705,16 +705,18 @@ public class Bridge {
                 return;
             }
 
-            Logger.verbose(
-                "callback: " +
-                call.getCallbackId() +
-                ", pluginId: " +
-                plugin.getId() +
-                ", methodName: " +
-                methodName +
-                ", methodData: " +
-                call.getData().toString()
-            );
+            if (Logger.shouldLog()) {
+                Logger.verbose(
+                    "callback: " +
+                    call.getCallbackId() +
+                    ", pluginId: " +
+                    plugin.getId() +
+                    ", methodName: " +
+                    methodName +
+                    ", methodData: " +
+                    call.getData().toString()
+                );
+            }
 
             Runnable currentThreadTask = () -> {
                 try {

--- a/android/capacitor/src/main/java/com/getcapacitor/Logger.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Logger.java
@@ -97,7 +97,7 @@ public class Logger {
         Log.e(tag, message, e);
     }
 
-    protected static boolean shouldLog() {
+    public static boolean shouldLog() {
         return config == null || config.isLoggingEnabled();
     }
 }


### PR DESCRIPTION
When a memory dump is done in a Capacitor app any Logger.verbose etc calls will appear with their payload even if the loglevel is set to None, this is because all method call parameter objects are placed on the stack and require a GC to empty. 

This particular Logger.verbose statement passes the data of the call which is likely to contain sensitive data if making say a login API request so by checking if we should log before calling the statement it ensure that call.getData() is not called and the verbose method is not called.

Note: other plugins are likely to still insert sensitive data into memory but these would be treated separately. This PR is just for Capacitor.