### PR TITLE
feat(android): Removing enableJetifier

### DIFF
--- a/android-template/gradle.properties
+++ b/android-template/gradle.properties
@@ -20,5 +20,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true

--- a/android-template/gradle.properties
+++ b/android-template/gradle.properties
@@ -22,4 +22,3 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-

--- a/android-template/gradle.properties
+++ b/android-template/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
+

--- a/android/capacitor/gradle.properties
+++ b/android/capacitor/gradle.properties
@@ -20,5 +20,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,5 +20,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -24,7 +24,7 @@ else
     printf %"s\n" "Publishing $CAP_VERSION to MavenCentral production..."
 
     # Build and publish
-    $DIR/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1 -b $DIR/capacitor/build.gradle -Pandroid.useAndroidX=true -Pandroid.enableJetifier=true > $LOG_OUTPUT 2>&1
+    $DIR/gradlew clean build publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1 -b $DIR/capacitor/build.gradle -Pandroid.useAndroidX=true > $LOG_OUTPUT 2>&1
 
     echo $RESULT
 


### PR DESCRIPTION
Removes `android.enableJetifier` in core and in the publish script as its no longer needed for modern libraries.