### PR TITLE
fix(ci): use macos-11 to run and pin @types/node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - run: npm test
         working-directory: ./core
   test-ios:
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 30
     needs:
       - setup
@@ -128,7 +128,7 @@ jobs:
       - run: npm run verify
         working-directory: ./android
   deploy-next:
-    runs-on: macos-latest
+    runs-on: macos-11
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Release') && (contains(github.event.head_commit.message, 'rc') || contains(github.event.head_commit.message, 'beta') || contains(github.event.head_commit.message, 'alpha'))
     timeout-minutes: 30
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: ~/.npm
           key: ${{ runner.OS }}-dependency-cache-${{ hashFiles('**/package.json') }}
   lint:
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 30
     steps:
       - uses: actions/setup-node@v1
@@ -43,7 +43,7 @@ jobs:
       - run: npm install
       - run: npm run lint
   test-cli:
-    runs-on: macos-latest
+    runs-on: macos-11
     timeout-minutes: 30
     needs:
       - setup
@@ -154,7 +154,7 @@ jobs:
       - run: npm install
       - run: npm run lerna:publish:next || true
   deploy-latest:
-    runs-on: macos-latest
+    runs-on: macos-11
     if: github.event_name == 'push' && github.ref == 'refs/heads/3.x' && startsWith(github.event.head_commit.message, 'Release') && (!contains(github.event.head_commit.message, 'rc') && !contains(github.event.head_commit.message, 'beta') && !contains(github.event.head_commit.message, 'alpha'))
     timeout-minutes: 30
     needs:

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,6 +48,7 @@
     "@ionic/utils-fs": "^3.1.5",
     "@ionic/utils-subprocess": "^2.1.6",
     "@ionic/utils-terminal": "^2.3.0",
+    "@types/node": "18.11.18",
     "commander": "^6.0.0",
     "debug": "^4.2.0",
     "env-paths": "^2.2.0",


### PR DESCRIPTION
3.x branch doesn't build on the ci because of macos-latest not having xcode 12.4 and a problem on latest @types/node
use macos-11 and pin @types/node version so it builds