### PR TITLE
feat(cli): add npm update step to migrate

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -363,6 +363,11 @@ async function installLatestLibs(
   if (runInstall) {
     rimraf.sync(join(config.app.rootDir, 'node_modules/@capacitor/!(cli)'));
     await runCommand(dependencyManager, ['install']);
+    if (dependencyManager == 'yarn') {
+      await runCommand(dependencyManager, ['upgrade']);
+    } else {
+      await runCommand(dependencyManager, ['update']);
+    }
   } else {
     logger.info(
       `Please run an install command with your package manager of choice. (ex: yarn install)`,


### PR DESCRIPTION
Requested by @dtarnawsky as part of #6461 - we now run `npm update` or the equivalent when we migrate.