### PR TITLE
fix(ios): encode whitespace in http plugin urls

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
@@ -3,10 +3,6 @@ import Foundation
 @objc(CAPHttpPlugin)
 public class CAPHttpPlugin: CAPPlugin {
     @objc func http(_ call: CAPPluginCall, _ httpMethod: String?) {
-        // Protect against bad values from JS before calling request
-        guard let url = call.getString("url") else { return call.reject("Must provide a URL"); }
-        guard var _ = URL(string: url) else { return call.reject("Invalid URL"); }
-
         do {
             try HttpRequestHandler.request(call, httpMethod, self.bridge?.config)
         } catch let error {

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -141,7 +141,7 @@ class HttpRequestHandler {
     }
 
     public static func request(_ call: CAPPluginCall, _ httpMethod: String?, _ config: InstanceConfiguration?) throws {
-        guard let urlString = call.getString("url") else { throw URLError(.badURL) }
+        guard let urlString = call.getString("url")?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { throw URLError(.badURL) }
         let method = httpMethod ?? call.getString("method", "GET")
 
         // swiftlint:disable force_cast


### PR DESCRIPTION
I've removed the url validation checks on `CapacitorHttp.swift` because they are also done on `HttpRequestHandler.swift`.

The fix encodes the provided url so whitespaces can be used

closes https://github.com/ionic-team/capacitor/issues/6122