### PR TITLE
feat(ios): add webContentsDebuggingEnabled configuration

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -438,7 +438,8 @@ export interface CapacitorConfig {
     handleApplicationNotifications?: boolean;
 
     /**
-     * On iOS 16.4 and greater, enable debuggable web content for release builds.
+     * On iOS 16.4 and greater, enable debuggable web content for release builds
+     * Requires Xcode 14.3
      *
      * If not set, it's `true` for development builds.
      *

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -438,8 +438,7 @@ export interface CapacitorConfig {
     handleApplicationNotifications?: boolean;
 
     /**
-     * On iOS 16.4 and greater, enable debuggable web content for release builds
-     * Requires Xcode 14.3
+     * Using Xcode 14.3, on iOS 16.4 and greater, enable debuggable web content for release builds.
      *
      * If not set, it's `true` for development builds.
      *

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -436,6 +436,16 @@ export interface CapacitorConfig {
      * @default true
      */
     handleApplicationNotifications?: boolean;
+
+    /**
+     * On iOS 16.4 and greater, enable debuggable web content for release builds.
+     *
+     * This is always `true` for development builds.
+     *
+     * @since 5.0.0
+     * @default false
+     */
+    webContentsDebuggingEnabled?: boolean;
   };
 
   server?: {

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -442,7 +442,7 @@ export interface CapacitorConfig {
      *
      * This is always `true` for development builds.
      *
-     * @since 5.0.0
+     * @since 4.7.4
      * @default false
      */
     webContentsDebuggingEnabled?: boolean;

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -440,7 +440,7 @@ export interface CapacitorConfig {
     /**
      * On iOS 16.4 and greater, enable debuggable web content for release builds.
      *
-     * This is always `true` for development builds.
+     * If not set, it's `true` for development builds.
      *
      * @since 4.8.0
      * @default false

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -442,7 +442,7 @@ export interface CapacitorConfig {
      *
      * This is always `true` for development builds.
      *
-     * @since 4.7.4
+     * @since 4.8.0
      * @default false
      */
     webContentsDebuggingEnabled?: boolean;

--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2F81F5CA26FB7CB400DD35BE /* CAPBridgeViewController+CDVScreenOrientationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F81F5C826FB7CB400DD35BE /* CAPBridgeViewController+CDVScreenOrientationDelegate.m */; };
 		373A69C1255C9360000A6F44 /* NotificationHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A69C0255C9360000A6F44 /* NotificationHandlerProtocol.swift */; };
 		373A69F2255C95D0000A6F44 /* NotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373A69F1255C95D0000A6F44 /* NotificationRouter.swift */; };
+		4D0D590F29E86FAB008A6833 /* WKWebView+Capacitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D0D590D29E86FAB008A6833 /* WKWebView+Capacitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		501CBAA71FC0A723009B0D4D /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 501CBAA61FC0A723009B0D4D /* WebKit.framework */; };
 		50503EE91FC08595003606DC /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50503EDF1FC08594003606DC /* Capacitor.framework */; };
 		50503EEE1FC08595003606DC /* CapacitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50503EED1FC08595003606DC /* CapacitorTests.swift */; };
@@ -142,6 +143,7 @@
 		2F81F5C826FB7CB400DD35BE /* CAPBridgeViewController+CDVScreenOrientationDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CAPBridgeViewController+CDVScreenOrientationDelegate.m"; sourceTree = "<group>"; };
 		373A69C0255C9360000A6F44 /* NotificationHandlerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandlerProtocol.swift; sourceTree = "<group>"; };
 		373A69F1255C95D0000A6F44 /* NotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRouter.swift; sourceTree = "<group>"; };
+		4D0D590D29E86FAB008A6833 /* WKWebView+Capacitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WKWebView+Capacitor.h"; sourceTree = "<group>"; };
 		501CBAA61FC0A723009B0D4D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		50503EDF1FC08594003606DC /* Capacitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Capacitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50503EE81FC08595003606DC /* CapacitorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CapacitorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -356,6 +358,7 @@
 				62959B112524DA7700A3D7F1 /* Data+Capacitor.swift */,
 				62FABD1925AE5C01007B3814 /* Array+Capacitor.swift */,
 				62D43AEF2581817500673C24 /* WKWebView+Capacitor.swift */,
+				4D0D590D29E86FAB008A6833 /* WKWebView+Capacitor.h */,
 				62D43B642582A13D00673C24 /* WKWebView+Capacitor.m */,
 				2F81F5C726FB7CB400DD35BE /* CAPBridgeViewController+CDVScreenOrientationDelegate.h */,
 				2F81F5C826FB7CB400DD35BE /* CAPBridgeViewController+CDVScreenOrientationDelegate.m */,
@@ -438,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				62959B412524DA7800A3D7F1 /* Capacitor.h in Headers */,
+				4D0D590F29E86FAB008A6833 /* WKWebView+Capacitor.h in Headers */,
 				62959B452524DA7800A3D7F1 /* CAPPlugin.h in Headers */,
 				62959B162524DA7800A3D7F1 /* CAPPluginCall.h in Headers */,
 				62959B3B2524DA7800A3D7F1 /* CAPPluginMethod.h in Headers */,

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
@@ -19,6 +19,7 @@ NS_SWIFT_NAME(InstanceConfiguration)
 @property (nonatomic, readonly) BOOL scrollingEnabled;
 @property (nonatomic, readonly) BOOL allowLinkPreviews;
 @property (nonatomic, readonly) BOOL handleApplicationNotifications;
+@property (nonatomic, readonly) BOOL isWebDebuggable;
 @property (nonatomic, readonly) BOOL cordovaDeployDisabled;
 @property (nonatomic, readonly) UIScrollViewContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior;
 @property (nonatomic, readonly, nonnull) NSURL *appLocation;

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -37,6 +37,7 @@
         _limitsNavigationsToAppBoundDomains = descriptor.limitsNavigationsToAppBoundDomains;
         _preferredContentMode = descriptor.preferredContentMode;
         _pluginConfigurations = descriptor.pluginConfigurations;
+        _isWebDebuggable = descriptor.isWebDebuggable;
         _legacyConfig = descriptor.legacyConfig;
         // construct the necessary URLs
         _localURL = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://%@", descriptor.urlScheme, descriptor.urlHostname]];
@@ -67,6 +68,7 @@
         _scrollingEnabled = configuration.scrollingEnabled;
         _allowLinkPreviews = configuration.allowLinkPreviews;
         _handleApplicationNotifications = configuration.handleApplicationNotifications;
+        _isWebDebuggable = configuration.isWebDebuggable;
         _cordovaDeployDisabled = configuration.cordovaDeployDisabled;
         _contentInsetAdjustmentBehavior = configuration.contentInsetAdjustmentBehavior;
         // we don't care about internal usage of deprecated APIs and the framework should build cleanly

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -94,6 +94,11 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, assign) BOOL handleApplicationNotifications;
 /**
+ @brief Enables web debugging by setting isInspectable of  @c WKWebView to @c true on iOS 16.4 and greater
+ @discussion Defaults to true in debug mode and false in production
+ */
+@property (nonatomic, assign) BOOL isWebDebuggable;
+/**
  @brief How the web view will inset its content
  @discussion Set by @c ios.contentInset in the configuration file. Corresponds to @c contentInsetAdjustmentBehavior on WKWebView.
  */

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
@@ -39,6 +39,7 @@ NSString* const CAPInstanceDescriptorDefaultHostname = @"localhost";
     _scrollingEnabled = YES;
     _allowLinkPreviews = YES;
     _handleApplicationNotifications = YES;
+    _isWebDebuggable = NO;
     _contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     _appLocation = location;
     _limitsNavigationsToAppBoundDomains = FALSE;

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -134,6 +134,9 @@ internal extension InstanceDescriptor {
             if let handleNotifications = config[keyPath: "ios.handleApplicationNotifications"] as? Bool {
                 handleApplicationNotifications = handleNotifications
             }
+            if let webContentsDebuggingEnabled = config[keyPath: "ios.webContentsDebuggingEnabled"] as? Bool {
+                isWebDebuggable = webContentsDebuggingEnabled
+            }
         }
     }
     // swiftlint:enable cyclomatic_complexity

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -136,6 +136,10 @@ internal extension InstanceDescriptor {
             }
             if let webContentsDebuggingEnabled = config[keyPath: "ios.webContentsDebuggingEnabled"] as? Bool {
                 isWebDebuggable = webContentsDebuggingEnabled
+            } else {
+                #if DEBUG
+                    isWebDebuggable = true
+                #endif
             }
         }
     }

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -138,7 +138,7 @@ internal extension InstanceDescriptor {
                 isWebDebuggable = webContentsDebuggingEnabled
             } else {
                 #if DEBUG
-                    isWebDebuggable = true
+                isWebDebuggable = true
                 #endif
             }
         }

--- a/ios/Capacitor/Capacitor/Capacitor.h
+++ b/ios/Capacitor/Capacitor/Capacitor.h
@@ -12,3 +12,5 @@ FOUNDATION_EXPORT const unsigned char CapacitorVersionString[];
 #import <Capacitor/CAPPluginMethod.h>
 #import <Capacitor/CAPInstanceDescriptor.h>
 #import <Capacitor/CAPInstanceConfiguration.h>
+#import <Capacitor/WKWebView+Capacitor.h>
+

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -209,6 +209,8 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
         observers.append(NotificationCenter.default.addObserver(forName: type(of: self).tmpVCAppeared.name, object: .none, queue: .none) { [weak self] _ in
             self?.tmpWindow = nil
         })
+
+        self.setupWebDebugging(configuration: configuration)
     }
 
     deinit {
@@ -434,6 +436,19 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
     func docLink(_ url: String) -> String {
         return "\(type(of: self).capacitorSite)docs/\(url)"
+    }
+
+    private func setupWebDebugging(configuration: InstanceConfiguration) {
+        let isWebDebuggable = configuration.isWebDebuggable
+        if isWebDebuggable, #unavailable(iOS 16.4) {
+            CAPLog.print("⚡️ Warning: isWebDebuggable only functions as intended on iOS 16.4 and above.")
+        }
+
+        if isDevEnvironment {
+            self.webView?.setInspectableIfRequired(true)
+        } else {
+            self.webView?.setInspectableIfRequired(isWebDebuggable)
+        }
     }
 
     /**

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -444,11 +444,7 @@ internal class CapacitorBridge: NSObject, CAPBridgeProtocol {
             CAPLog.print("⚡️ Warning: isWebDebuggable only functions as intended on iOS 16.4 and above.")
         }
 
-        if isDevEnvironment {
-            self.webView?.setInspectableIfRequired(true)
-        } else {
-            self.webView?.setInspectableIfRequired(isWebDebuggable)
-        }
+        self.webView?.setInspectableIfRequired(isWebDebuggable)
     }
 
     /**

--- a/ios/Capacitor/Capacitor/WKWebView+Capacitor.h
+++ b/ios/Capacitor/Capacitor/WKWebView+Capacitor.h
@@ -1,0 +1,11 @@
+@import UIKit;
+@import WebKit;
+
+#ifndef WKWebView_Capacitor_h
+#define WKWebView_Capacitor_h
+
+@interface WKWebView (CapacitorInspectablity)
+- (void)setInspectableIfRequired: (BOOL)shouldInspect;
+@end
+
+#endif /* WKWebView_Capacitor_h */

--- a/ios/Capacitor/Capacitor/WKWebView+Capacitor.m
+++ b/ios/Capacitor/Capacitor/WKWebView+Capacitor.m
@@ -13,3 +13,16 @@
     [self _swizzleKeyboardMethods];
 }
 @end
+
+// TODO: Remove this after Xcode 14.3 is required
+@implementation WKWebView (CapacitorInspectablity)
+
+- (void)setInspectableIfRequired: (BOOL)shouldInspect {
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+    if (@available(iOS 16.4, *)) {
+        self.inspectable = shouldInspect;
+    }
+    #endif
+}
+
+@end

--- a/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
+++ b/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
@@ -116,7 +116,7 @@ internal extension WKWebView {
     // This is in here because iOS 16.4 needs this - but will fail to compile under Xcode < 14.3
     func setInspectableIfRequired(_ shouldInspect: Bool) {
         if responds(to: Selector(("setInspectable:"))) {
-            perform(Selector(("setInspectable:")), with: NSNumber(booleanLiteral: shouldInspect))
+            perform(Selector(("setInspectable:")), with: ObjCBool(booleanLiteral: shouldInspect))
         }
     }
 }

--- a/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
+++ b/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
@@ -111,12 +111,4 @@ internal extension WKWebView {
             objc_setAssociatedObject(self, &associatedKeyboardFlagHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
-
-    // TODO: Remove this after Xcode 14.3 is required
-    // This is in here because iOS 16.4 needs this - but will fail to compile under Xcode < 14.3
-    func setInspectableIfRequired(_ shouldInspect: Bool) {
-        if responds(to: Selector(("setInspectable:"))) {
-            perform(Selector(("setInspectable:")), with: ObjCBool(booleanLiteral: shouldInspect))
-        }
-    }
 }

--- a/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
+++ b/ios/Capacitor/Capacitor/WKWebView+Capacitor.swift
@@ -111,4 +111,12 @@ internal extension WKWebView {
             objc_setAssociatedObject(self, &associatedKeyboardFlagHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
+
+    // TODO: Remove this after Xcode 14.3 is required
+    // This is in here because iOS 16.4 needs this - but will fail to compile under Xcode < 14.3
+    func setInspectableIfRequired(_ shouldInspect: Bool) {
+        if responds(to: Selector(("setInspectable:"))) {
+            perform(Selector(("setInspectable:")), with: NSNumber(booleanLiteral: shouldInspect))
+        }
+    }
 }


### PR DESCRIPTION
allow WKWebViews to be inspectable in 16.4 without using the 16.4 SDK with Xcode 14.3