### PR TITLE
fix(ios): set cors headers in asset handler for live reload

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -42,7 +42,7 @@ import Cordova
         setScreenOrientationDefaults()
 
         // get the web view
-        let assetHandler = WebViewAssetHandler(router: router())
+        let assetHandler = WebViewAssetHandler(router: router(), serverURL: configuration.serverURL.absoluteString)
         assetHandler.setAssetPath(configuration.appLocation.path)
         let delegationHandler = WebViewDelegationHandler()
         prepareWebView(with: configuration, assetHandler: assetHandler, delegationHandler: delegationHandler)

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -44,7 +44,7 @@ import Cordova
         // get the web view
         let assetHandler = WebViewAssetHandler(router: router())
         assetHandler.setAssetPath(configuration.appLocation.path)
-        assetHandler.setServerUrl(configuration.serverURL.absoluteString)
+        assetHandler.setServerUrl(configuration.serverURL)
         let delegationHandler = WebViewDelegationHandler()
         prepareWebView(with: configuration, assetHandler: assetHandler, delegationHandler: delegationHandler)
         view = webView

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -42,8 +42,9 @@ import Cordova
         setScreenOrientationDefaults()
 
         // get the web view
-        let assetHandler = WebViewAssetHandler(router: router(), serverURL: configuration.serverURL.absoluteString)
+        let assetHandler = WebViewAssetHandler(router: router())
         assetHandler.setAssetPath(configuration.appLocation.path)
+        assetHandler.setServerUrl(configuration.serverURL.absoluteString)
         let delegationHandler = WebViewDelegationHandler()
         prepareWebView(with: configuration, assetHandler: assetHandler, delegationHandler: delegationHandler)
         view = webView

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -26,8 +26,9 @@ open class CAPWebView: UIView {
     private lazy var configuration = InstanceConfiguration(with: configDescriptor, isDebug: CapacitorBridge.isDevEnvironment)
 
     private lazy var assetHandler: WebViewAssetHandler = {
-        let handler = WebViewAssetHandler(router: router, serverURL: bridge.config.serverURL.absoluteString)
+        let handler = WebViewAssetHandler(router: router)
         handler.setAssetPath(configuration.appLocation.path)
+        handler.setServerUrl(bridge.config.serverURL.absoluteString)
         return handler
     }()
 

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -26,7 +26,7 @@ open class CAPWebView: UIView {
     private lazy var configuration = InstanceConfiguration(with: configDescriptor, isDebug: CapacitorBridge.isDevEnvironment)
 
     private lazy var assetHandler: WebViewAssetHandler = {
-        let handler = WebViewAssetHandler(router: router)
+        let handler = WebViewAssetHandler(router: router, serverURL: bridge.config.serverURL.absoluteString)
         handler.setAssetPath(configuration.appLocation.path)
         return handler
     }()

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -28,7 +28,7 @@ open class CAPWebView: UIView {
     private lazy var assetHandler: WebViewAssetHandler = {
         let handler = WebViewAssetHandler(router: router)
         handler.setAssetPath(configuration.appLocation.path)
-        handler.setServerUrl(bridge.config.serverURL.absoluteString)
+        handler.setServerUrl(bridge.config.serverURL)
         return handler
     }()
 

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -5,7 +5,7 @@ import MobileCoreServices
 // swiftlint:disable type_body_length
 internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
     private var router: Router
-    private var serverUrl: String?
+    private var serverUrl: URL?
 
     init(router: Router) {
         self.router = router
@@ -16,7 +16,7 @@ internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
         router.basePath = assetPath
     }
 
-    func setServerUrl(_ serverUrl: String?) {
+    func setServerUrl(_ serverUrl: URL?) {
         self.serverUrl = serverUrl
     }
 
@@ -43,8 +43,8 @@ internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             ]
 
             // if using live reload, then set CORS headers
-            if self.serverUrl != nil && self.serverUrl != localUrl.absoluteString {
-                headers["Access-Control-Allow-Origin"] = self.serverUrl
+            if self.serverUrl != nil && self.serverUrl?.scheme != localUrl.scheme  {
+                headers["Access-Control-Allow-Origin"] = self.serverUrl?.absoluteString
                 headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
             }
 

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -5,9 +5,11 @@ import MobileCoreServices
 // swiftlint:disable type_body_length
 internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
     private var router: Router
+    private var serverURL: String
 
-    init(router: Router) {
+    init(router: Router, serverURL: String) {
         self.router = router
+        self.serverURL = serverURL
         super.init()
     }
 
@@ -33,6 +35,8 @@ internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             var data = Data()
             let mimeType = mimeTypeForExtension(pathExtension: url.pathExtension)
             var headers =  [
+                "Access-Control-Allow-Origin": self.serverURL,
+                "Access-Control-Allow-Methods": "GET, OPTIONS",
                 "Content-Type": mimeType,
                 "Cache-Control": "no-cache"
             ]

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -16,7 +16,7 @@ internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
         router.basePath = assetPath
     }
 
-    func setServerUrl(_ serverUrl: String) {
+    func setServerUrl(_ serverUrl: String?) {
         self.serverUrl = serverUrl
     }
 


### PR DESCRIPTION
Addresses: #4089

This PR sets CORS headers so local files can be fetched on iOS while using live reload.