### PR TITLE
feat(android): add plugin hooks for WebViewClient.onRenderProcessGone

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -15,6 +15,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.ValueCallback;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -395,6 +396,22 @@ public class Bridge {
             return true;
         }
         return false;
+    }
+
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        /*
+         * Give plugins the chance to handle or record render process removal
+         */
+        boolean result = false;
+        for (Map.Entry<String, PluginHandle> entry : plugins.entrySet()) {
+            Plugin plugin = entry.getValue().getInstance();
+            if (plugin != null) {
+                if (plugin.onRenderProcessGone(view, detail)) {
+                    result = true;
+                }
+            }
+        }
+        return result;
     }
 
     private boolean isNewBinary() {

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -2,6 +2,7 @@ package com.getcapacitor;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -91,5 +92,10 @@ public class BridgeWebViewClient extends WebViewClient {
         if (errorPath != null && request.isForMainFrame()) {
             view.loadUrl(errorPath);
         }
+    }
+
+    @Override
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        return bridge.onRenderProcessGone(view, detail);
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -7,6 +7,8 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -1004,6 +1006,23 @@ public class Plugin {
     @SuppressWarnings("unused")
     public Boolean shouldOverrideLoad(Uri url) {
         return null;
+    }
+
+
+    /**
+     * Give the plugins a chance to record or respond to a WebView render process terminating.
+     *
+     * Note: A plugin must not attempt to recover a webview that it does not own/manage.
+     * Returning true without proper recovery will leave the webview in
+     * an invalid state. See {@link android.webkit.WebViewClient#onRenderProcessGone} for information about
+     * how to properly recover a webview.
+     *
+     * Returning true indicates the WebView termination has been handled by the plugin.
+     * Returning false indicates the WebView termination has not been handled.
+     */
+    @SuppressWarnings("unused")
+    public boolean onRenderProcessGone(final WebView view, RenderProcessGoneDetail detail) {
+        return false;
     }
 
     /**


### PR DESCRIPTION
This change allows more advanced handling of the webview render process termination. This can be useful for capturing additional information, or even conceivably allow the crash to be prevented should a plugin choose to.

Source:
https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)