### PR TITLE
chore(android): native artifact publish logic

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -9,8 +9,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: native-publish
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -16,15 +16,28 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
+
+        if (System.getenv("CAP_PUBLISH") == "true") {
+            classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+        }
     }
 }
 
 tasks.withType(Javadoc).all { enabled = false }
 
 apply plugin: 'com.android.library'
+
+if (System.getenv("CAP_PUBLISH") == "true") {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    apply from: file('../scripts/publish-root.gradle')
+    apply from: file('../scripts/publish-module.gradle')
+}
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32

--- a/android/scripts/publish-module.gradle
+++ b/android/scripts/publish-module.gradle
@@ -1,0 +1,77 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+def LIB_VERSION = System.getenv('CAP_VERSION')
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        from android.sourceSets.main.java.srcDirs
+    } else {
+        from sourceSets.main.java.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = 'com.capacitorjs'
+version = LIB_VERSION
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Coordinates
+                groupId 'com.capacitorjs'
+                artifactId 'core'
+                version LIB_VERSION
+
+                // Two artifacts, the `aar` (or `jar`) and the sources
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.release
+                } else {
+                    artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+                }
+
+                artifact androidSourcesJar
+
+                // POM Data
+                pom {
+                    name = 'core'
+                    description = 'Capacitor Android Core Native Library'
+                    url = 'https://github.com/ionic-team/capacitor'
+                    licenses {
+                        license {
+                            name = 'MIT'
+                            url = 'https://github.com/ionic-team/capacitor/blob/main/LICENSE'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'Ionic'
+                            email = 'hi@ionic.io'
+                        }
+                    }
+
+                    // Version Control Info
+                    scm {
+                        connection = 'scm:git:github.com:ionic-team/capacitor.git'
+                        developerConnection = 'scm:git:ssh://github.com:ionic-team/capacitor.git'
+                        url = 'https://github.com/ionic-team/capacitor/tree/main'
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+            rootProject.ext["signing.keyId"],
+            rootProject.ext["signing.key"],
+            rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
+}

--- a/android/scripts/publish-root.gradle
+++ b/android/scripts/publish-root.gradle
@@ -1,0 +1,37 @@
+// Create variables with empty default values
+ext["signing.keyId"] = ''
+ext["signing.key"] = ''
+ext["signing.password"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File secretPropsFile = file('../local.properties')
+if (secretPropsFile.exists()) {
+    // Read local.properties file first if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhUsername"] = System.getenv('ANDROID_OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('ANDROID_OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('ANDROID_SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('ANDROID_SIGNING_KEY_ID')
+    ext["signing.key"] = System.getenv('ANDROID_SIGNING_KEY')
+    ext["signing.password"] = System.getenv('ANDROID_SIGNING_PASSWORD')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+    repositoryDescription = 'Capacitor Android Core v' + System.getenv('CAP_VERSION')
+}

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+DIR=../android
+LOG_OUTPUT=./tmp/capacitor-android.txt
+CAP_VERSION=`grep '"version": ' $DIR/package.json | awk '{print $2}' | tr -d '",'`
+echo Attempting to build and publish Capacitor native libraries with version $CAP_VERSION
+
+# Make log dir if doesnt exist
+mkdir -p ./tmp
+
+# Export ENV variable used by Gradle for Versioning
+export CAP_VERSION=4.4.0-beta1
+export CAP_PUBLISH=true
+
+# Get latest com.capacitorjs:core XML version info
+CAPACITOR_PUBLISHED_URL="https://repo1.maven.org/maven2/com/capacitorjs/core/maven-metadata.xml"
+CAPACITOR_PUBLISHED_DATA=$(curl -s $CAPACITOR_PUBLISHED_URL)
+CAPACITOR_PUBLISHED_VERSION="$(perl -ne 'print and last if s/.*<latest>(.*)<\/latest>.*/\1/;' <<< $CAPACITOR_PUBLISHED_DATA)"
+
+# Check if we need to publish a new native version of the Capacitor Android library
+if [[ $CAP_VERSION == $CAPACITOR_PUBLISHED_VERSION ]]; then
+    printf %"s\n" "Native Capacitor Android library version $CAPACITOR_PUBLISHED_VERSION is already published on MavenCentral, skipping."
+else
+    printf %"s\n" "Publishing $CAP_VERSION to MavenCentral production..."
+
+    # Build and publish
+    $DIR/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1 -b $DIR/capacitor/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
+
+    echo $RESULT
+
+    if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
+        printf %"s\n" "Success: Capacitor Android Library published to MavenCentral."
+    else
+        printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manual publication review may be necessary at the Sonatype Repository Manager https://s01.oss.sonatype.org/"
+        cat $LOG_OUTPUT
+        exit 1
+    fi
+fi

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -9,7 +9,7 @@ echo Attempting to build and publish Capacitor native libraries with version $CA
 mkdir -p ./tmp
 
 # Export ENV variable used by Gradle for Versioning
-export CAP_VERSION=4.4.0-beta1
+export CAP_VERSION
 export CAP_PUBLISH=true
 
 # Get latest com.capacitorjs:core XML version info


### PR DESCRIPTION
Adds native publication step for android into Capacitor v4. No separate publication branch required like in v3.

Triggering a build requires ENV variable set for `CAP_PUBLISH=true` when running the build and publish Gradle commands so that the appropriate plugins are imported with Gradle. The CI publish script will include this.

ENV variable requirement fixes a previous error in traditional Capacitor apps where the parent App project threw a Gradle sync error due to the presence of the publishing plugin in the entire project.
```A problem occurred evaluating project ':capacitor-android'.
> Failed to apply plugin 'io.github.gradle-nexus.publish-plugin'.
   > Plugin must be applied to the root project but was applied to :capacitor-android
```

Removed the manual review step from Sonatype. **Whenever a fresh build is run with this publish script, as long as it is not already published on MavenCentral, Capacitor Core will be fully published** with these changes. Test version was successful. https://central.sonatype.dev/artifact/com.capacitorjs/core/4.4.0-beta1