### PR TITLE
feat: add target configuration

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -282,6 +282,7 @@ async function loadIOSConfig(
   const platformDir = extConfig.ios?.path ?? 'ios';
   const platformDirAbs = resolve(rootDir, platformDir);
   const scheme = extConfig.ios?.scheme ?? 'App';
+  const target = extConfig.ios?.target ?? extConfig.ios?.scheme ?? 'App';
   const nativeProjectDir = 'App';
   const nativeProjectDirAbs = resolve(platformDirAbs, nativeProjectDir);
   const nativeTargetDir = `${nativeProjectDir}/App`;
@@ -306,6 +307,7 @@ async function loadIOSConfig(
     platformDir,
     platformDirAbs,
     scheme,
+    target,
     cordovaPluginsDir,
     cordovaPluginsDirAbs: resolve(platformDirAbs, cordovaPluginsDir),
     nativeProjectDir,

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -299,6 +299,21 @@ export interface CapacitorConfig {
     scheme?: string;
 
     /**
+     * iOS build target to use.
+     *
+     * Usually this matches your app's target in Xcode. You can use the
+     * following command to list target:
+     *
+     * ```shell
+     * xcodebuild -workspace ios/App/App.xcworkspace -list
+     * ```
+     *
+     * @since 3.0.0
+     * @default App
+     */
+    target?: string;
+
+    /**
      * User agent of Capacitor Web View on iOS.
      *
      * Overrides global `overrideUserAgent` option.

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -112,6 +112,7 @@ export interface IOSConfig extends PlatformConfig {
   readonly minVersion: string;
   readonly podPath: string;
   readonly scheme: string;
+  readonly target: string;
   readonly webDir: Promise<string>;
   readonly webDirAbs: Promise<string>;
   readonly nativeProjectDir: string;

--- a/cli/src/ios/run.ts
+++ b/cli/src/ios/run.ts
@@ -48,7 +48,7 @@ export async function runIOS(
     }),
   );
 
-  const appName = `${runScheme}.app`;
+  const appName = `${config.ios.target}.app`;
   const appPath = resolve(
     derivedDataPath,
     'Build/Products',


### PR DESCRIPTION
This change allows the target name to be configured. If it's not set, it will fallback to the current behavior of using the scheme. If scheme is not set, it falls back to the current behavior of `"App"`

This resolves  the following:
- #5036

Related:
- #5131
- #4166
- #3993