### PR TITLE
feat(android): Fix for #6258, add Huawei webview support

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -87,6 +87,8 @@ public class Bridge {
     public static final String CAPACITOR_CONTENT_START = "/_capacitor_content_";
     public static final int DEFAULT_ANDROID_WEBVIEW_VERSION = 60;
     public static final int MINIMUM_ANDROID_WEBVIEW_VERSION = 55;
+    public static final int DEFAULT_HUAWEI_WEBVIEW_VERSION = 10;
+    public static final int MINIMUM_HUAWEI_WEBVIEW_VERSION = 10;
 
     // Loaded Capacitor config
     private CapConfig config;
@@ -323,6 +325,11 @@ public class Bridge {
         // Check getCurrentWebViewPackage() directly if above Android 8
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             PackageInfo info = WebView.getCurrentWebViewPackage();
+            if (info.packageName.equals("com.huawei.webview")) {
+                String majorVersionStr = info.versionName.split("\\.")[0];
+                int majorVersion = Integer.parseInt(majorVersionStr);
+                return majorVersion >= config.getMinHuaweiWebViewVersion();
+            }
             String majorVersionStr = info.versionName.split("\\.")[0];
             int majorVersion = Integer.parseInt(majorVersionStr);
             return majorVersion >= config.getMinWebViewVersion();

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -3,6 +3,8 @@ package com.getcapacitor;
 import static com.getcapacitor.Bridge.CAPACITOR_HTTP_SCHEME;
 import static com.getcapacitor.Bridge.DEFAULT_ANDROID_WEBVIEW_VERSION;
 import static com.getcapacitor.Bridge.MINIMUM_ANDROID_WEBVIEW_VERSION;
+import static com.getcapacitor.Bridge.DEFAULT_HUAWEI_WEBVIEW_VERSION;
+import static com.getcapacitor.Bridge.MINIMUM_HUAWEI_WEBVIEW_VERSION;
 import static com.getcapacitor.FileUtils.readFileFromAssets;
 
 import android.content.Context;
@@ -48,6 +50,7 @@ public class CapConfig {
     private boolean initialFocus = true;
     private boolean useLegacyBridge = false;
     private int minWebViewVersion = DEFAULT_ANDROID_WEBVIEW_VERSION;
+    private int minHuaweiWebViewVersion = DEFAULT_HUAWEI_WEBVIEW_VERSION;
     private String errorPath;
 
     // Embedded
@@ -172,6 +175,7 @@ public class CapConfig {
         this.initialFocus = builder.initialFocus;
         this.useLegacyBridge = builder.useLegacyBridge;
         this.minWebViewVersion = builder.minWebViewVersion;
+        this.minHuaweiWebViewVersion = builder.minHuaweiWebViewVersion;
         this.errorPath = builder.errorPath;
 
         // Embedded
@@ -263,6 +267,7 @@ public class CapConfig {
                 JSONUtils.getBoolean(configJSON, "allowMixedContent", allowMixedContent)
             );
         minWebViewVersion = JSONUtils.getInt(configJSON, "android.minWebViewVersion", DEFAULT_ANDROID_WEBVIEW_VERSION);
+        minHuaweiWebViewVersion = JSONUtils.getInt(configJSON, "android.minHuaweiWebViewVersion", DEFAULT_HUAWEI_WEBVIEW_VERSION);
         captureInput = JSONUtils.getBoolean(configJSON, "android.captureInput", captureInput);
         useLegacyBridge = JSONUtils.getBoolean(configJSON, "android.useLegacyBridge", useLegacyBridge);
         webContentsDebuggingEnabled = JSONUtils.getBoolean(configJSON, "android.webContentsDebuggingEnabled", isDebug);
@@ -374,6 +379,15 @@ public class CapConfig {
         }
 
         return minWebViewVersion;
+    }
+
+    public int getMinHuaweiWebViewVersion() {
+        if (minHuaweiWebViewVersion < MINIMUM_HUAWEI_WEBVIEW_VERSION) {
+            Logger.warn("Specified minimum Huawei webview version is too low, defaulting to " + MINIMUM_HUAWEI_WEBVIEW_VERSION);
+            return MINIMUM_HUAWEI_WEBVIEW_VERSION;
+        }
+
+        return minHuaweiWebViewVersion;
     }
 
     public PluginConfig getPluginConfiguration(String pluginId) {
@@ -535,6 +549,7 @@ public class CapConfig {
         private boolean initialFocus = false;
         private boolean useLegacyBridge = false;
         private int minWebViewVersion = DEFAULT_ANDROID_WEBVIEW_VERSION;
+        private int minHuaweiWebViewVersion = DEFAULT_HUAWEI_WEBVIEW_VERSION;
 
         // Embedded
         private String startPath = null;

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -226,6 +226,20 @@ export interface CapacitorConfig {
      */
     minWebViewVersion?: number;
 
+    /**
+     * The minimum supported Huawei webview version on Android supported by your app.
+     *
+     * The minimum supported cannot be lower than version `10`, which is required for Capacitor.
+     *
+     * If the device uses a lower WebView version, an error message will be shown on Logcat.
+     * If `server.errorPath` is configured, the WebView will redirect to that file, so can be
+     * used to show a custom error.
+     *
+     * @since 4.6.4
+     * @default 10
+     */
+    minHuaweiWebViewVersion?: number;
+
     buildOptions?: {
       /**
        * Path to your keystore


### PR DESCRIPTION
This PR add Huawei webview support in minimal Android webview check. Also add ability to specify minimum supported Huawei webview version. 

Huawei webview use different versioning, the minimum i found is 10.x.x.x. Current is 12.x.x.x. So i set minimal version 10. Have tested on Honor 10 device with installed 11 and 12 Huawei webview.

Close #6258