### PR TITLE
fix(cli/ios): Read handleApplicationNotifications configuration option

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -418,6 +418,15 @@ export interface CapacitorConfig {
      * @default recommended
      */
     preferredContentMode?: 'recommended' | 'desktop' | 'mobile';
+
+    /**
+     * Configure if Capacitor will handle local/push notifications.
+     * Set to false if you want to use your own UNUserNotificationCenter to handle notifications.
+     *
+     * @since 4.4.1
+     * @default true
+     */
+    handleApplicationNotifications?: boolean;
   };
 
   server?: {

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -131,6 +131,9 @@ internal extension InstanceDescriptor {
             if let preferredMode = (config[keyPath: "ios.preferredContentMode"] as? String) {
                 preferredContentMode = preferredMode
             }
+            if let handleNotifications = config[keyPath: "ios.handleApplicationNotifications"] as? Bool {
+                handleApplicationNotifications = handleNotifications
+            }
         }
     }
     // swiftlint:enable cyclomatic_complexity


### PR DESCRIPTION
`ios.handleApplicationNotifications` is not being read at the moment nor exposed on the types.
Expose it and read the value to allow to use a custom `UNUserNotificationCenter`