### PR TITLE
fix(android): Silence deprecation warning on handlePermissionResult

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaInterfaceImpl.java
@@ -26,6 +26,7 @@ public class MockCordovaInterfaceImpl extends CordovaInterfaceImpl {
      * @param grantResults
      * @return true if Cordova handled the permission request, false if not
      */
+    @SuppressWarnings("deprecation")
     public boolean handlePermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
         Pair<CordovaPlugin, Integer> callback = permissionResultCallbacks.getAndRemoveCallback(requestCode);
         if (callback != null) {


### PR DESCRIPTION
We have the same code cordova-android has in here https://github.com/apache/cordova-android/blob/2a84d7c44ddf5eb169f34a2448915a53d0a30fcd/framework/src/org/apache/cordova/CordovaInterfaceImpl.java#L220-L223

So silence the warning for now until it gets replaced there