### PR TITLE
chore(cli): missing bundledWebRuntime removal

### DIFF
--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -60,7 +60,6 @@ export async function initCommand(
         appId,
         appName,
         webDir,
-        bundledWebRuntime: false,
         server: {
           androidScheme: androidScheme,
         },


### PR DESCRIPTION
I just noticed I had this unsaved change from https://github.com/ionic-team/capacitor/pull/6420