### PR TITLE
fix: sync platform failing to create capacitor.config.json

### DIFF
--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -1,4 +1,9 @@
-import { copy as fsCopy, pathExists, remove, writeJSON } from '@ionic/utils-fs';
+import {
+  copy as fsCopy,
+  outputJSON,
+  pathExists,
+  remove,
+} from '@ionic/utils-fs';
 import { basename, join, relative, resolve } from 'path';
 
 import c from '../colors';
@@ -204,7 +209,7 @@ async function copyCapacitorConfig(config: Config, nativeAbsDir: string) {
     `Creating ${c.strong(nativeConfigFile)} in ${nativeRelDir}`,
     async () => {
       delete (config.app.extConfig.android as any)?.buildOptions;
-      await writeJSON(nativeConfigFilePath, config.app.extConfig, {
+      await outputJSON(nativeConfigFilePath, config.app.extConfig, {
         spaces: '\t',
       });
     },


### PR DESCRIPTION
When adding android platform, it fails to create `capacitor.config.json` due to `assets` directory missing (failed to copy `webDir` but having `server.url` set).

```
[warn] Cannot copy web assets from program to android/app/src/main/assets/public
       Web asset directory specified by webDir does not exist. This is not an error because server.url is set in config.
✖ Creating capacitor.config.json in android/app/src/main/assets - failed!
```