### PR TITLE
fix(cli): Remove buildOptions from platform capacitor.config.json

### DIFF
--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -181,6 +181,7 @@ async function copyCapacitorConfig(config: Config, nativeAbsDir: string) {
   await runTask(
     `Creating ${c.strong(nativeConfigFile)} in ${nativeRelDir}`,
     async () => {
+      delete (config.app.extConfig.android as any)?.buildOptions;
       await writeJSON(nativeConfigFilePath, config.app.extConfig, {
         spaces: '\t',
       });


### PR DESCRIPTION
all `extConfig` properties are read only, so typescript doesn't allow to delete `buildOptions` directly
by casting to any, we can easily remove `buildOptions` from `extConfig.android` before writing the platforms `capacitor.config.json` file

close https://github.com/ionic-team/capacitor/issues/6246