### PR TITLE
fix(ios/android): copy url from nativeResponse to response

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -396,6 +396,14 @@ var nativeBridge = (function (exports) {
                                 headers: nativeResponse.headers,
                                 status: nativeResponse.status,
                             });
+                            /*
+                             * copy url to response, `cordova-plugin-ionic` uses this url from the response
+                             * we need `Object.defineProperty` because url is an inherited getter on the Response
+                             * see: https://stackoverflow.com/a/57382543
+                             * */
+                            Object.defineProperty(response, 'url', {
+                                value: nativeResponse.url,
+                            });
                             console.timeEnd(tag);
                             return response;
                         }
@@ -525,10 +533,9 @@ var nativeBridge = (function (exports) {
                                     this._headers = nativeResponse.headers;
                                     this.status = nativeResponse.status;
                                     this.response = nativeResponse.data;
-                                    this.responseText =
-                                        !nativeResponse.headers['Content-Type'].startsWith('application/json')
-                                            ? nativeResponse.data
-                                            : JSON.stringify(nativeResponse.data);
+                                    this.responseText = !nativeResponse.headers['Content-Type'].startsWith('application/json')
+                                        ? nativeResponse.data
+                                        : JSON.stringify(nativeResponse.data);
                                     this.responseURL = nativeResponse.url;
                                     this.readyState = 4;
                                     this.dispatchEvent(new Event('load'));

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -396,6 +396,14 @@ var nativeBridge = (function (exports) {
                                 headers: nativeResponse.headers,
                                 status: nativeResponse.status,
                             });
+                            /*
+                             * copy url to response, `cordova-plugin-ionic` uses this url from the response
+                             * we need `Object.defineProperty` because url is an inherited getter on the Response
+                             * see: https://stackoverflow.com/a/57382543
+                             * */
+                            Object.defineProperty(response, 'url', {
+                                value: nativeResponse.url,
+                            });
                             console.timeEnd(tag);
                             return response;
                         }
@@ -525,10 +533,9 @@ var nativeBridge = (function (exports) {
                                     this._headers = nativeResponse.headers;
                                     this.status = nativeResponse.status;
                                     this.response = nativeResponse.data;
-                                    this.responseText =
-                                        !nativeResponse.headers['Content-Type'].startsWith('application/json')
-                                            ? nativeResponse.data
-                                            : JSON.stringify(nativeResponse.data);
+                                    this.responseText = !nativeResponse.headers['Content-Type'].startsWith('application/json')
+                                        ? nativeResponse.data
+                                        : JSON.stringify(nativeResponse.data);
                                     this.responseURL = nativeResponse.url;
                                     this.readyState = 4;
                                     this.dispatchEvent(new Event('load'));


### PR DESCRIPTION
https://github.com/ionic-team/capacitor/pull/6397 was merged, but it only included the changes in the .ts file, not in the generated .js files

the [4.x cherry-pick](https://github.com/ionic-team/capacitor/pull/6470) is correct, so it's only needed in main branch