### PR TITLE
fix(iOS): Separate cookies by ; rather than ; when accessing through document.cookie (Cap 4.x)

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
@@ -88,7 +88,7 @@ public class CapacitorCookieManager {
         let jar = HTTPCookieStorage.shared
         guard let url = self.getServerUrl() else { return "" }
         guard let cookies = jar.cookies(for: url) else { return "" }
-        return cookies.map({"\($0.name)=\($0.value)"}).joined(separator: ";")
+        return cookies.map({"\($0.name)=\($0.value)"}).joined(separator: "; ")
     }
 
     public func deleteCookie(_ url: URL, _ key: String) {


### PR DESCRIPTION
Fixes https://github.com/ionic-team/capacitor/issues/6308 for Capacitor 4.x

[Relevant comment](https://github.com/ionic-team/capacitor/pull/6313#issuecomment-1462355249)