### PR TITLE
chore(android): hide ObsoleteSdkInt errors

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -60,6 +60,7 @@ android {
         baseline file("lint-baseline.xml")
         abortOnError true
         warningsAsErrors true
+        lintConfig file('lint.xml')
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/android/capacitor/lint.xml
+++ b/android/capacitor/lint.xml
@@ -5,4 +5,5 @@
     <issue id="DiscouragedApi">
         <ignore path="src/main/java/com/getcapacitor/plugin/util/AssetUtil.java" />
     </issue>
+    <issue id="ObsoleteSdkInt" severity="informational" />
 </lint>


### PR DESCRIPTION
made it `informational` instead of `ignore` so it still gets shown in the lint analysis results, so we have the `Build.VERSION.SDK_INT` checks present for future Capacitor updates where we drop support of older Android versions and the code is no longer needed.

closes https://github.com/ionic-team/capacitor/issues/6260