### PR TITLE
feat(android): enable loading of assets outside of the content web asset directory

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/ProcessedRoute.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/ProcessedRoute.java
@@ -34,5 +34,4 @@ public class ProcessedRoute {
     public void setIgnoreAssetPath(boolean ignoreAssetPath) {
         this.ignoreAssetPath = ignoreAssetPath;
     }
-
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/ProcessedRoute.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/ProcessedRoute.java
@@ -9,6 +9,7 @@ public class ProcessedRoute {
 
     private String path;
     private boolean isAsset;
+    private boolean ignoreAssetPath;
 
     public String getPath() {
         return path;
@@ -25,4 +26,13 @@ public class ProcessedRoute {
     public void setAsset(boolean asset) {
         isAsset = asset;
     }
+
+    public boolean isIgnoreAssetPath() {
+        return ignoreAssetPath;
+    }
+
+    public void setIgnoreAssetPath(boolean ignoreAssetPath) {
+        this.ignoreAssetPath = ignoreAssetPath;
+    }
+
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -484,10 +484,12 @@ public class WebViewLocalServer {
 
                 // Pass path to routeProcessor if present
                 RouteProcessor routeProcessor = bridge.getRouteProcessor();
+                boolean ignoreAssetPath = false;
                 if (routeProcessor != null) {
                     ProcessedRoute processedRoute = bridge.getRouteProcessor().process("", path);
                     path = processedRoute.getPath();
                     isAsset = processedRoute.isAsset();
+                    ignoreAssetPath = processedRoute.isIgnoreAssetPath();
                 }
 
                 try {
@@ -501,6 +503,8 @@ public class WebViewLocalServer {
                         }
 
                         stream = protocolHandler.openFile(path);
+                    } else if (ignoreAssetPath) {
+                        stream = protocolHandler.openAsset(path);
                     } else {
                         stream = protocolHandler.openAsset(assetPath + path);
                     }


### PR DESCRIPTION
Adds an override option for the RouteProcessor to allow Portals to request a route outside of the `assetPath` location. EG: a Portal at `/assets/mywebapp/index.html` wants to load an image at `/assets/sharedimages/fish.jpg`

Example usage in Portals:

```kotlin
// If AssetMap contains this virtual route, reroute to shared assets location
assetLoop@ for ((mapName, assetMap) in assetMaps) {
    if (path != null) {
        if(path.startsWith(assetMap.virtualPath)) {
            val assetMapObj = assetMaps[mapName]
            if (assetMapObj != null) {
                var trimmedPath = path.replace(assetMap.virtualPath,assetMapObj.getAssetPath())
                if (trimmedPath.startsWith("/")) {
                    trimmedPath = trimmedPath.drop(1)
                }

                processedRoute.path = trimmedPath
                processedRoute.isAsset = true
                processedRoute.isIgnoreAssetPath = true
                break@assetLoop
            }
        }
    }
}
```