### PR TITLE
chore(http): make interfaces public

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -45,7 +45,7 @@ public class HttpRequestHandler {
 
         static final ResponseType DEFAULT = TEXT;
 
-        static ResponseType parse(String value) {
+        public static ResponseType parse(String value) {
             for (ResponseType responseType : values()) {
                 if (responseType.name.equalsIgnoreCase(value)) {
                     return responseType;
@@ -58,16 +58,16 @@ public class HttpRequestHandler {
     /**
      * Internal builder class for building a CapacitorHttpUrlConnection
      */
-    private static class HttpURLConnectionBuilder {
+    public static class HttpURLConnectionBuilder {
 
-        private Integer connectTimeout;
-        private Integer readTimeout;
-        private Boolean disableRedirects;
-        private JSObject headers;
-        private String method;
-        private URL url;
+        public Integer connectTimeout;
+        public Integer readTimeout;
+        public Boolean disableRedirects;
+        public JSObject headers;
+        public String method;
+        public URL url;
 
-        private CapacitorHttpUrlConnection connection;
+        public CapacitorHttpUrlConnection connection;
 
         public HttpURLConnectionBuilder setConnectTimeout(Integer connectTimeout) {
             this.connectTimeout = connectTimeout;
@@ -188,7 +188,7 @@ public class HttpRequestHandler {
      * @throws IOException Thrown if the InputStream is unable to be parsed correctly
      * @throws JSONException Thrown if the JSON is unable to be parsed
      */
-    private static JSObject buildResponse(CapacitorHttpUrlConnection connection) throws IOException, JSONException {
+    public static JSObject buildResponse(CapacitorHttpUrlConnection connection) throws IOException, JSONException {
         return buildResponse(connection, ResponseType.DEFAULT);
     }
 
@@ -200,7 +200,7 @@ public class HttpRequestHandler {
      * @throws IOException Thrown if the InputStream is unable to be parsed correctly
      * @throws JSONException Thrown if the JSON is unable to be parsed
      */
-    private static JSObject buildResponse(CapacitorHttpUrlConnection connection, ResponseType responseType)
+    public static JSObject buildResponse(CapacitorHttpUrlConnection connection, ResponseType responseType)
         throws IOException, JSONException {
         int statusCode = connection.getResponseCode();
 
@@ -226,7 +226,7 @@ public class HttpRequestHandler {
      * @throws IOException Thrown if the InputStreams cannot be properly parsed
      * @throws JSONException Thrown if the JSON is malformed when parsing as JSON
      */
-    static Object readData(ICapacitorHttpUrlConnection connection, ResponseType responseType) throws IOException, JSONException {
+    public static Object readData(ICapacitorHttpUrlConnection connection, ResponseType responseType) throws IOException, JSONException {
         InputStream errorStream = connection.getErrorStream();
         String contentType = connection.getHeaderField("Content-Type");
 
@@ -261,7 +261,7 @@ public class HttpRequestHandler {
      * @param mimeTypes The Mime-Type values to check against
      * @return
      */
-    private static boolean isOneOf(String contentType, MimeType... mimeTypes) {
+    public static boolean isOneOf(String contentType, MimeType... mimeTypes) {
         if (contentType != null) {
             for (MimeType mimeType : mimeTypes) {
                 if (contentType.contains(mimeType.getValue())) {
@@ -277,7 +277,7 @@ public class HttpRequestHandler {
      * @param connection The CapacitorHttpUrlConnection connection
      * @return A JSObject of the header values from the CapacitorHttpUrlConnection
      */
-    private static JSObject buildResponseHeaders(CapacitorHttpUrlConnection connection) {
+    public static JSObject buildResponseHeaders(CapacitorHttpUrlConnection connection) {
         JSObject output = new JSObject();
 
         for (Map.Entry<String, List<String>> entry : connection.getHeaderFields().entrySet()) {
@@ -294,7 +294,7 @@ public class HttpRequestHandler {
      * @return A JSObject or JSArray
      * @throws JSONException thrown if the JSON is malformed
      */
-    private static Object parseJSON(String input) throws JSONException {
+    public static Object parseJSON(String input) throws JSONException {
         JSONObject json = new JSONObject();
         try {
             if ("null".equals(input.trim())) {
@@ -323,7 +323,7 @@ public class HttpRequestHandler {
      * @return String value of InputStream
      * @throws IOException thrown if the InputStream is unable to be read as base64
      */
-    private static String readStreamAsBase64(InputStream in) throws IOException {
+    public static String readStreamAsBase64(InputStream in) throws IOException {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             byte[] buffer = new byte[1024];
             int readBytes;
@@ -341,7 +341,7 @@ public class HttpRequestHandler {
      * @return String value of InputStream
      * @throws IOException thrown if the InputStream is unable to be read
      */
-    private static String readStreamAsString(InputStream in) throws IOException {
+    public static String readStreamAsString(InputStream in) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
             StringBuilder builder = new StringBuilder();
             String line = reader.readLine();

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/ICapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/ICapacitorHttpUrlConnection.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 /**
  * This interface was extracted from {@link CapacitorHttpUrlConnection} to enable mocking that class.
  */
-interface ICapacitorHttpUrlConnection {
+public interface ICapacitorHttpUrlConnection {
     InputStream getErrorStream();
 
     String getHeaderField(String name);

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
@@ -4,7 +4,15 @@ import Foundation
 public class CAPHttpPlugin: CAPPlugin {
     @objc func http(_ call: CAPPluginCall, _ httpMethod: String?) {
         do {
-            try HttpRequestHandler.request(call, httpMethod, self.bridge?.config)
+            if let clazz = NSClassFromString("SSLPinningHttpRequestHandlerClass") {
+                (clazz as! NSObject.Type).perform(Selector.init(("request:")), with: [
+                    "call": call,
+                    "httpMethod": httpMethod as Any,
+                    "config": self.bridge?.config as Any
+                ])
+            } else {
+                try HttpRequestHandler.request(call, httpMethod, self.bridge?.config)
+            }
         } catch let error {
             call.reject(error.localizedDescription)
         }

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
@@ -5,7 +5,7 @@ public class CAPHttpPlugin: CAPPlugin {
     @objc func http(_ call: CAPPluginCall, _ httpMethod: String?) {
         do {
             if let clazz = NSClassFromString("SSLPinningHttpRequestHandlerClass") {
-                (clazz as! NSObject.Type).perform(Selector.init(("request:")), with: [
+                (clazz as! NSObject.Type).perform(#selector(self.request(_:)), with: [
                     "call": call,
                     "httpMethod": httpMethod as Any,
                     "config": self.bridge?.config as Any

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorHttp.swift
@@ -5,11 +5,13 @@ public class CAPHttpPlugin: CAPPlugin {
     @objc func http(_ call: CAPPluginCall, _ httpMethod: String?) {
         do {
             if let clazz = NSClassFromString("SSLPinningHttpRequestHandlerClass") {
+                // swiftlint:disable force_cast
                 (clazz as! NSObject.Type).perform(#selector(self.request(_:)), with: [
                     "call": call,
                     "httpMethod": httpMethod as Any,
                     "config": self.bridge?.config as Any
                 ])
+                // swiftlint:enable force_cast
             } else {
                 try HttpRequestHandler.request(call, httpMethod, self.bridge?.config)
             }

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
-    private var request: URLRequest
-    private var headers: [String: String]
+    public var request: URLRequest
+    public var headers: [String: String]
 
-    enum CapacitorUrlRequestError: Error {
+    public enum CapacitorUrlRequestError: Error {
         case serializationError(String?)
     }
 
-    init(_ url: URL, method: String) {
+    public init(_ url: URL, method: String) {
         request = URLRequest(url: url)
         request.httpMethod = method
         headers = [:]
@@ -22,7 +22,7 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         }
     }
 
-    private func getRequestDataAsJson(_ data: JSValue) throws -> Data? {
+    public func getRequestDataAsJson(_ data: JSValue) throws -> Data? {
         // We need to check if the JSON is valid before attempting to serialize, as JSONSerialization.data will not throw an exception that can be caught, and will cause the application to crash if it fails.
         if JSONSerialization.isValidJSONObject(data) {
             return try JSONSerialization.data(withJSONObject: data)
@@ -31,7 +31,7 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         }
     }
 
-    private func getRequestDataAsFormUrlEncoded(_ data: JSValue) throws -> Data? {
+    public func getRequestDataAsFormUrlEncoded(_ data: JSValue) throws -> Data? {
         guard var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false) else { return nil }
         components.queryItems = []
 
@@ -51,7 +51,7 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         return nil
     }
 
-    private func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data {
+    public func getRequestDataAsMultipartFormData(_ data: JSValue) throws -> Data {
         guard let obj = data as? JSObject else {
             // Throw, other data types explicitly not supported.
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ application/x-www-form-urlencoded ] may only be a plain javascript object")
@@ -77,14 +77,14 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         return data
     }
 
-    private func getRequestDataAsString(_ data: JSValue) throws -> Data {
+    public func getRequestDataAsString(_ data: JSValue) throws -> Data {
         guard let stringData = data as? String else {
             throw CapacitorUrlRequestError.serializationError("[ data ] argument could not be parsed as string")
         }
         return Data(stringData.utf8)
     }
 
-    func getRequestHeader(_ index: String) -> Any? {
+    public func getRequestHeader(_ index: String) -> Any? {
         var normalized = [:] as [String: Any]
         self.headers.keys.forEach { (key: String) in
             normalized[key.lowercased()] = self.headers[key]
@@ -93,7 +93,7 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         return normalized[index.lowercased()]
     }
 
-    func getRequestData(_ body: JSValue, _ contentType: String) throws -> Data? {
+    public func getRequestData(_ body: JSValue, _ contentType: String) throws -> Data? {
         // If data can be parsed directly as a string, return that without processing.
         if let strVal = try? getRequestDataAsString(body) {
             return strVal

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
+open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
     public var request: URLRequest
     public var headers: [String: String]
 
@@ -136,11 +136,11 @@ public class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         return request
     }
 
-    public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+    open func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
         completionHandler(nil)
     }
 
-    public func getUrlSession(_ call: CAPPluginCall) -> URLSession {
+    open func getUrlSession(_ call: CAPPluginCall) -> URLSession {
         let disableRedirects = call.getBool("disableRedirects") ?? false
         if !disableRedirects {
             return URLSession.shared

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 /// See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
-private enum ResponseType: String {
+public enum ResponseType: String {
     case arrayBuffer = "arraybuffer"
     case blob = "blob"
     case document = "document"
     case json = "json"
     case text = "text"
 
-    static let `default`: ResponseType = .text
+    public static let `default`: ResponseType = .text
 
-    init(string: String?) {
+    public init(string: String?) {
         guard let string = string else {
             self = .default
             return
@@ -38,11 +38,11 @@ func tryParseJson(_ data: Data) -> Any {
 }
 
 class HttpRequestHandler {
-    private class CapacitorHttpRequestBuilder {
-        private var url: URL?
-        private var method: String?
-        private var params: [String: String]?
-        private var request: CapacitorUrlRequest?
+    public class CapacitorHttpRequestBuilder {
+        public var url: URL?
+        public var method: String?
+        public var params: [String: String]?
+        public var request: CapacitorUrlRequest?
 
         /// Set the URL of the HttpRequest
         /// - Throws: an error of URLError if the urlString cannot be parsed
@@ -97,7 +97,7 @@ class HttpRequestHandler {
         }
     }
 
-    private static func setCookiesFromResponse(_ response: HTTPURLResponse, _ config: InstanceConfiguration?) {
+    public static func setCookiesFromResponse(_ response: HTTPURLResponse, _ config: InstanceConfiguration?) {
         let headers = response.allHeaderFields
         if let cookies = headers["Set-Cookie"] as? String {
             for cookie in cookies.components(separatedBy: ",") {
@@ -115,7 +115,7 @@ class HttpRequestHandler {
         CapacitorCookieManager(config).syncCookiesToWebView()
     }
 
-    private static func buildResponse(_ data: Data?, _ response: HTTPURLResponse, responseType: ResponseType = .default) -> [String: Any] {
+    public static func buildResponse(_ data: Data?, _ response: HTTPURLResponse, responseType: ResponseType = .default) -> [String: Any] {
         var output = [:] as [String: Any]
 
         output["status"] = response.statusCode

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -43,7 +43,7 @@ open class HttpRequestHandler {
         public var method: String?
         public var params: [String: String]?
         open var request: CapacitorUrlRequest?
-        
+
         public init() { }
 
         /// Set the URL of the HttpRequest

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -37,12 +37,14 @@ func tryParseJson(_ data: Data) -> Any {
     }
 }
 
-class HttpRequestHandler {
-    public class CapacitorHttpRequestBuilder {
+open class HttpRequestHandler {
+    open class CapacitorHttpRequestBuilder {
         public var url: URL?
         public var method: String?
         public var params: [String: String]?
-        public var request: CapacitorUrlRequest?
+        open var request: CapacitorUrlRequest?
+        
+        public init() { }
 
         /// Set the URL of the HttpRequest
         /// - Throws: an error of URLError if the urlString cannot be parsed
@@ -87,7 +89,7 @@ class HttpRequestHandler {
             return self
         }
 
-        public func openConnection() -> CapacitorHttpRequestBuilder {
+        open func openConnection() -> CapacitorHttpRequestBuilder {
             request = CapacitorUrlRequest(url!, method: method!)
             return self
         }


### PR DESCRIPTION
This PR changes the interfaces in the HTTP plugin to be public so they can be extended by other plugins.