### PR TITLE
Fix for bug #6237 for allowing number parameters also in iOS requests

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -77,7 +77,11 @@ class HttpRequestHandler {
                             urlSafeParams.append(URLQueryItem(name: key, value: str))
                         }
                     } else {
-                        urlSafeParams.append(URLQueryItem(name: key, value: (value as! String)))
+                        if let valueNumber = value as? Double {
+                            urlSafeParams.append(URLQueryItem(name: key, value: String(valueNumber)))
+                        } else {
+                            urlSafeParams.append(URLQueryItem(name: key, value: String(describing: value)))
+                        }
                     }
                 }
 


### PR DESCRIPTION
This Pull request fixes capacitor http handler not allowing url params as number and gets stuck on emulator. Fixes bug #6237 