### PR TITLE
chore(ci): enable npm package provenance

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -2,6 +2,10 @@ name: Publish Latest
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish-npm-latest:
     uses: ./.github/workflows/publish-npm-latest.yml

--- a/.github/workflows/publish-npm-alpha.yml
+++ b/.github/workflows/publish-npm-alpha.yml
@@ -2,34 +2,33 @@ name: Publish NPM Alpha
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-alpha:
     runs-on: macos-12
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
+          npm whoami
           npm run ci:publish:alpha

--- a/.github/workflows/publish-npm-beta.yml
+++ b/.github/workflows/publish-npm-beta.yml
@@ -2,6 +2,10 @@ name: Publish NPM Beta
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-beta:
     runs-on: macos-12
@@ -13,23 +17,18 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
+          npm whoami
           npm run ci:publish:beta

--- a/.github/workflows/publish-npm-dev.yml
+++ b/.github/workflows/publish-npm-dev.yml
@@ -2,36 +2,36 @@ name: Publish NPM Dev
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-dev:
     runs-on: macos-12
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - name: NPM Install
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
           echo $GITHUB_REF_NAME
-          npx lerna publish prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +"%Y%m%dT%H%M%S") --dist-tag dev --allow-branch $GITHUB_REF_NAME --force-publish --no-verify-access --no-changelog --no-git-tag-version --no-push --yes
+          npm whoami
+          npx lerna version prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +"%Y%m%dT%H%M%S") --allow-branch $GITHUB_REF_NAME --force-publish --no-changelog --no-git-tag-version --no-push --yes
+          npx lerna exec -- npm publish --tag dev --provenance

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -9,6 +9,10 @@ on:
         required: true
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-latest:
     if: github.ref == 'refs/heads/main'
@@ -21,23 +25,18 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
+          npm whoami
           npm run ci:publish:latest

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -4,6 +4,10 @@ on:
  schedule:
    - cron: '0 15 * * 1-5'
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-nightly:
     if: github.ref == 'refs/heads/main'
@@ -16,23 +20,18 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
+          npm whoami
           npm run ci:publish:nightly

--- a/.github/workflows/publish-npm-rc.yml
+++ b/.github/workflows/publish-npm-rc.yml
@@ -2,34 +2,33 @@ name: Publish NPM RC
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   deploy-npm-rc:
     runs-on: macos-12
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - name: NPM ^9.5.0
-        run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - name: Restore Dependency Cache
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: '**/package.json'
       - run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          npm whoami
           npm install
       - name: Version & Publish
         env: 
           GH_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           git config user.name "Github Workflow (on behalf of ${{ github.actor }})"
           git config user.email "users.noreply.github.com"
+          npm whoami
           npm run ci:publish:rc

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "./core/"
   ],
   "scripts": {
-    "ci:publish:nightly": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid nightly-$(date +\"%Y%m%dT%H%M%S\") --dist-tag nightly --force-publish --no-verify-access --no-changelog --no-git-tag-version --no-push --yes",
-    "ci:publish:alpha": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid alpha --dist-tag next --force-publish --no-verify-access --yes",
-    "ci:publish:beta": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid beta --dist-tag next --force-publish --no-verify-access --yes",
-    "ci:publish:rc": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid rc --dist-tag next --force-publish --no-verify-access --yes",
-    "ci:publish:latest": "lerna publish --conventional-commits --dist-tag latest --force-publish --no-verify-access --yes",
-    "ci:publish:dev": "lerna publish prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +\"%Y%m%dT%H%M%S\") --dist-tag dev --force-publish --no-verify-access --no-changelog --no-git-tag-version --no-push --yes",
+    "ci:publish:nightly": "lerna version prerelease --conventional-commits --conventional-prerelease --preid nightly-$(date +\"%Y%m%dT%H%M%S\") --force-publish --no-changelog --no-git-tag-version --no-push --yes && lerna exec -- npm publish --tag nightly --provenance",
+    "ci:publish:alpha": "lerna version prerelease --conventional-commits --conventional-prerelease --preid alpha --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
+    "ci:publish:beta": "lerna version prerelease --conventional-commits --conventional-prerelease --preid beta --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
+    "ci:publish:rc": "lerna version prerelease --conventional-commits --conventional-prerelease --preid rc --force-publish --yes && lerna exec -- npm publish --tag next --provenance",
+    "ci:publish:latest": "lerna version --conventional-commits --force-publish --yes && lerna exec -- npm publish --tag latest --provenance",
+    "ci:publish:dev": "lerna version prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +\"%Y%m%dT%H%M%S\") --force-publish --no-changelog --no-git-tag-version --no-push --yes && lerna exec -- npm publish --tag dev --provenance",
     "build:nativebridge": "lerna run build:nativebridge",
     "sync-peer-dependencies": "node scripts/sync-peer-dependencies.mjs",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",


### PR DESCRIPTION
See https://github.blog/2023-04-19-introducing-npm-package-provenance/

This also cleans up the following in the GitHub Actions workflows:
* npm 9.5 is now included with node 18
* use setup-node to [cache package data](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data)
* use setup-node to configure npm token via [NODE_AUTH_TOKEN](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)