### PR TITLE
feat(cli): allow adding options for pod install by environment variables

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -279,6 +279,7 @@ async function loadIOSConfig(
 ): Promise<IOSConfig> {
   const name = 'ios';
   const podPath = determineCocoapodPath();
+  const podsOptions = getCocoaPodsOptions();
   const platformDir = extConfig.ios?.path ?? 'ios';
   const platformDirAbs = resolve(rootDir, platformDir);
   const scheme = extConfig.ios?.scheme ?? 'App';
@@ -321,6 +322,7 @@ async function loadIOSConfig(
     webDir: lazy(async () => relative(platformDirAbs, await webDirAbs)),
     webDirAbs,
     podPath,
+    podsOptions,
   };
 }
 
@@ -437,6 +439,10 @@ function determineCocoapodPath(): string {
   }
 
   return 'pod';
+}
+
+function getCocoaPodsOptions(): string {
+  return process.env.PODS_OPTIONS || '';
 }
 
 function formatConfigTS(extConfig: ExternalConfig): string {

--- a/cli/src/definitions.ts
+++ b/cli/src/definitions.ts
@@ -111,6 +111,7 @@ export interface IOSConfig extends PlatformConfig {
   readonly cordovaPluginsDirAbs: string;
   readonly minVersion: string;
   readonly podPath: string;
+  readonly podsOptions: string;
   readonly scheme: string;
   readonly webDir: Promise<string>;
   readonly webDirAbs: Promise<string>;

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -81,7 +81,9 @@ export async function installCocoaPodsPlugins(
 ): Promise<void> {
   await runTask(
     `Updating iOS native dependencies with ${c.input(
-      `${config.ios.podPath} install`,
+      `${config.ios.podPath} install ${deployment ? '--deployment' : ''} ${
+        config.ios.podsOptions
+      }`,
     )}`,
     () => {
       return updatePodfile(config, plugins, deployment);
@@ -111,7 +113,11 @@ async function updatePodfile(
     }
     await runCommand(
       config.ios.podPath,
-      ['install', ...(deployment ? ['--deployment'] : [])],
+      [
+        'install ',
+        ...(deployment ? ['--deployment'] : []),
+        ...(config.ios.podsOptions ? [config.ios.podsOptions] : []),
+      ],
       { cwd: config.ios.nativeProjectDirAbs },
     );
   } else {


### PR DESCRIPTION
Hi, 

Currently there is no way to add extra options for `pod install` when we run `sync` or `update`. In my case, I needed `--repo-update` and sometimes `--verbose`. So, I made it optional to add an environment variables called `PODS_OPTIONS` to allow adding options 

<img width="700" alt="image" src="https://user-images.githubusercontent.com/4671486/221172890-1d88ad87-53e5-4295-b1d1-a12ef28efabc.png">


Usage example 
```
PODS_OPTIONS='--verbose --repo-update' ionic cap sync ios
```
