### PR TITLE
fix(android): launching intents without host

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -383,7 +383,7 @@ public class Bridge {
 
         Uri appUri = Uri.parse(appUrl);
         if (
-            !(url.getHost().equals(appUri.getHost()) && url.getScheme().equals(appUri.getScheme())) &&
+            !(appUri.getHost().equals(url.getHost()) && url.getScheme().equals(appUri.getScheme())) &&
             !appAllowNavigationMask.matches(url.getHost())
         ) {
             try {


### PR DESCRIPTION
`url` can be a `tel:` or `mailto:` or other app urls that will not include a host, which will make the app to crash because of using `equals` on a null object.
Reversing the check order, since `appUri` will always have a host, it will not crash.

closes https://github.com/ionic-team/capacitor/issues/6483