### PR TITLE
fix(android): Appropriately intercept 302 redirect on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -25,7 +25,12 @@ public class BridgeWebViewClient extends WebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         Uri url = request.getUrl();
-        return bridge.launchIntent(url);
+        boolean shouldOverride = bridge.launchIntent(url);
+        Logger.debug("ShouldOverrideUrlLoading (result:"+shouldOverride+") " + request.getMethod() + ": " + request.getUrl().toString());
+        if (!shouldOverride) {
+            shouldOverride = bridge.getLocalServer().shouldOverrideUrlLoading(view, request);
+        }
+        return shouldOverride;
     }
 
     @Deprecated


### PR DESCRIPTION
The capacitor webview might be sent to an authorization flow and then travel through multiple redirects back to capacitor.

This change addresses an issue where redirects wouldn’t get intercepted by capacitor’s web server as [WebViewClient.shouldInterceptRequest](https://developer.android.com/reference/android/webkit/WebViewClient#shouldInterceptRequest(android.webkit.WebView,%20android.webkit.WebResourceRequest)) is only called for the initial web request and not subsequent redirects. This meant that we could be redirected back to our application without capacitor loaded.

On iOS it appears that redirects are already properly intercepted by capacitor so this fix attempts to get both platforms to behave consistently.

### Caveat
This is behaviour only works on Android SDK 24+ as inspecting that a request is the result of a redirect is only possible from 24 onward.