### PR TITLE
feat(android): update default scheme from http to https

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -1,6 +1,6 @@
 package com.getcapacitor;
 
-import static com.getcapacitor.Bridge.CAPACITOR_HTTP_SCHEME;
+import static com.getcapacitor.Bridge.CAPACITOR_HTTPS_SCHEME;
 import static com.getcapacitor.Bridge.DEFAULT_ANDROID_WEBVIEW_VERSION;
 import static com.getcapacitor.Bridge.MINIMUM_ANDROID_WEBVIEW_VERSION;
 import static com.getcapacitor.FileUtils.readFileFromAssets;
@@ -34,7 +34,7 @@ public class CapConfig {
     private boolean html5mode = true;
     private String serverUrl;
     private String hostname = "localhost";
-    private String androidScheme = CAPACITOR_HTTP_SCHEME;
+    private String androidScheme = CAPACITOR_HTTPS_SCHEME;
     private String[] allowNavigation;
 
     // Android Config
@@ -521,7 +521,7 @@ public class CapConfig {
         private String serverUrl;
         private String errorPath;
         private String hostname = "localhost";
-        private String androidScheme = CAPACITOR_HTTP_SCHEME;
+        private String androidScheme = CAPACITOR_HTTPS_SCHEME;
         private String[] allowNavigation;
 
         // Android Config Values

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -472,7 +472,7 @@ export interface CapacitorConfig {
      * Configure the local scheme on Android.
      *
      * @since 1.2.0
-     * @default http
+     * @default https
      */
     androidScheme?: string;
 


### PR DESCRIPTION
Update default Android scheme from http to https. 

Will only effect use of the default scheme - anyone overriding it will continue to.