### PR TITLE
fix(cli): Pin @Ionic dependencies for node 12 support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -44,10 +44,10 @@
     "watch": "npm run assets && tsc -w"
   },
   "dependencies": {
-    "@ionic/cli-framework-output": "^2.2.1",
-    "@ionic/utils-fs": "^3.1.5",
-    "@ionic/utils-subprocess": "^2.1.6",
-    "@ionic/utils-terminal": "^2.3.0",
+    "@ionic/cli-framework-output": "2.2.5",
+    "@ionic/utils-fs": "3.1.6",
+    "@ionic/utils-subprocess": "2.1.11",
+    "@ionic/utils-terminal": "2.3.3",
     "commander": "^6.0.0",
     "debug": "^4.2.0",
     "env-paths": "^2.2.0",


### PR DESCRIPTION
same as https://github.com/ionic-team/capacitor/pull/6527 but for Capacitor 3