### PR TITLE
fix(cli): Pin @ionic/utils-subprocess version for node 12 support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@ionic/cli-framework-output": "^2.2.5",
     "@ionic/utils-fs": "^3.1.6",
-    "@ionic/utils-subprocess": "^2.1.11",
+    "@ionic/utils-subprocess": "2.1.11",
     "@ionic/utils-terminal": "^2.3.3",
     "commander": "^9.3.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
Latest release of @ionic/utils-subprocess doesn't work on node 12.
While docs say that Capacitor 4 supports node 14 and newer, on code it requires node 12.4 or newer, so I think it should still work there.
Or if not, we should change the node check to require node 14 so the users see an error about the node version being unsupported rather than a weird message