### PR TITLE
fix(ios/android): better http error handling

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
@@ -34,8 +34,7 @@ public class CapacitorHttp extends Plugin {
                     JSObject response = HttpRequestHandler.request(call, httpMethod);
                     call.resolve(response);
                 } catch (Exception e) {
-                    System.out.println(e.toString());
-                    call.reject(e.getClass().getSimpleName(), e);
+                    call.reject(e.getLocalizedMessage(), e.getClass().getSimpleName(), e);
                 }
             }
         };

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -170,7 +170,7 @@ class HttpRequestHandler {
             } catch {
                 // Explicitly reject if the http request body was not set successfully,
                 // so as to not send a known malformed request, and to provide the developer with additional context.
-                call.reject("Error", "REQUEST", error, [:])
+                call.reject(error.localizedDescription, (error as NSError).domain, error, nil)
                 return
             }
         }
@@ -180,7 +180,8 @@ class HttpRequestHandler {
         let task = urlSession.dataTask(with: urlRequest) { (data, response, error) in
             urlSession.invalidateAndCancel()
 
-            if error != nil {
+            if let error = error {
+                call.reject(error.localizedDescription, (error as NSError).domain, error, nil)
                 return
             }
 


### PR DESCRIPTION
On Android:
remove the System.out line
Return the error localized message first and then the exception name as rejection code

On iOS:
Add missing rejection on data task error
return the localized message instead of "Error" and the error domain as rejection code instead of "REQUEST" on the existing and new rejection

closes https://github.com/ionic-team/capacitor/issues/6024
closes https://github.com/ionic-team/capacitor/pull/6033