### PR TITLE
feat(cli): Add support for Android build `--flavor`

### DIFF
--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -13,8 +13,10 @@ export async function buildAndroid(
 ): Promise<void> {
   const releaseType = buildOptions.androidreleasetype ?? 'AAB';
   const releaseTypeIsAAB = releaseType === 'AAB';
-  const flavor = buildOptions.flavor ?? "";
-  const arg = releaseTypeIsAAB ? `:app:bundle${flavor}Release` : `assemble${flavor}Release`;
+  const flavor = buildOptions.flavor ?? '';
+  const arg = releaseTypeIsAAB
+    ? `:app:bundle${flavor}Release`
+    : `assemble${flavor}Release`;
   const gradleArgs = [arg];
 
   if (
@@ -47,7 +49,7 @@ export async function buildAndroid(
     'build',
     'outputs',
     releaseTypeIsAAB ? 'bundle' : 'apk',
-    buildOptions.flavor ? `${flavor}Release`: 'release'
+    buildOptions.flavor ? `${flavor}Release` : 'release',
   );
 
   const unsignedReleaseName = `app${

--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -13,7 +13,8 @@ export async function buildAndroid(
 ): Promise<void> {
   const releaseType = buildOptions.androidreleasetype ?? 'AAB';
   const releaseTypeIsAAB = releaseType === 'AAB';
-  const arg = releaseTypeIsAAB ? ':app:bundleRelease' : 'assembleRelease';
+  const flavor = buildOptions.flavor ?? "";
+  const arg = releaseTypeIsAAB ? `:app:bundle${flavor}Release` : `assemble${flavor}Release`;
   const gradleArgs = [arg];
 
   if (

--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -47,7 +47,7 @@ export async function buildAndroid(
     'build',
     'outputs',
     releaseTypeIsAAB ? 'bundle' : 'apk',
-    'release',
+    buildOptions.flavor ? `${flavor}Release`: 'release'
   );
 
   const unsignedReleaseName = `app${

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -141,6 +141,7 @@ export function runProgram(config: Config): void {
     .command('build <platform>')
     .description('builds the release version of the selected platform')
     .option('--scheme <schemeToBuild>', 'iOS Scheme to build')
+    .option('--flavor <flavorToBuild>', 'Android Flavor to build')
     .option('--keystorepath <keystorePath>', 'Path to the keystore')
     .option('--keystorepass <keystorePass>', 'Password to the keystore')
     .option('--keystorealias <keystoreAlias>', 'Key Alias in the keystore')

--- a/cli/src/tasks/build.ts
+++ b/cli/src/tasks/build.ts
@@ -6,6 +6,7 @@ import { buildiOS } from '../ios/build';
 
 export interface BuildCommandOptions {
   scheme?: string;
+  flavor?: string;
   keystorepath?: string;
   keystorepass?: string;
   keystorealias?: string;
@@ -31,6 +32,7 @@ export async function buildCommand(
 
   const buildCommandOptions: BuildCommandOptions = {
     scheme: buildOptions.scheme || config.ios.scheme,
+    flavor: buildOptions.flavor || config.android.flavor,
     keystorepath:
       buildOptions.keystorepath || config.android.buildOptions.keystorePath,
     keystorepass:


### PR DESCRIPTION
Adds support for Android build flavors via `cap build android --flavor <flavor>`.

closes: https://github.com/ionic-team/capacitor/issues/6269