### PR TITLE
fix: remove accept-charset

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -338,7 +338,6 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
      * This is called as early as possible to allow overrides by user-provided values.
      */
     private void setDefaultRequestProperties() {
-        connection.setRequestProperty("Accept-Charset", StandardCharsets.UTF_8.name());
         String acceptLanguage = buildDefaultAcceptLanguageProperty();
         if (!TextUtils.isEmpty(acceptLanguage)) {
             connection.setRequestProperty("Accept-Language", acceptLanguage);


### PR DESCRIPTION
> Today, `Accept-Charset` is most notable for being one of several forbidden header names.

more info at
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset
https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name

this header is part of one of our OWASP rulesets and is causing many issues.

