### PR TITLE
fix(cli): calculate padding of super.onCreate(savedInstanceState); line

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -955,10 +955,12 @@ async function migrateMainActivity(config: Config) {
     }
 
     const rindex = data.indexOf('registerPlugin');
+    const superLine = 'super.onCreate(savedInstanceState);';
     if (rindex !== -1) {
-      if (data.indexOf('super.onCreate(savedInstanceState);') < rindex) {
+      if (data.indexOf(superLine) < rindex) {
+        const linePadding = rindex - data.indexOf(superLine) - superLine.length - 1;
         data = data.replace(
-          'super.onCreate(savedInstanceState);\n        ',
+          `${superLine}\n${" ".repeat(linePadding)}`,
           '',
         );
         const eindex = data.lastIndexOf('.class);') + 8;
@@ -967,7 +969,7 @@ async function migrateMainActivity(config: Config) {
           `${data.substring(
             bindex,
             eindex,
-          )}\n        super.onCreate(savedInstanceState);`,
+          )}\n${" ".repeat(linePadding) + superLine.padStart(linePadding)}`,
         );
       }
     }

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -958,18 +958,15 @@ async function migrateMainActivity(config: Config) {
     const superLine = 'super.onCreate(savedInstanceState);';
     if (rindex !== -1) {
       if (data.indexOf(superLine) < rindex) {
-        const linePadding = rindex - data.indexOf(superLine) - superLine.length - 1;
-        data = data.replace(
-          `${superLine}\n${" ".repeat(linePadding)}`,
-          '',
-        );
+        const linePadding =
+          rindex - data.indexOf(superLine) - superLine.length - 1;
+        data = data.replace(`${superLine}\n${' '.repeat(linePadding)}`, '');
         const eindex = data.lastIndexOf('.class);') + 8;
         data = data.replace(
           data.substring(bindex, eindex),
-          `${data.substring(
-            bindex,
-            eindex,
-          )}\n${" ".repeat(linePadding) + superLine.padStart(linePadding)}`,
+          `${data.substring(bindex, eindex)}\n${
+            ' '.repeat(linePadding) + superLine.padStart(linePadding)
+          }`,
         );
       }
     }


### PR DESCRIPTION
If `super.onCreate(savedInstanceState);` line has a different padding than the hardcoded one, the migrate command will fail to remove the line and will end up with it duplicated (see https://github.com/jcesarmobile/capacitor-migration-issue/pull/2/files)

This PR calculates the padding of the `super.onCreate(savedInstanceState);` line to use it on the string replacement so it works with any padding.

