### PR TITLE
docs(cli): correct since version of handleApplicationNotifications

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -432,7 +432,7 @@ export interface CapacitorConfig {
      * Configure if Capacitor will handle local/push notifications.
      * Set to false if you want to use your own UNUserNotificationCenter to handle notifications.
      *
-     * @since 4.4.1
+     * @since 4.5.0
      * @default true
      */
     handleApplicationNotifications?: boolean;


### PR DESCRIPTION
4.4.1 was never released, so the change was made in 4.5.0