### PR TITLE
fix(cli): use scheme when setting nativeXcodeProjDir

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -286,7 +286,7 @@ async function loadIOSConfig(
   const nativeProjectDirAbs = resolve(platformDirAbs, nativeProjectDir);
   const nativeTargetDir = `${nativeProjectDir}/App`;
   const nativeTargetDirAbs = resolve(platformDirAbs, nativeTargetDir);
-  const nativeXcodeProjDir = `${nativeProjectDir}/App.xcodeproj`;
+  const nativeXcodeProjDir = `${nativeProjectDir}/${scheme}.xcodeproj`;
   const nativeXcodeProjDirAbs = resolve(platformDirAbs, nativeXcodeProjDir);
   const nativeXcodeWorkspaceDirAbs = lazy(() =>
     determineXcodeWorkspaceDirAbs(nativeProjectDirAbs),


### PR DESCRIPTION
Currently the ios config is not using the user provided `scheme`. This causes commands like `cap update` to fail with the following, provided the `capacitor.config.json` points to the correct scheme:

```
[error] Command line invocation:
        /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj clean
        
        User defaults from command line:
        IDEPackageSupportUseBuiltinSCM = YES
        
        2023-03-21 19:18:14.031 xcodebuild[74289:4092982] Writing error result bundle to
        /var/folders/kl/9rf67c9n3v508lrblmfkssr40000gn/T/ResultBundle_2023-21-03_19-18-0014.xcresult
        xcodebuild: error: 'App.xcodeproj' does not exist.
        
error Command failed with exit code 1.
```

This PR addresses this bug and makes if possible to truly have a custom scheme.