### PR TITLE
feat(android): add ability to create config from a custom file path

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1512,7 +1512,7 @@ public class Bridge {
                 config
             );
 
-            if (webView instanceof  CapacitorWebView) {
+            if (webView instanceof CapacitorWebView) {
                 CapacitorWebView capacitorWebView = (CapacitorWebView) webView;
                 capacitorWebView.setBridge(bridge);
             }

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1511,6 +1511,12 @@ public class Bridge {
                 preferences,
                 config
             );
+
+            if (webView instanceof  CapacitorWebView) {
+                CapacitorWebView capacitorWebView = (CapacitorWebView) webView;
+                capacitorWebView.setBridge(bridge);
+            }
+
             bridge.setCordovaWebView(mockWebView);
             bridge.setWebViewListeners(webViewListeners);
             bridge.setRouteProcessor(routeProcessor);

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -78,7 +78,7 @@ public class CapConfig {
             this.configJSON = config;
         } else {
             // Load the capacitor.config.json
-            loadConfig(assetManager);
+            loadConfigFromAssets(assetManager, null);
         }
 
         deserializeConfig(null);
@@ -98,7 +98,47 @@ public class CapConfig {
             return config;
         }
 
-        config.loadConfig(context.getAssets());
+        config.loadConfigFromAssets(context.getAssets(), null);
+        config.deserializeConfig(context);
+        return config;
+    }
+
+    /**
+     * Constructs a Capacitor Configuration from config.json file within the app assets.
+     *
+     * @param context The context.
+     * @param path A path relative to the root assets directory.
+     * @return A loaded config file, if successful.
+     */
+    public static CapConfig loadFromAssets(Context context, String path) {
+        CapConfig config = new CapConfig();
+
+        if (context == null) {
+            Logger.error("Capacitor Config could not be created from file. Context must not be null.");
+            return config;
+        }
+
+        config.loadConfigFromAssets(context.getAssets(), path);
+        config.deserializeConfig(context);
+        return config;
+    }
+
+    /**
+     * Constructs a Capacitor Configuration from config.json file within the app file-space.
+     *
+     * @param context The context.
+     * @param path A path relative to the root assets directory.
+     * @return A loaded config file, if successful.
+     */
+    public static CapConfig loadFromFile(Context context, String path) {
+        CapConfig config = new CapConfig();
+
+        if (context == null) {
+            Logger.error("Capacitor Config could not be created from file. Context must not be null.");
+            return config;
+        }
+
+        config.loadConfigFromAssets(context.getAssets(), path);
         config.deserializeConfig(context);
         return config;
     }
@@ -142,13 +182,41 @@ public class CapConfig {
 
     /**
      * Loads a Capacitor Configuration JSON file into a Capacitor Configuration object.
+     * An optional path string can be provided to look for the config in a subdirectory path.
      */
-    private void loadConfig(AssetManager assetManager) {
+    private void loadConfigFromAssets(AssetManager assetManager, String path) {
+        if (path == null) {
+            path = "";
+        } else {
+            // Add slash at the end to form a proper file path if going deeper in assets dir
+            if (path.charAt(path.length()-1) != '/') {
+                path = path + "/";
+            }
+        }
+
         try {
-            String jsonString = readFile(assetManager, "capacitor.config.json");
+            String jsonString = readFile(assetManager, path + "capacitor.config.json");
             configJSON = new JSONObject(jsonString);
         } catch (IOException ex) {
             Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);
+        } catch (JSONException ex) {
+            Logger.error("Unable to parse capacitor.config.json. Make sure it's valid json", ex);
+        }
+    }
+
+    /**
+     * Loads a Capacitor Configuration JSON file into a Capacitor Configuration object.
+     * An optional path string can be provided to look for the config in a subdirectory path.
+     */
+    private void loadConfigFromFile(String path) {
+        if (path == null) {
+            path = "";
+        }
+
+        try {
+            //String jsonString = readFile(assetManager, path + "capacitor.config.json");
+            String jsonString = "";
+            configJSON = new JSONObject(jsonString);
         } catch (JSONException ex) {
             Logger.error("Unable to parse capacitor.config.json. Make sure it's valid json", ex);
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -10,7 +10,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
 import androidx.annotation.Nullable;
 import com.getcapacitor.util.JSONUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -191,7 +190,7 @@ public class CapConfig {
             path = "";
         } else {
             // Add slash at the end to form a proper file path if going deeper in assets dir
-            if (path.charAt(path.length()-1) != '/') {
+            if (path.charAt(path.length() - 1) != '/') {
                 path = path + "/";
             }
         }
@@ -215,7 +214,7 @@ public class CapConfig {
             path = "";
         } else {
             // Add slash at the end to form a proper file path if going deeper in assets dir
-            if (path.charAt(path.length()-1) != '/') {
+            if (path.charAt(path.length() - 1) != '/') {
                 path = path + "/";
             }
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -3,13 +3,15 @@ package com.getcapacitor;
 import static com.getcapacitor.Bridge.CAPACITOR_HTTP_SCHEME;
 import static com.getcapacitor.Bridge.DEFAULT_ANDROID_WEBVIEW_VERSION;
 import static com.getcapacitor.Bridge.MINIMUM_ANDROID_WEBVIEW_VERSION;
-import static com.getcapacitor.FileUtils.readFile;
+import static com.getcapacitor.FileUtils.readFileFromAssets;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
 import androidx.annotation.Nullable;
 import com.getcapacitor.util.JSONUtils;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -138,7 +140,7 @@ public class CapConfig {
             return config;
         }
 
-        config.loadConfigFromAssets(context.getAssets(), path);
+        config.loadConfigFromFile(path);
         config.deserializeConfig(context);
         return config;
     }
@@ -195,7 +197,7 @@ public class CapConfig {
         }
 
         try {
-            String jsonString = readFile(assetManager, path + "capacitor.config.json");
+            String jsonString = readFileFromAssets(assetManager, path + "capacitor.config.json");
             configJSON = new JSONObject(jsonString);
         } catch (IOException ex) {
             Logger.error("Unable to load capacitor.config.json. Run npx cap copy first", ex);
@@ -211,14 +213,21 @@ public class CapConfig {
     private void loadConfigFromFile(String path) {
         if (path == null) {
             path = "";
+        } else {
+            // Add slash at the end to form a proper file path if going deeper in assets dir
+            if (path.charAt(path.length()-1) != '/') {
+                path = path + "/";
+            }
         }
 
         try {
-            //String jsonString = readFile(assetManager, path + "capacitor.config.json");
-            String jsonString = "";
+            File configFile = new File(path + "capacitor.config.json");
+            String jsonString = FileUtils.readFileFromDisk(configFile);
             configJSON = new JSONObject(jsonString);
         } catch (JSONException ex) {
             Logger.error("Unable to parse capacitor.config.json. Make sure it's valid json", ex);
+        } catch (IOException ex) {
+            Logger.error("Unable to load capacitor.config.json.", ex);
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -128,7 +128,7 @@ public class CapConfig {
      * Constructs a Capacitor Configuration from config.json file within the app file-space.
      *
      * @param context The context.
-     * @param path A path relative to the root assets directory.
+     * @param path A path relative to the root of the app file-space.
      * @return A loaded config file, if successful.
      */
     public static CapConfig loadFromFile(Context context, String path) {

--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -11,14 +11,25 @@ import android.webkit.WebView;
 public class CapacitorWebView extends WebView {
 
     private BaseInputConnection capInputConnection;
+    private Bridge bridge;
 
     public CapacitorWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
+    public void setBridge(Bridge bridge) {
+        this.bridge = bridge;
+    }
+
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        CapConfig config = CapConfig.loadDefault(getContext());
+        CapConfig config;
+        if (bridge != null) {
+            config = bridge.getConfig();
+        } else {
+            config = CapConfig.loadDefault(getContext());
+        }
+
         boolean captureInput = config.isInputCaptured();
         if (captureInput) {
             if (capInputConnection == null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -36,7 +36,6 @@ import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -156,7 +155,7 @@ public class FileUtils {
             StringBuilder buffer = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
-                buffer.append(line + "\n");
+                buffer.append(line).append("\n");
             }
 
             return buffer.toString();
@@ -175,7 +174,7 @@ public class FileUtils {
             StringBuilder buffer = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
-                buffer.append(line + "\n");
+                buffer.append(line).append("\n");
             }
 
             return buffer.toString();

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -36,7 +36,9 @@ import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -142,15 +144,34 @@ public class FileUtils {
     }
 
     /**
-     * Read a plaintext file.
+     * Read a plaintext file from the assets directory.
      *
      * @param assetManager Used to open the file.
      * @param fileName The path of the file to read.
      * @return The contents of the file path.
      * @throws IOException Thrown if any issues reading the provided file path.
      */
-    static String readFile(AssetManager assetManager, String fileName) throws IOException {
+    static String readFileFromAssets(AssetManager assetManager, String fileName) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(assetManager.open(fileName)))) {
+            StringBuilder buffer = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line + "\n");
+            }
+
+            return buffer.toString();
+        }
+    }
+
+    /**
+     * Read a plaintext file from within the app disk space.
+     *
+     * @param file The file to read.
+     * @return The contents of the file path.
+     * @throws IOException Thrown if any issues reading the provided file path.
+     */
+    static String readFileFromDisk(File file) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             StringBuilder buffer = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {

--- a/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSExport.java
@@ -1,6 +1,6 @@
 package com.getcapacitor;
 
-import static com.getcapacitor.FileUtils.readFile;
+import static com.getcapacitor.FileUtils.readFileFromAssets;
 
 import android.content.Context;
 import android.text.TextUtils;
@@ -24,7 +24,7 @@ public class JSExport {
     public static String getCordovaJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context.getAssets(), "public/cordova.js");
+            fileContent = readFileFromAssets(context.getAssets(), "public/cordova.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova.js file, Cordova plugins will not work");
         }
@@ -34,7 +34,7 @@ public class JSExport {
     public static String getCordovaPluginsFileJS(Context context) {
         String fileContent = "";
         try {
-            fileContent = readFile(context.getAssets(), "public/cordova_plugins.js");
+            fileContent = readFileFromAssets(context.getAssets(), "public/cordova_plugins.js");
         } catch (IOException ex) {
             Logger.error("Unable to read public/cordova_plugins.js file, Cordova plugins will not work");
         }
@@ -91,7 +91,7 @@ public class JSExport {
                     }
                 }
             } else {
-                return readFile(context.getAssets(), path);
+                return readFileFromAssets(context.getAssets(), path);
             }
         } catch (IOException ex) {
             Logger.warn("Unable to read file at path " + path);


### PR DESCRIPTION
This PR adds the ability to create configs from a provided file path. It will be used by Portals to allow config files to be contained within specific Portal subdirs in assets and also to allow them to be contained within live update files on disk. 

This PR also fixes a bug that was found where CapacitorWebView may not read the correct config that was provided to Capacitor when used with Portals.