### PR TITLE
feat(cli): Pin shared dependencies that accidentally changed the node engine requirements

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,10 +44,10 @@
     "watch": "npm run assets && tsc -w"
   },
   "dependencies": {
-    "@ionic/cli-framework-output": "^2.2.5",
-    "@ionic/utils-fs": "^3.1.6",
-    "@ionic/utils-subprocess": "^2.1.11",
-    "@ionic/utils-terminal": "^2.3.3",
+    "@ionic/cli-framework-output": "2.2.5",
+    "@ionic/utils-fs": "3.1.6",
+    "@ionic/utils-subprocess": "2.1.11",
+    "@ionic/utils-terminal": "2.3.3",
     "commander": "^9.3.0",
     "debug": "^4.3.4",
     "env-paths": "^2.2.0",


### PR DESCRIPTION
When Ionic CLI began requiring Node 16 this requirement accidentally was pulled into the Capacitor CLI. So this PR pins the Dependencies for Capacitor 4:
    "@ionic/cli-framework-output": "2.2.5",
    "@ionic/utils-fs": "3.1.6",
    "@ionic/utils-subprocess": "2.1.11",
    "@ionic/utils-terminal": "2.3.3",