### PR TITLE
fix(android): solve and/or silence lint errors

### DIFF
--- a/android/capacitor/lint.xml
+++ b/android/capacitor/lint.xml
@@ -2,4 +2,7 @@
 <lint>
     <issue id="GradleDependency" severity="ignore" />
     <issue id="AndroidGradlePluginVersion" severity="ignore" />
+    <issue id="DiscouragedApi">
+        <ignore path="src/main/java/com/getcapacitor/plugin/util/AssetUtil.java" />
+    </issue>
 </lint>

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -22,8 +22,7 @@ public class BridgeActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         bridgeBuilder.setInstanceState(savedInstanceState);
-        getApplication().setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
-        setTheme(getResources().getIdentifier("AppTheme_NoActionBar", "style", getPackageName()));
+        getApplication().setTheme(R.style.AppTheme_NoActionBar);
         setTheme(R.style.AppTheme_NoActionBar);
         setContentView(R.layout.bridge_layout_main);
         PluginManager loader = new PluginManager(getAssets());


### PR DESCRIPTION
When targeting SDK 33, multiple `DiscouragedApi` errors appear in `BridgeActivity.java` and `AssetUtil.java` classes because of the usage of reflection for getting resources from the name.

`BridgeActivity.java` I've used `R.style.AppTheme_NoActionBar` instead of the name, there was already a line like that for the activity theme, so removed the string one and replace the string with the `R.style.AppTheme_NoActionBar` on the app theme line. Not sure if it was a mistake to have them duplicated, but doesn't seem to break anything with the change.

For `AssetUtil.java` it can't be fixed because we allow plugins to get resources dynamically from the javascript name the users provide, so I've just silenced the warnings. 
We could probably remove some of the methods that generate the warnings since looks like some of them are not being used, but not all of them. 