### PR TITLE
fix(android): get application/x-www-form-urlencoded as string

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -188,8 +188,6 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                 dataString = call.getString("data");
             }
             this.writeRequestBody(dataString != null ? dataString : "");
-        } else if (contentType.contains("application/x-www-form-urlencoded")) {
-            this.writeRequestBody(body.toString());
         } else {
             this.writeRequestBody(body.toString());
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -189,20 +189,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
             }
             this.writeRequestBody(dataString != null ? dataString : "");
         } else if (contentType.contains("application/x-www-form-urlencoded")) {
-            StringBuilder builder = new StringBuilder();
-
-            JSObject obj = body.toJSObject();
-            Iterator<String> keys = obj.keys();
-            while (keys.hasNext()) {
-                String key = keys.next();
-                Object d = obj.get(key);
-                builder.append(key).append("=").append(URLEncoder.encode(d.toString(), "UTF-8"));
-
-                if (keys.hasNext()) {
-                    builder.append("&");
-                }
-            }
-            this.writeRequestBody(builder.toString());
+            this.writeRequestBody(body.toString());
         } else {
             this.writeRequestBody(body.toString());
         }


### PR DESCRIPTION
As far as I understand, when using `application/x-www-form-urlencoded` you send a string, so that's why the `body.toJSObject()` is crashing, because it's a string, not a JSObject.

The PR removes the whole `application/x-www-form-urlencoded` else and goes directly to the final else where it read the body as string.

If you think there might be bases where the `application/x-www-form-urlencoded` could be getting a `JSObject`, let me know and I'll change the code to catch the JSON exception and fallback to string in that case.

closes https://github.com/ionic-team/capacitor/issues/5996