### PR TITLE
Fix parsing non-object JSON response in CapacitorHttp plugin

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -378,7 +378,7 @@ const nativeBridge = (function (exports) {
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
                                 headers: (options === null || options === void 0 ? void 0 : options.headers) ? options.headers : undefined,
                             });
-                            const data = typeof nativeResponse.data === 'string'
+                            const data = !nativeResponse.headers['Content-Type'].startsWith('application/json')
                                 ? nativeResponse.data
                                 : JSON.stringify(nativeResponse.data);
                             // intercept & parse response before returning
@@ -510,7 +510,7 @@ const nativeBridge = (function (exports) {
                                     this.status = nativeResponse.status;
                                     this.response = nativeResponse.data;
                                     this.responseText =
-                                        typeof nativeResponse.data === 'string'
+                                        !nativeResponse.headers['Content-Type'].startsWith('application/json')
                                             ? nativeResponse.data
                                             : JSON.stringify(nativeResponse.data);
                                     this.responseURL = nativeResponse.url;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -305,6 +305,9 @@ public class HttpRequestHandler {
                 return new JSONObject().put("flag", "false");
             } else if (input.trim().length() <= 0) {
                 return "";
+             } else if (input.trim().matches("^\".*\"$")) {
+                // a string enclosed in " " is a json value, return the string without the quotes
+                return input.trim().substring(1, input.trim().length() - 1);
             } else {
                 try {
                     return new JSObject(input);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -432,7 +432,7 @@ const initBridge = (w: any): void => {
             );
 
             const data =
-              typeof nativeResponse.data === 'string'
+              !nativeResponse.headers['Content-Type'].startsWith('application/json')
                 ? nativeResponse.data
                 : JSON.stringify(nativeResponse.data);
             // intercept & parse response before returning
@@ -593,7 +593,7 @@ const initBridge = (w: any): void => {
                   this.status = nativeResponse.status;
                   this.response = nativeResponse.data;
                   this.responseText =
-                    typeof nativeResponse.data === 'string'
+                    !nativeResponse.headers['Content-Type'].startsWith('application/json')
                       ? nativeResponse.data
                       : JSON.stringify(nativeResponse.data);
                   this.responseURL = nativeResponse.url;

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -31,7 +31,7 @@ private enum ResponseType: String {
 /// - Returns: The parsed value or an error
 func tryParseJson(_ data: Data) -> Any {
     do {
-        return try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
+        return try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .fragmentsAllowed])
     } catch {
         return error.localizedDescription
     }

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -378,7 +378,7 @@ const nativeBridge = (function (exports) {
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
                                 headers: (options === null || options === void 0 ? void 0 : options.headers) ? options.headers : undefined,
                             });
-                            const data = typeof nativeResponse.data === 'string'
+                            const data = !nativeResponse.headers['Content-Type'].startsWith('application/json')
                                 ? nativeResponse.data
                                 : JSON.stringify(nativeResponse.data);
                             // intercept & parse response before returning
@@ -510,7 +510,7 @@ const nativeBridge = (function (exports) {
                                     this.status = nativeResponse.status;
                                     this.response = nativeResponse.data;
                                     this.responseText =
-                                        typeof nativeResponse.data === 'string'
+                                        !nativeResponse.headers['Content-Type'].startsWith('application/json')
                                             ? nativeResponse.data
                                             : JSON.stringify(nativeResponse.data);
                                     this.responseURL = nativeResponse.url;


### PR DESCRIPTION
The following valid json 
```json
"hello world"
```
is not handled correctly in the CapacitorHttp core plugin. This PR fixes that, although on Android there might be some improvements possible.

See https://github.com/JanMisker/Capacitor-JSONParseError for a simple app that reproduces this error.