### PR TITLE
chore(ios-template): git ignore App/output folder produced by cap build ios

### DIFF
--- a/ios-template/.gitignore
+++ b/ios-template/.gitignore
@@ -1,5 +1,6 @@
 App/build
 App/Pods
+App/output
 App/Podfile.lock
 App/App/public
 DerivedData


### PR DESCRIPTION
The cap build ios command will produce an ipa file in the folder App/output. This change ensures that the folder is ignored by source control