### PR TITLE
refactor(ios): remove allowFileAccessFromFileURLs preference call

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -287,7 +287,6 @@ extension CAPBridgeViewController {
         aWebView.scrollView.bounces = false
         aWebView.scrollView.contentInsetAdjustmentBehavior = configuration.contentInsetAdjustmentBehavior
         aWebView.allowsLinkPreview = configuration.allowLinkPreviews
-        aWebView.configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
         aWebView.scrollView.isScrollEnabled = configuration.scrollingEnabled
         if let overrideUserAgent = configuration.overridenUserAgentString {
             aWebView.customUserAgent = overrideUserAgent

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -157,7 +157,6 @@ extension CAPWebView {
         webView.scrollView.bounces = false
         webView.scrollView.contentInsetAdjustmentBehavior = configuration.contentInsetAdjustmentBehavior
         webView.allowsLinkPreview = configuration.allowLinkPreviews
-        webView.configuration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
         webView.scrollView.isScrollEnabled = configuration.scrollingEnabled
 
         if let overrideUserAgent = configuration.overridenUserAgentString {


### PR DESCRIPTION
allowFileAccessFromFileURLs is a non documented preference that can cause security warnings
it allows to load file:// urls in the WKWebView, but Capacitor uses custom schemes for serving the local files and provides a helper to convert any file:// url to a capacitor://localhost url, so the preference shouldn't be needed anymore, and if anybody is using it, should move to the capacitor://localhost urls

closes https://github.com/ionic-team/capacitor/issues/6131