### PR TITLE
fix(ios): CapacitorHttp cannot use delete method

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
@@ -30,7 +30,7 @@ public class CAPHttpPlugin: CAPPlugin {
         http(call, "PATCH")
     }
 
-    @objc func del(_ call: CAPPluginCall) {
+    @objc func delete(_ call: CAPPluginCall) {
         http(call, "DELETE")
     }
 }


### PR DESCRIPTION
Fixes #6219 