### PR TITLE
fix(cookies): init cookie manager after server url is set

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
@@ -20,17 +20,18 @@ public class CapacitorCookies extends Plugin {
     @Override
     public void load() {
         this.bridge.getWebView().addJavascriptInterface(this, "CapacitorCookiesAndroidInterface");
-        if (isEnabled()) {
-            this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
-            CookieHandler.setDefault(cookieManager);
-        }
         super.load();
     }
 
     @JavascriptInterface
     public boolean isEnabled() {
         PluginConfig pluginConfig = getBridge().getConfig().getPluginConfiguration("CapacitorCookies");
-        return pluginConfig.getBoolean("enabled", false);
+        boolean isEnabled = pluginConfig.getBoolean("enabled", false);
+        if (isEnabled) {
+            this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
+            CookieHandler.setDefault(cookieManager);
+        }
+        return isEnabled;
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue with `CapacitorCookies` where `localUrl` and `serverUrl` were initialized to null due to the plugin loading before the WebView. Instead we move the initialization of the `cookieManager` to after the patching of `document.cookie`

Addresses: #6467 and #6479 in `4.x`