### PR TITLE
fix: handle fetch headers that are Headers objects

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -374,13 +374,15 @@ const nativeBridge = (function (exports) {
                         console.time(tag);
                         try {
                             // intercept request & pass to the bridge
+                            let headers = options === null || options === void 0 ? void 0 : options.headers;
+                            if (options && options.headers && (typeof options.headers.entries === 'function')) {
+                                headers = Object.fromEntries(options.headers.entries());
+                            }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers)
-                                    ? options.headers
-                                    : undefined,
+                                headers: headers
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data
@@ -508,7 +510,9 @@ const nativeBridge = (function (exports) {
                                 url: this._url,
                                 method: this._method,
                                 data: body !== null ? body : undefined,
-                                headers: this._headers != null && Object.keys(this._headers).length > 0 ? this._headers : undefined,
+                                headers: this._headers != null && Object.keys(this._headers).length > 0
+                                    ? this._headers
+                                    : undefined,
                             })
                                 .then((nativeResponse) => {
                                 // intercept & parse response before returning

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -366,6 +366,7 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
+                        var _a;
                         if (!(resource.toString().startsWith('http:') ||
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
@@ -375,7 +376,7 @@ var nativeBridge = (function (exports) {
                         try {
                             // intercept request & pass to the bridge
                             let headers = options === null || options === void 0 ? void 0 : options.headers;
-                            if (options && options.headers && (typeof options.headers.entries === 'function')) {
+                            if ((typeof ((_a = options === null || options === void 0 ? void 0 : options.headers) === null || _a === void 0 ? void 0 : _a.entries) === 'function')) {
                                 headers = Object.fromEntries(options.headers.entries());
                             }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -366,7 +366,6 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
-                        var _a;
                         if (!(resource.toString().startsWith('http:') ||
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
@@ -376,14 +375,14 @@ var nativeBridge = (function (exports) {
                         try {
                             // intercept request & pass to the bridge
                             let headers = options === null || options === void 0 ? void 0 : options.headers;
-                            if ((typeof ((_a = options === null || options === void 0 ? void 0 : options.headers) === null || _a === void 0 ? void 0 : _a.entries) === 'function')) {
+                            if ((options === null || options === void 0 ? void 0 : options.headers) instanceof Headers) {
                                 headers = Object.fromEntries(options.headers.entries());
                             }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: headers
+                                headers: headers,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -422,6 +422,10 @@ const initBridge = (w: any): void => {
           console.time(tag);
           try {
             // intercept request & pass to the bridge
+            let headers = options?.headers;
+            if (options && options.headers && (typeof options.headers.entries === 'function') ) {
+              headers = Object.fromEntries(options.headers.entries());
+            }
             const nativeResponse: HttpResponse = await cap.nativePromise(
               'CapacitorHttp',
               'request',
@@ -429,7 +433,7 @@ const initBridge = (w: any): void => {
                 url: resource,
                 method: options?.method ? options.method : undefined,
                 data: options?.body ? options.body : undefined,
-                headers: options?.headers ? options.headers : undefined,
+                headers: headers
               },
             );
 

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -423,8 +423,8 @@ const initBridge = (w: any): void => {
           try {
             // intercept request & pass to the bridge
             let headers = options?.headers;
-            if (typeof options?.headers?.entries === 'function') {
-              headers = Object.fromEntries(options.headers.entries());
+            if (options?.headers instanceof Headers) {
+              headers = Object.fromEntries((options.headers as any).entries());
             }
             const nativeResponse: HttpResponse = await cap.nativePromise(
               'CapacitorHttp',

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -423,7 +423,7 @@ const initBridge = (w: any): void => {
           try {
             // intercept request & pass to the bridge
             let headers = options?.headers;
-            if (options && options.headers && (typeof options.headers.entries === 'function') ) {
+            if (typeof options?.headers?.entries === 'function') {
               headers = Object.fromEntries(options.headers.entries());
             }
             const nativeResponse: HttpResponse = await cap.nativePromise(
@@ -433,7 +433,7 @@ const initBridge = (w: any): void => {
                 url: resource,
                 method: options?.method ? options.method : undefined,
                 data: options?.body ? options.body : undefined,
-                headers: headers
+                headers: headers,
               },
             );
 

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -2,7 +2,7 @@
 /*! Capacitor: https://capacitorjs.com/ - MIT License */
 /* Generated File. Do not edit. */
 
-const nativeBridge = (function (exports) {
+var nativeBridge = (function (exports) {
     'use strict';
 
     var ExceptionCode;
@@ -374,13 +374,15 @@ const nativeBridge = (function (exports) {
                         console.time(tag);
                         try {
                             // intercept request & pass to the bridge
+                            let headers = options === null || options === void 0 ? void 0 : options.headers;
+                            if (options && options.headers && (typeof options.headers.entries === 'function')) {
+                                headers = Object.fromEntries(options.headers.entries());
+                            }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: (options === null || options === void 0 ? void 0 : options.headers)
-                                    ? options.headers
-                                    : undefined,
+                                headers: headers
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data
@@ -508,7 +510,9 @@ const nativeBridge = (function (exports) {
                                 url: this._url,
                                 method: this._method,
                                 data: body !== null ? body : undefined,
-                                headers: this._headers != null && Object.keys(this._headers).length > 0 ? this._headers : undefined,
+                                headers: this._headers != null && Object.keys(this._headers).length > 0
+                                    ? this._headers
+                                    : undefined,
                             })
                                 .then((nativeResponse) => {
                                 // intercept & parse response before returning

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -366,6 +366,7 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
+                        var _a;
                         if (!(resource.toString().startsWith('http:') ||
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
@@ -375,7 +376,7 @@ var nativeBridge = (function (exports) {
                         try {
                             // intercept request & pass to the bridge
                             let headers = options === null || options === void 0 ? void 0 : options.headers;
-                            if (options && options.headers && (typeof options.headers.entries === 'function')) {
+                            if ((typeof ((_a = options === null || options === void 0 ? void 0 : options.headers) === null || _a === void 0 ? void 0 : _a.entries) === 'function')) {
                                 headers = Object.fromEntries(options.headers.entries());
                             }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -366,7 +366,6 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
-                        var _a;
                         if (!(resource.toString().startsWith('http:') ||
                             resource.toString().startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
@@ -376,14 +375,14 @@ var nativeBridge = (function (exports) {
                         try {
                             // intercept request & pass to the bridge
                             let headers = options === null || options === void 0 ? void 0 : options.headers;
-                            if ((typeof ((_a = options === null || options === void 0 ? void 0 : options.headers) === null || _a === void 0 ? void 0 : _a.entries) === 'function')) {
+                            if ((options === null || options === void 0 ? void 0 : options.headers) instanceof Headers) {
                                 headers = Object.fromEntries(options.headers.entries());
                             }
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: resource,
                                 method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
                                 data: (options === null || options === void 0 ? void 0 : options.body) ? options.body : undefined,
-                                headers: headers
+                                headers: headers,
                             });
                             const data = typeof nativeResponse.data === 'string'
                                 ? nativeResponse.data


### PR DESCRIPTION
If the fetch call uses headers created with the Headers interface, they can't be handled by http plugin since they are not serializable on iOS and are serializable on Android but are not proper headers.

This PR checks if the headers are a instance of `Headers` and use its entries to get the headers javascript object.