### PR TITLE
fix(cli): Update gradle versions only if they are older

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -530,13 +530,19 @@ async function updateBuildGradle(
 
   for (const dep of Object.keys(neededDeps)) {
     if (replaced.includes(`classpath '${dep}`)) {
-      replaced = setAllStringIn(
-        replaced,
-        `classpath '${dep}:`,
-        `'`,
-        neededDeps[dep],
-      );
-      logger.info(`Set ${dep} = ${neededDeps[dep]}.`);
+      const semver = await import('semver');
+      const firstIndex = replaced.indexOf(dep) + dep.length + 1;
+      const existingVersion =
+        '' + replaced.substring(firstIndex, replaced.indexOf("'", firstIndex));
+      if (semver.gte(neededDeps[dep], existingVersion)) {
+        replaced = setAllStringIn(
+          replaced,
+          `classpath '${dep}:`,
+          `'`,
+          neededDeps[dep],
+        );
+        logger.info(`Set ${dep} = ${neededDeps[dep]}.`);
+      }
     }
   }
 


### PR DESCRIPTION
get the current gradle version and check if it's older than the version on the template to not downgrade user projects in case they had already upgraded gradle to 7.3.0 or newer.