### PR TITLE
refactor(android)!: make call getArray and getObject return null

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -318,11 +318,7 @@ public class PluginCall {
     }
 
     public JSObject getObject(String name) {
-        Logger.warn(
-            Logger.tags("Plugin"),
-            "getObject calls without a default value will return null in Capacitor 5 instead of an empty object to match iOS behavior"
-        );
-        return this.getObject(name, new JSObject());
+        return this.getObject(name, null);
     }
 
     @Nullable
@@ -343,11 +339,7 @@ public class PluginCall {
     }
 
     public JSArray getArray(String name) {
-        Logger.warn(
-            Logger.tags("Plugin"),
-            "getArray calls without a default value will return null in Capacitor 5 instead of an empty array to match iOS behavior"
-        );
-        return this.getArray(name, new JSArray());
+        return this.getArray(name, null);
     }
 
     /**


### PR DESCRIPTION
breaking change, we have been warning about it.
To match iOS behavior, make getArray and getObject return null

We are doing null checks in most plugins and they are not working because of this returning empty objects/arrays, so should fix several problems.
But also will break camera requestPermissions as it's not doing null check, and probably several user plugins.