### PR TITLE
fix(android): remove stored references to bridge that holds it in memory

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
@@ -17,7 +17,10 @@ import java.util.Objects;
 public class CapacitorCookieManager extends CookieManager {
 
     private final android.webkit.CookieManager webkitCookieManager;
-    private final Bridge bridge;
+
+    private final String localUrl;
+
+    private final String serverUrl;
 
     /**
      * Create a new cookie manager with the default cookie store and policy
@@ -36,18 +39,19 @@ public class CapacitorCookieManager extends CookieManager {
     public CapacitorCookieManager(CookieStore store, CookiePolicy policy, Bridge bridge) {
         super(store, policy);
         webkitCookieManager = android.webkit.CookieManager.getInstance();
-        this.bridge = bridge;
+        this.localUrl = bridge.getLocalUrl();
+        this.serverUrl = bridge.getServerUrl();
     }
 
     public String getSanitizedDomain(String url) {
         if (url == null || url.isEmpty()) {
-            url = this.bridge.getLocalUrl();
+            url = this.localUrl;
         }
 
         try {
             new URI(url);
         } catch (Exception ex) {
-            return this.bridge.getServerUrl();
+            return this.serverUrl;
         }
 
         return url;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
@@ -31,8 +31,7 @@ public class CapacitorHttp extends Plugin {
             @Override
             public void run() {
                 try {
-                    HttpRequestHandler.bridge = bridge;
-                    JSObject response = HttpRequestHandler.request(call, httpMethod);
+                    JSObject response = HttpRequestHandler.request(call, httpMethod, getBridge());
                     call.resolve(response);
                 } catch (Exception e) {
                     call.reject(e.getLocalizedMessage(), e.getClass().getSimpleName(), e);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -368,7 +368,8 @@ public class HttpRequestHandler {
      * @throws URISyntaxException thrown when the URI is malformed
      * @throws JSONException thrown when the incoming JSON is malformed
      */
-    public static JSObject request(PluginCall call, String httpMethod, Bridge bridge) throws IOException, URISyntaxException, JSONException {
+    public static JSObject request(PluginCall call, String httpMethod, Bridge bridge)
+        throws IOException, URISyntaxException, JSONException {
         String urlString = call.getString("url", "");
         JSObject headers = call.getObject("headers", new JSObject());
         JSObject params = call.getObject("params", new JSObject());

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -27,8 +27,6 @@ import org.json.JSONObject;
 
 public class HttpRequestHandler {
 
-    public static Bridge bridge = null;
-
     /**
      * An enum specifying conventional HTTP Response Types
      * See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
@@ -370,7 +368,7 @@ public class HttpRequestHandler {
      * @throws URISyntaxException thrown when the URI is malformed
      * @throws JSONException thrown when the incoming JSON is malformed
      */
-    public static JSObject request(PluginCall call, String httpMethod) throws IOException, URISyntaxException, JSONException {
+    public static JSObject request(PluginCall call, String httpMethod, Bridge bridge) throws IOException, URISyntaxException, JSONException {
         String urlString = call.getString("url", "");
         JSObject headers = call.getObject("headers", new JSObject());
         JSObject params = call.getObject("params", new JSObject());


### PR DESCRIPTION
Storing references to the Bridge in static classes will hold views in memory outside of their lifecycle, because the Bridge has an activity/fragment variable to keep a reference to its view. This is more obvious in Portals apps where memory leaks were found:

```
┬───
│ GC Root: System class
│
├─ java.net.CookieHandler class
│    Leaking: NO (a class is never leaking)
│    ↓ static CookieHandler.cookieHandler
│                           ~~~~~~~~~~~~~
├─ com.getcapacitor.plugin.CapacitorCookieManager instance
│    Leaking: UNKNOWN
│    Retaining 266.6 kB in 3585 objects
│    ↓ CapacitorCookieManager.bridge
│                             ~~~~~~
├─ com.getcapacitor.Bridge instance
│    Leaking: UNKNOWN
│    Retaining 266.5 kB in 3580 objects
│    context instance of com.vattenfall.androidnative.ui.PortalActivity with
│    mDestroyed = true
│    ↓ Bridge.context
│             ~~~~~~~
╰→ com.vattenfall.androidnative.ui.PortalActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.vattenfall.
​     androidnative.ui.PortalActivity received Activity#onDestroy() callback
​     and Activity#mDestroyed is true)
​     Retaining 170.8 kB in 2801 objects
​     key = d889e27d-5ecc-4c83-a43c-02a2190de86e
​     watchDurationMillis = 5540
​     retainedDurationMillis = 537
​     mApplication instance of com.vattenfall.androidnative.
​     AndroidNativeApplication
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper

METADATA

Build.VERSION.SDK_INT: 31
Build.MANUFACTURER: Google
LeakCanary version: 2.10
App process name: com.vattenfall.androidnative
Class count: 23099
Instance count: 199481
Primitive array count: 133823
Object array count: 28068
Thread count: 35
Heap total bytes: 25058634
Bitmap count: 4
Bitmap total bytes: 153944
Large bitmap count: 0
Large bitmap total bytes: 0
Count of retained yet cleared: 4 KeyedWeakReference instances
Stats: LruCache[maxSize=3000,hits=110723,misses=191299,hitRate=36%]
RandomAccess[bytes=9439717,reads=191299,travel=55942458465,range=30650108,size=3
7711052]
Analysis duration: 3605 ms
```

After removing variables storing the Bridge on the `HttpRequestHandler` (a direct static reference) and on the `CapacitorCookieManager` (stored by static `CookieHandler` reference by the system) this memory leak seems to be resolved.