### PR TITLE
feat(android-template): Removing enableJetifier

### DIFF
--- a/android-template/gradle.properties
+++ b/android-template/gradle.properties
@@ -20,5 +20,3 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true


### PR DESCRIPTION
Removes `android.enableJetifier` in from the android template as its no longer needed for modern libraries.