### PR TITLE
Capacitor HTTP fetch API support

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -418,7 +418,7 @@ const initBridge = (w: any): void => {
               request.url.startsWith('https:')
             )
           ) {
-            return window.CapacitorWebFetch(resource, options);
+            return win.CapacitorWebFetch(resource, options);
           }
 
           try {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -409,13 +409,16 @@ const initBridge = (w: any): void => {
           resource: RequestInfo | URL,
           options?: RequestInit,
         ) => {
+          // Parse the request arguments to a standard Request object, to support all fetch function signatures.
+          const request = new Request(resource, options);
+
           if (
             !(
-              resource.toString().startsWith('http:') ||
-              resource.toString().startsWith('https:')
+              request.url.startsWith('http:') ||
+              request.url.startsWith('https:')
             )
           ) {
-            return win.CapacitorWebFetch(resource, options);
+            return window.CapacitorWebFetch(resource, options);
           }
 
           try {
@@ -424,10 +427,10 @@ const initBridge = (w: any): void => {
               'CapacitorHttp',
               'request',
               {
-                url: resource,
-                method: options?.method ? options.method : undefined,
-                data: options?.body ? options.body : undefined,
-                headers: options?.headers ? options.headers : undefined,
+                url: request.url,
+                method: request.method,
+                data: request.body,
+                headers: Object.fromEntries(request.headers)
               },
             );
 

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -422,6 +422,13 @@ const initBridge = (w: any): void => {
           }
 
           try {
+            // Parse data from the request body.
+            let requestData;
+
+            if (request.body) {
+              requestData = await new Response(request.body).json();
+            }
+            
             // intercept request & pass to the bridge
             const nativeResponse: HttpResponse = await cap.nativePromise(
               'CapacitorHttp',
@@ -429,7 +436,7 @@ const initBridge = (w: any): void => {
               {
                 url: request.url,
                 method: request.method,
-                data: request.body,
+                data: requestData,
                 headers: Object.fromEntries(request.headers)
               },
             );


### PR DESCRIPTION
The Capacitor HTTP plugin currently requires that all request to the browser fetch API is in the form ```fetch(resource: string, options: object)``` in order to proxy request through the native HTTP plugin. This is confusing, as the fetch API supports other formats like ```fetch(resource: Request)``` which is then not proxied, but instead sent through the browser fetch API directly which may leads to CORS issues.

This fixes [bug: CapacitorHTTP fetch with Request object fails #6174](https://github.com/ionic-team/capacitor/issues/6174)