### PR TITLE
chore(ios): iOS pub v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
       - run: npm install
       - run: npm run verify
         working-directory: ./ios
+      - name: Validate native podspec
+        run: sh ./scripts/native-podspec.sh lint
   test-android:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Install Cocoapods
         run: gem install cocoapods
       - name: Deploy to Cocoapods
-        run: |
-          set -eo pipefail
-          pod trunk push ./ios/CapacitorCordova.podspec --allow-warnings
-          pod trunk push ./ios/Capacitor.podspec --allow-warnings
+        run: sh ./scripts/native-podspec.sh publish
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -11,8 +11,6 @@ jobs:
         with:
           node-version: 14.x
       - uses: actions/checkout@v2
-        with:
-          ref: native-publish
       - name: Install Cocoapods
         run: gem install cocoapods
       - name: Deploy to Cocoapods

--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -1,5 +1,5 @@
-require "json"
-package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 Pod::Spec.new do |s|
   s.name = 'Capacitor'
   s.version = package['version']
@@ -7,9 +7,9 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/capacitorjs'
   s.license = 'MIT'
   s.homepage = 'https://capacitorjs.com/'
-  s.ios.deployment_target  = '13.0'
+  s.ios.deployment_target = '13.0'
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
-  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :branch => "portals-dev" }
+  s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => package['version'] }
   s.source_files = 'Capacitor/Capacitor/*.{swift,h,m}', 'Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
   s.module_map = 'Capacitor/Capacitor/Capacitor.modulemap'
   s.resources = ['Capacitor/Capacitor/assets/native-bridge.js']

--- a/ios/Capacitor.podspec.patch
+++ b/ios/Capacitor.podspec.patch
@@ -1,0 +1,15 @@
+--- Capacitor.podspec	2022-10-25 12:05:24.000000000 -0500
++++ NativeCapacitor.podspec	2022-10-25 12:07:52.000000000 -0500
+@@ -10,9 +10,9 @@
+   s.ios.deployment_target = '13.0'
+   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
+   s.source = { :git => 'https://github.com/ionic-team/capacitor.git', :tag => package['version'] }
+-  s.source_files = 'Capacitor/Capacitor/*.{swift,h,m}', 'Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
+-  s.module_map = 'Capacitor/Capacitor/Capacitor.modulemap'
+-  s.resources = ['Capacitor/Capacitor/assets/native-bridge.js']
++  s.source_files = 'ios/Capacitor/Capacitor/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/*.{swift,h,m}', 'ios/Capacitor/Capacitor/Plugins/**/*.{swift,h,m}'
++  s.module_map = 'ios/Capacitor/Capacitor/Capacitor.modulemap'
++  s.resources = ['ios/Capacitor/Capacitor/assets/native-bridge.js']
+   s.dependency 'CapacitorCordova'
+   s.swift_version = '5.1'
+ end

--- a/ios/CapacitorCordova.podspec
+++ b/ios/CapacitorCordova.podspec
@@ -1,11 +1,11 @@
-require "json"
-package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 Pod::Spec.new do |s|
-  s.name         = "CapacitorCordova"
+  s.name         = 'CapacitorCordova'
   s.module_name  = 'Cordova'
   s.version      = package['version']
-  s.summary      = "Capacitor Cordova Compatibility Layer"
-  s.homepage     = "https://capacitorjs.com"
+  s.summary      = 'Capacitor Cordova Compatibility Layer'
+  s.homepage     = 'https://capacitorjs.com'
   s.license      = 'MIT'
   s.authors      = { 'Ionic Team' => 'hi@ionicframework.com' }
   s.source       = { :git => 'https://github.com/ionic-team/capacitor', :tag => s.version.to_s }
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'CapacitorCordova/CapacitorCordova/Classes/Public/*.h', 'CapacitorCordova/CapacitorCordova/CapacitorCordova.h'
   s.module_map = 'CapacitorCordova/CapacitorCordova/CapacitorCordova.modulemap'
   s.requires_arc = true
-  s.framework    = "WebKit"
+  s.framework    = 'WebKit'
 end

--- a/ios/CapacitorCordova.podspec.patch
+++ b/ios/CapacitorCordova.podspec.patch
@@ -1,0 +1,15 @@
+--- CapacitorCordova.podspec	2022-10-25 12:06:11.000000000 -0500
++++ NativeCordova.podspec	2022-10-25 12:09:51.000000000 -0500
+@@ -10,9 +10,9 @@
+   s.authors      = { 'Ionic Team' => 'hi@ionicframework.com' }
+   s.source       = { :git => 'https://github.com/ionic-team/capacitor', :tag => s.version.to_s }
+   s.platform     = :ios, 13.0
+-  s.source_files = 'CapacitorCordova/CapacitorCordova/**/*.{h,m}'
+-  s.public_header_files = 'CapacitorCordova/CapacitorCordova/Classes/Public/*.h', 'CapacitorCordova/CapacitorCordova/CapacitorCordova.h'
+-  s.module_map = 'CapacitorCordova/CapacitorCordova/CapacitorCordova.modulemap'
++  s.source_files = 'ios/CapacitorCordova/CapacitorCordova/**/*.{h,m}'
++  s.public_header_files = 'ios/CapacitorCordova/CapacitorCordova/Classes/Public/*.h', 'ios/CapacitorCordova/CapacitorCordova/CapacitorCordova.h'
++  s.module_map = 'ios/CapacitorCordova/CapacitorCordova/CapacitorCordova.modulemap'
+   s.requires_arc = true
+   s.framework    = 'WebKit'
+ end

--- a/ios/package-lock.json
+++ b/ios/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "@capacitor/ios",
-  "version": "3.5.1",
-  "lockfileVersion": 1
-}

--- a/ios/package-lock.json
+++ b/ios/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@capacitor/ios",
+  "version": "3.5.1",
+  "lockfileVersion": 1
+}

--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/sh
-printenv
 set -eo pipefail
 
 patch -u ios/Capacitor.podspec -i ios/Capacitor.podspec.patch

--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/sh
+printenv
+set -eo pipefail
+
+patch -u ios/Capacitor.podspec -i ios/Capacitor.podspec.patch
+patch -u ios/CapacitorCordova.podspec -i ios/CapacitorCordova.podspec.patch
+
+case $1 in
+     lint) 
+       pod spec lint ios/CapacitorCordova.podspec --allow-warnings
+       pod spec lint ios/Capacitor.podspec --allow-warnings;;
+
+     publish) 
+       pod trunk push ios/CapacitorCordova.podspec --allow-warnings
+       pod trunk push ios/Capacitor.podspec --allow-warnings;;
+
+     *) echo "'lint' or 'publish' were not provided. Exiting...";;
+esac
+
+git restore ios/Capacitor.podspec ios/CapacitorCordova.podspec


### PR DESCRIPTION
This removes the need to maintain two separate branches. Having a Capacitor.podspec and CapacitorCordova.podspec in the root of the repo would also solve this problem. I went this patchfile route to avoid any potential drift that having two separate sources of truth would eventually cause. 