### PR TITLE
fix: copy url from nativeResponse to response in native-bridge.ts

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -454,6 +454,15 @@ const initBridge = (w: any): void => {
               status: nativeResponse.status,
             });
 
+            /*
+             * copy url to response, `cordova-plugin-ionic` uses this url from the response
+             * we need `Object.defineProperty` because url is an inherited getter on the Response
+             * see: https://stackoverflow.com/a/57382543
+             * */
+            Object.defineProperty(response, 'url', {
+              value: nativeResponse.url,
+            });
+
             console.timeEnd(tag);
             return response;
           } catch (error) {


### PR DESCRIPTION
This url is used in `cordova-plugin-ionic` to do live updates. Without this fix the `response.url` would be an empty string here:
 https://github.com/ionic-team/cordova-plugin-ionic/blob/5b190675525806ea15e56d4e59eb67b74cc58c55/www/common.ts#L288
 and live updates do not work.