### PR TITLE
fix(cli): add vite config to framework detection

### DIFF
--- a/cli/src/framework-configs.ts
+++ b/cli/src/framework-configs.ts
@@ -69,6 +69,12 @@ const FRAMEWORK_CONFIGS: FrameworkConfig[] = [
     priority: 3,
   },
   {
+    name: 'Vite',
+    isMatch: config => hasDependency(config, 'vite'),
+    webDir: 'dist',
+    priority: 2
+  },
+  {
     name: 'Vue',
     isMatch: config => hasDependency(config, '@vue/cli-service'),
     webDir: 'dist',

--- a/cli/src/framework-configs.ts
+++ b/cli/src/framework-configs.ts
@@ -72,7 +72,7 @@ const FRAMEWORK_CONFIGS: FrameworkConfig[] = [
     name: 'Vite',
     isMatch: config => hasDependency(config, 'vite'),
     webDir: 'dist',
-    priority: 2
+    priority: 2,
   },
   {
     name: 'Vue',


### PR DESCRIPTION
Adds vite framework detection to hopefully help with some detection issues around svelte. Older svelte projects used the public directory, but newer ones use vite as the primary bundler which has `dist` as the output directory. This should also add support for other vite-based frameworks such as solidjs.