### PR TITLE
fix(cookies): check isEnabled before setting cookieHandler

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
@@ -20,8 +20,10 @@ public class CapacitorCookies extends Plugin {
     @Override
     public void load() {
         this.bridge.getWebView().addJavascriptInterface(this, "CapacitorCookiesAndroidInterface");
-        this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
-        CookieHandler.setDefault(cookieManager);
+        if (isEnabled()) {
+            this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
+            CookieHandler.setDefault(cookieManager);
+        }
         super.load();
     }
 


### PR DESCRIPTION
This PR fixes a bug on Android where the cookie handler is overwritten even when the plugin is disabled.