### PR TITLE
fix(ios): crash when http headers contain numbers

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -376,7 +376,9 @@ var nativeBridge = (function (exports) {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? JSON.stringify(options.headers) : undefined,
+                                headers: (options === null || options === void 0 ? void 0 : options.headers)
+                                    ? JSON.stringify(options.headers)
+                                    : undefined,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -376,7 +376,7 @@ const nativeBridge = (function (exports) {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? options.headers : undefined,
+                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? JSON.stringify(options.headers) : undefined,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data
@@ -500,7 +500,7 @@ const nativeBridge = (function (exports) {
                                 url: this._url,
                                 method: this._method,
                                 data: body !== null ? body : undefined,
-                                headers: this._headers,
+                                headers: JSON.stringify(this._headers),
                             })
                                 .then((nativeResponse) => {
                                 // intercept & parse response before returning

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -427,7 +427,9 @@ const initBridge = (w: any): void => {
                 url: resource,
                 method: options?.method ? options.method : undefined,
                 data: options?.body ? options.body : undefined,
-                headers: options?.headers ? JSON.stringify(options.headers) : undefined,
+                headers: options?.headers
+                  ? JSON.stringify(options.headers)
+                  : undefined,
               },
             );
 

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -427,7 +427,7 @@ const initBridge = (w: any): void => {
                 url: resource,
                 method: options?.method ? options.method : undefined,
                 data: options?.body ? options.body : undefined,
-                headers: options?.headers ? options.headers : undefined,
+                headers: options?.headers ? JSON.stringify(options.headers) : undefined,
               },
             );
 
@@ -583,7 +583,7 @@ const initBridge = (w: any): void => {
                 url: this._url,
                 method: this._method,
                 data: body !== null ? body : undefined,
-                headers: this._headers,
+                headers: JSON.stringify(this._headers),
               })
               .then((nativeResponse: any) => {
                 // intercept & parse response before returning

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -376,7 +376,9 @@ var nativeBridge = (function (exports) {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? JSON.stringify(options.headers) : undefined,
+                                headers: (options === null || options === void 0 ? void 0 : options.headers)
+                                    ? JSON.stringify(options.headers)
+                                    : undefined,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -376,7 +376,7 @@ const nativeBridge = (function (exports) {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? options.headers : undefined,
+                                headers: (options === null || options === void 0 ? void 0 : options.headers) ? JSON.stringify(options.headers) : undefined,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data
@@ -500,7 +500,7 @@ const nativeBridge = (function (exports) {
                                 url: this._url,
                                 method: this._method,
                                 data: body !== null ? body : undefined,
-                                headers: this._headers,
+                                headers: JSON.stringify(this._headers),
                             })
                                 .then((nativeResponse) => {
                                 // intercept & parse response before returning


### PR DESCRIPTION
Stringify the headers so the native side only gets strings as native headers can only be strings.

closes https://github.com/ionic-team/capacitor/issues/6202