### PR TITLE
chore(core): Add `console.time` and `console.timeEnd` calls to patched network requests

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -370,6 +370,8 @@ const nativeBridge = (function (exports) {
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
                         }
+                        const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
+                        console.time(tag);
                         try {
                             // intercept request & pass to the bridge
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
@@ -386,9 +388,11 @@ const nativeBridge = (function (exports) {
                                 headers: nativeResponse.headers,
                                 status: nativeResponse.status,
                             });
+                            console.timeEnd(tag);
                             return response;
                         }
                         catch (error) {
+                            console.timeEnd(tag);
                             return Promise.reject(error);
                         }
                     };
@@ -492,6 +496,8 @@ const nativeBridge = (function (exports) {
                             !(this._url.startsWith('http:') || this._url.startsWith('https:'))) {
                             return win.CapacitorWebXMLHttpRequest.send.call(this, body);
                         }
+                        const tag = `CapacitorHttp XMLHttpRequest ${Date.now()} ${this._url}`;
+                        console.time(tag);
                         try {
                             this.readyState = 2;
                             // intercept request & pass to the bridge
@@ -518,6 +524,7 @@ const nativeBridge = (function (exports) {
                                     this.dispatchEvent(new Event('load'));
                                     this.dispatchEvent(new Event('loadend'));
                                 }
+                                console.timeEnd(tag);
                             })
                                 .catch((error) => {
                                 this.dispatchEvent(new Event('loadstart'));
@@ -529,6 +536,7 @@ const nativeBridge = (function (exports) {
                                 this.readyState = 4;
                                 this.dispatchEvent(new Event('error'));
                                 this.dispatchEvent(new Event('loadend'));
+                                console.timeEnd(tag);
                             });
                         }
                         catch (error) {
@@ -541,6 +549,7 @@ const nativeBridge = (function (exports) {
                             this.readyState = 4;
                             this.dispatchEvent(new Event('error'));
                             this.dispatchEvent(new Event('loadend'));
+                            console.timeEnd(tag);
                         }
                     };
                     // XHR patch getAllResponseHeaders

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -356,7 +356,7 @@ async function generateCordovaPodspec(
       `s.vendored_frameworks = '${customFrameworks.join(`', '`)}'`,
     );
     frameworkDeps.push(
-      `s.exclude_files = 'sources/**/*.framework/Headers/*.h'`,
+      `s.exclude_files = 'sources/**/*.framework/Headers/*.h', 'sources/**/*.framework/PrivateHeaders/*.h'`,
     );
   }
   if (sourceFrameworks.length > 0) {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -578,7 +578,7 @@ const initBridge = (w: any): void => {
             return win.CapacitorWebXMLHttpRequest.send.call(this, body);
           }
 
-          const tag = `CapacitorHttp XMLHttpRequest ${Date.now()} ${this._url}`
+          const tag = `CapacitorHttp XMLHttpRequest ${Date.now()} ${this._url}`;
           console.time(tag);
 
           try {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -219,12 +219,12 @@ const initBridge = (w: any): void => {
 
           c.groupCollapsed(
             '%cresult %c' +
-            result.pluginId +
-            '.' +
-            result.methodName +
-            ' (#' +
-            result.callbackId +
-            ')',
+              result.pluginId +
+              '.' +
+              result.methodName +
+              ' (#' +
+              result.callbackId +
+              ')',
             tagStyles,
             'font-style: italic; font-weight: bold; color: #444',
           );
@@ -248,12 +248,12 @@ const initBridge = (w: any): void => {
         if (isFullConsole(c)) {
           c.groupCollapsed(
             '%cnative %c' +
-            call.pluginId +
-            '.' +
-            call.methodName +
-            ' (#' +
-            call.callbackId +
-            ')',
+              call.pluginId +
+              '.' +
+              call.methodName +
+              ' (#' +
+              call.callbackId +
+              ')',
             'font-weight: lighter; color: gray',
             'font-weight: bold; color: #000',
           );
@@ -321,7 +321,7 @@ const initBridge = (w: any): void => {
 
       if (doPatchCookies) {
         Object.defineProperty(document, 'cookie', {
-          get: function() {
+          get: function () {
             if (platform === 'ios') {
               // Use prompt to synchronously get cookies.
               // https://stackoverflow.com/questions/29249132/wkwebview-complex-communication-between-javascript-native-code/49474323#49474323
@@ -338,13 +338,13 @@ const initBridge = (w: any): void => {
               return win.CapacitorCookiesAndroidInterface.getCookies();
             }
           },
-          set: function(val) {
+          set: function (val) {
             const cookiePairs = val.split(';');
             const domainSection = val.toLowerCase().split('domain=')[1];
             const domain =
               cookiePairs.length > 1 &&
-                domainSection != null &&
-                domainSection.length > 0
+              domainSection != null &&
+              domainSection.length > 0
                 ? domainSection.split(';')[0].trim()
                 : '';
 
@@ -452,39 +452,39 @@ const initBridge = (w: any): void => {
         };
 
         // XHR event listeners
-        const addEventListeners = function() {
-          this.addEventListener('abort', function() {
+        const addEventListeners = function () {
+          this.addEventListener('abort', function () {
             if (typeof this.onabort === 'function') this.onabort();
           });
 
-          this.addEventListener('error', function() {
+          this.addEventListener('error', function () {
             if (typeof this.onerror === 'function') this.onerror();
           });
 
-          this.addEventListener('load', function() {
+          this.addEventListener('load', function () {
             if (typeof this.onload === 'function') this.onload();
           });
 
-          this.addEventListener('loadend', function() {
+          this.addEventListener('loadend', function () {
             if (typeof this.onloadend === 'function') this.onloadend();
           });
 
-          this.addEventListener('loadstart', function() {
+          this.addEventListener('loadstart', function () {
             if (typeof this.onloadstart === 'function') this.onloadstart();
           });
 
-          this.addEventListener('readystatechange', function() {
+          this.addEventListener('readystatechange', function () {
             if (typeof this.onreadystatechange === 'function')
               this.onreadystatechange();
           });
 
-          this.addEventListener('timeout', function() {
+          this.addEventListener('timeout', function () {
             if (typeof this.ontimeout === 'function') this.ontimeout();
           });
         };
 
         // XHR patch abort
-        window.XMLHttpRequest.prototype.abort = function() {
+        window.XMLHttpRequest.prototype.abort = function () {
           if (
             this._url == null ||
             !(this._url.startsWith('http:') || this._url.startsWith('https:'))
@@ -497,7 +497,7 @@ const initBridge = (w: any): void => {
         };
 
         // XHR patch open
-        window.XMLHttpRequest.prototype.open = function(
+        window.XMLHttpRequest.prototype.open = function (
           method: string,
           url: string,
         ) {
@@ -519,10 +519,10 @@ const initBridge = (w: any): void => {
               writable: true,
             },
             readyState: {
-              get: function() {
+              get: function () {
                 return this._readyState ?? 0;
               },
-              set: function(val: number) {
+              set: function (val: number) {
                 this._readyState = val;
                 this.dispatchEvent(new Event('readystatechange'));
               },
@@ -550,7 +550,7 @@ const initBridge = (w: any): void => {
         };
 
         // XHR patch set request header
-        window.XMLHttpRequest.prototype.setRequestHeader = function(
+        window.XMLHttpRequest.prototype.setRequestHeader = function (
           header: string,
           value: string,
         ) {
@@ -568,7 +568,7 @@ const initBridge = (w: any): void => {
         };
 
         // XHR patch send
-        window.XMLHttpRequest.prototype.send = function(
+        window.XMLHttpRequest.prototype.send = function (
           body?: Document | XMLHttpRequestBodyInit,
         ) {
           if (
@@ -637,7 +637,7 @@ const initBridge = (w: any): void => {
         };
 
         // XHR patch getAllResponseHeaders
-        window.XMLHttpRequest.prototype.getAllResponseHeaders = function() {
+        window.XMLHttpRequest.prototype.getAllResponseHeaders = function () {
           if (
             this._url == null ||
             !(this._url.startsWith('http:') || this._url.startsWith('https:'))
@@ -657,7 +657,7 @@ const initBridge = (w: any): void => {
         };
 
         // XHR patch getResponseHeader
-        window.XMLHttpRequest.prototype.getResponseHeader = function(name) {
+        window.XMLHttpRequest.prototype.getResponseHeader = function (name) {
           if (
             this._url == null ||
             !(this._url.startsWith('http:') || this._url.startsWith('https:'))
@@ -844,7 +844,7 @@ const initBridge = (w: any): void => {
     };
 
     if (win?.androidBridge) {
-      win.androidBridge.onmessage = function(event) {
+      win.androidBridge.onmessage = function (event) {
         returnResult(JSON.parse(event.data));
       };
     }
@@ -954,12 +954,12 @@ initBridge(
   typeof globalThis !== 'undefined'
     ? (globalThis as WindowCapacitor)
     : typeof self !== 'undefined'
-      ? (self as WindowCapacitor)
-      : typeof window !== 'undefined'
-        ? (window as WindowCapacitor)
-        : typeof global !== 'undefined'
-          ? (global as WindowCapacitor)
-          : ({} as WindowCapacitor),
+    ? (self as WindowCapacitor)
+    : typeof window !== 'undefined'
+    ? (window as WindowCapacitor)
+    : typeof global !== 'undefined'
+    ? (global as WindowCapacitor)
+    : ({} as WindowCapacitor),
 );
 
 // Export only for tests

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -370,6 +370,8 @@ const nativeBridge = (function (exports) {
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
                         }
+                        const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
+                        console.time(tag);
                         try {
                             // intercept request & pass to the bridge
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
@@ -386,9 +388,11 @@ const nativeBridge = (function (exports) {
                                 headers: nativeResponse.headers,
                                 status: nativeResponse.status,
                             });
+                            console.timeEnd(tag);
                             return response;
                         }
                         catch (error) {
+                            console.timeEnd(tag);
                             return Promise.reject(error);
                         }
                     };
@@ -492,6 +496,8 @@ const nativeBridge = (function (exports) {
                             !(this._url.startsWith('http:') || this._url.startsWith('https:'))) {
                             return win.CapacitorWebXMLHttpRequest.send.call(this, body);
                         }
+                        const tag = `CapacitorHttp XMLHttpRequest ${Date.now()} ${this._url}`;
+                        console.time(tag);
                         try {
                             this.readyState = 2;
                             // intercept request & pass to the bridge
@@ -518,6 +524,7 @@ const nativeBridge = (function (exports) {
                                     this.dispatchEvent(new Event('load'));
                                     this.dispatchEvent(new Event('loadend'));
                                 }
+                                console.timeEnd(tag);
                             })
                                 .catch((error) => {
                                 this.dispatchEvent(new Event('loadstart'));
@@ -529,6 +536,7 @@ const nativeBridge = (function (exports) {
                                 this.readyState = 4;
                                 this.dispatchEvent(new Event('error'));
                                 this.dispatchEvent(new Event('loadend'));
+                                console.timeEnd(tag);
                             });
                         }
                         catch (error) {
@@ -541,6 +549,7 @@ const nativeBridge = (function (exports) {
                             this.readyState = 4;
                             this.dispatchEvent(new Event('error'));
                             this.dispatchEvent(new Event('loadend'));
+                            console.timeEnd(tag);
                         }
                     };
                     // XHR patch getAllResponseHeaders


### PR DESCRIPTION
This allows for _some_ visibility into the native network requests being made. In the Chrome performance tools, this shows up in the timeline like this:
![Screenshot 2023-01-25 at 5 04 39 PM](https://user-images.githubusercontent.com/24440751/214899344-24fe84f3-e0f2-452a-8ff8-f3fbdde76d23.png)

It also will log to the console with the tag provided and the total time:
```
CapacitorHttp XMLHttpRequest {timestamp at start} http://localhost:8080/delay/3: 3219.450ms
```

In Safari Dev tools, the only thing that shows up is the timestamp in the console.