### PR TITLE
feat(cli): non interactive migrate

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -301,13 +301,15 @@ export function runProgram(config: Config): void {
 
   program
     .command('migrate')
+    .option('--noprompt', 'do not prompt for confirmation')
+    .option('--packagemanager <packageManager>', 'The package manager to use for dependency installs (npm, pnpm, yarn)')
     .description(
       'Migrate your current Capacitor app to the latest major version of Capacitor.',
     )
     .action(
       wrapAction(async () => {
         const { migrateCommand } = await import('./tasks/migrate');
-        await migrateCommand(config);
+        await migrateCommand(config, noprompt, packagemanager);
       }),
     );
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -302,7 +302,10 @@ export function runProgram(config: Config): void {
   program
     .command('migrate')
     .option('--noprompt', 'do not prompt for confirmation')
-    .option('--packagemanager <packageManager>', 'The package manager to use for dependency installs (npm, pnpm, yarn)')
+    .option(
+      '--packagemanager <packageManager>',
+      'The package manager to use for dependency installs (npm, pnpm, yarn)',
+    )
     .description(
       'Migrate your current Capacitor app to the latest major version of Capacitor.',
     )

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -310,7 +310,7 @@ export function runProgram(config: Config): void {
       'Migrate your current Capacitor app to the latest major version of Capacitor.',
     )
     .action(
-      wrapAction(async () => {
+      wrapAction(async ({ noprompt, packagemanager }) => {
         const { migrateCommand } = await import('./tasks/migrate');
         await migrateCommand(config, noprompt, packagemanager);
       }),

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -56,7 +56,11 @@ const coreVersion = 'next'; // TODO: Update when Capacitor 5 releases
 const pluginVersion = 'next'; // TODO: Update when Capacitor 5 releases
 const gradleVersion = '7.5';
 
-export async function migrateCommand(config: Config, noprompt: boolean, packagemanager: string): Promise<void> {
+export async function migrateCommand(
+  config: Config,
+  noprompt: boolean,
+  packagemanager: string,
+): Promise<void> {
   if (config === null) {
     fatal('Config data missing');
   }
@@ -92,30 +96,34 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
 
   logger.info(monorepoWarning);
 
-  const { migrateconfirm } = noprompt ? 'y' : await logPrompt(
-    `Capacitor 5 sets a deployment target of iOS 13 and Android 13 (SDK 33). \n`,
-    {
-      type: 'text',
-      name: 'migrateconfirm',
-      message: `Are you sure you want to migrate? (Y/n)`,
-      initial: 'y',
-    },
-  );
+  const { migrateconfirm } = noprompt
+    ? 'y'
+    : await logPrompt(
+        `Capacitor 5 sets a deployment target of iOS 13 and Android 13 (SDK 33). \n`,
+        {
+          type: 'text',
+          name: 'migrateconfirm',
+          message: `Are you sure you want to migrate? (Y/n)`,
+          initial: 'y',
+        },
+      );
 
   if (
     typeof migrateconfirm === 'string' &&
     migrateconfirm.toLowerCase() === 'y'
   ) {
     try {
-      const { depInstallConfirm } = noprompt ? 'y' : await logPrompt(
-        `Would you like the migrator to run npm, yarn, or pnpm install to install the latest versions of capacitor packages? (Those using other package managers should answer N)`,
-        {
-          type: 'text',
-          name: 'depInstallConfirm',
-          message: `Run Dependency Install? (Y/n)`,
-          initial: 'y',
-        },
-      );
+      const { depInstallConfirm } = noprompt
+        ? 'y'
+        : await logPrompt(
+            `Would you like the migrator to run npm, yarn, or pnpm install to install the latest versions of capacitor packages? (Those using other package managers should answer N)`,
+            {
+              type: 'text',
+              name: 'depInstallConfirm',
+              message: `Run Dependency Install? (Y/n)`,
+              initial: 'y',
+            },
+          );
 
       const runNpmInstall =
         typeof depInstallConfirm === 'string' &&
@@ -123,20 +131,19 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
 
       let installerType = 'npm';
       if (runNpmInstall) {
-        const { manager } = packagemanager ? packagemanager : await logPrompt(
-          'What dependency manager do you use?',
-          {
-            type: 'select',
-            name: 'manager',
-            message: `Dependency Management Tool`,
-            choices: [
-              { title: 'NPM', value: 'npm' },
-              { title: 'Yarn', value: 'yarn' },
-              { title: 'PNPM', value: 'pnpm' },
-            ],
-            initial: 0,
-          },
-        );
+        const { manager } = packagemanager
+          ? packagemanager
+          : await logPrompt('What dependency manager do you use?', {
+              type: 'select',
+              name: 'manager',
+              message: `Dependency Management Tool`,
+              choices: [
+                { title: 'NPM', value: 'npm' },
+                { title: 'Yarn', value: 'yarn' },
+                { title: 'PNPM', value: 'pnpm' },
+              ],
+              initial: 0,
+            });
         installerType = manager;
       }
 

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -97,7 +97,7 @@ export async function migrateCommand(
   logger.info(monorepoWarning);
 
   const { migrateconfirm } = noprompt
-    ? 'y'
+    ? { migrateconfirm: 'y' }
     : await logPrompt(
         `Capacitor 5 sets a deployment target of iOS 13 and Android 13 (SDK 33). \n`,
         {
@@ -114,7 +114,7 @@ export async function migrateCommand(
   ) {
     try {
       const { depInstallConfirm } = noprompt
-        ? 'y'
+        ? { depInstallConfirm: 'y' }
         : await logPrompt(
             `Would you like the migrator to run npm, yarn, or pnpm install to install the latest versions of capacitor packages? (Those using other package managers should answer N)`,
             {
@@ -132,7 +132,7 @@ export async function migrateCommand(
       let installerType = 'npm';
       if (runNpmInstall) {
         const { manager } = packagemanager
-          ? packagemanager
+          ? { manager: packagemanager }
           : await logPrompt('What dependency manager do you use?', {
               type: 'select',
               name: 'manager',

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -56,7 +56,7 @@ const coreVersion = 'next'; // TODO: Update when Capacitor 5 releases
 const pluginVersion = 'next'; // TODO: Update when Capacitor 5 releases
 const gradleVersion = '7.5';
 
-export async function migrateCommand(config: Config): Promise<void> {
+export async function migrateCommand(config: Config, noprompt: boolean, packagemanager: string): Promise<void> {
   if (config === null) {
     fatal('Config data missing');
   }
@@ -92,7 +92,7 @@ export async function migrateCommand(config: Config): Promise<void> {
 
   logger.info(monorepoWarning);
 
-  const { migrateconfirm } = await logPrompt(
+  const { migrateconfirm } = noprompt ? 'y' : await logPrompt(
     `Capacitor 5 sets a deployment target of iOS 13 and Android 13 (SDK 33). \n`,
     {
       type: 'text',
@@ -107,7 +107,7 @@ export async function migrateCommand(config: Config): Promise<void> {
     migrateconfirm.toLowerCase() === 'y'
   ) {
     try {
-      const { depInstallConfirm } = await logPrompt(
+      const { depInstallConfirm } = noprompt ? 'y' : await logPrompt(
         `Would you like the migrator to run npm, yarn, or pnpm install to install the latest versions of capacitor packages? (Those using other package managers should answer N)`,
         {
           type: 'text',
@@ -123,7 +123,7 @@ export async function migrateCommand(config: Config): Promise<void> {
 
       let installerType = 'npm';
       if (runNpmInstall) {
-        const { manager } = await logPrompt(
+        const { manager } = packagemanager ? packagemanager : await logPrompt(
           'What dependency manager do you use?',
           {
             type: 'select',


### PR DESCRIPTION
This adds a non-interactive option for cap migrate so:
npx cap migrate --noprompt --packagemanger pnpm

will migrate to cap 5 without requiring user interaction and use pnpm as the package manager. Package manager can be npm, yarn, pnpm