### PR TITLE
feat(HTTP) Updating array parameter parsing

### DIFF
--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -267,7 +267,7 @@ const buildUrlParams = (
       item = '';
       value.forEach(str => {
         encodedValue = shouldEncode ? encodeURIComponent(str) : str;
-        item += `${key}=${encodedValue}&`;
+        item += `${key}[]=${encodedValue}&`;
       });
       // last character will always be "&" so slice it off
       item.slice(0, -1);


### PR DESCRIPTION
That should cover most causes when sending array parameters,  since that's the only way a weak-typed language like PHP or RoR reads array parameters.

sources:
- https://stackoverflow.com/questions/3061273/send-an-array-with-an-http-get
- https://stackoverflow.com/questions/6243051/how-to-pass-an-array-within-a-query-string