### PR TITLE
fix(ios): Avoid double encoding on http urls

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -141,7 +141,7 @@ class HttpRequestHandler {
     }
 
     public static func request(_ call: CAPPluginCall, _ httpMethod: String?, _ config: InstanceConfiguration?) throws {
-        guard let urlString = call.getString("url")?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { throw URLError(.badURL) }
+        guard var urlString = call.getString("url") else { throw URLError(.badURL) }
         let method = httpMethod ?? call.getString("method", "GET")
 
         // swiftlint:disable force_cast
@@ -150,6 +150,11 @@ class HttpRequestHandler {
         let responseType = call.getString("responseType") ?? "text"
         let connectTimeout = call.getDouble("connectTimeout")
         let readTimeout = call.getDouble("readTimeout")
+
+        if urlString == urlString.removingPercentEncoding {
+            guard let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)  else { throw URLError(.badURL) }
+            urlString = encodedUrlString
+        }
 
         let request = try CapacitorHttpRequestBuilder()
             .setUrl(urlString)


### PR DESCRIPTION
compare the received url with the unencoded url and only encode the url if they are the same (if they are not encoded already)

closes https://github.com/ionic-team/capacitor/issues/6230