### PR TITLE
fix(cli): Move package to build.gradle in Capacitor plugins

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -31,6 +31,7 @@ import {
 } from '../plugin';
 import type { Plugin } from '../plugin';
 import { copy as copyTask } from '../tasks/copy';
+import { patchOldCapacitorPlugins } from '../tasks/migrate';
 import { convertToUnixPath } from '../util/fs';
 import { resolveNode } from '../util/node';
 import { extractTemplate } from '../util/template';
@@ -54,6 +55,7 @@ export async function updateAndroid(config: Config): Promise<void> {
   const cordovaPlugins = plugins.filter(
     p => getPluginType(p, platform) === PluginType.Cordova,
   );
+  await patchOldCapacitorPlugins(config);
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
   }

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -8,11 +8,13 @@ import {
 import { join } from 'path';
 import rimraf from 'rimraf';
 
+import { getAndroidPlugins } from '../android/common';
 import c from '../colors';
 import { getCoreVersion, runTask, checkJDKMajorVersion } from '../common';
 import type { Config } from '../definitions';
 import { fatal } from '../errors';
 import { logger, logPrompt, logSuccess } from '../log';
+import { getPlugins } from '../plugin';
 import { deleteFolderRecursive } from '../util/fs';
 import { runCommand, getCommandOutput } from '../util/subprocess';
 import { extractTemplate } from '../util/template';
@@ -312,6 +314,13 @@ export async function migrateCommand(
         });
 
         rimraf.sync(join(config.android.appDirAbs, 'build'));
+
+        await runTask(
+          'Migrating package from Manifest to build.gradle in Capacitor plugins',
+          () => {
+            return patchOldCapacitorPlugins(config);
+          },
+        );
       }
 
       // Run Cap Sync
@@ -662,24 +671,19 @@ async function movePackageFromManifestToBuildGradle(
   }
 
   let packageName: string;
-  const manifestRegEx = new RegExp(/<manifest ([^>]*package="(.+)"[^>]*)>/);
+  const manifestRegEx = new RegExp(/package="(.+)"/);
   const manifestResults = manifestRegEx.exec(manifestText);
 
   if (manifestResults === null) {
-    logger.error(`Unable to update Android Manifest. Missing <activity> tag`);
+    logger.error(`Unable to update Android Manifest. Package not found.`);
     return;
   } else {
-    packageName = manifestResults[2];
+    packageName = manifestResults[1];
   }
 
   let manifestReplaced = manifestText;
 
-  manifestReplaced = setAllStringIn(
-    manifestText,
-    '<manifest xmlns:android="http://schemas.android.com/apk/res/android"',
-    '>',
-    ``,
-  );
+  manifestReplaced = manifestReplaced.replace(manifestRegEx, '');
 
   if (manifestText == manifestReplaced) {
     logger.error(
@@ -826,4 +830,37 @@ function setAllStringIn(
     }
   }
   return result;
+}
+
+export async function patchOldCapacitorPlugins(
+  config: Config,
+): Promise<void[]> {
+  const allPlugins = await getPlugins(config, 'android');
+  const androidPlugins = await getAndroidPlugins(allPlugins);
+  return await Promise.all(
+    androidPlugins.map(async p => {
+      if (p.manifest?.android?.src) {
+        const buildGradlePath = join(
+          config.app.rootDir,
+          'node_modules',
+          p.id,
+          p.manifest.android.src,
+          'build.gradle',
+        );
+        const manifestPath = join(
+          config.app.rootDir,
+          'node_modules',
+          p.id,
+          p.manifest.android.src,
+          'src',
+          'main',
+          'AndroidManifest.xml',
+        );
+        const gradleContent = readFile(buildGradlePath);
+        if (!gradleContent?.includes('namespace')) {
+          movePackageFromManifestToBuildGradle(manifestPath, buildGradlePath);
+        }
+      }
+    }),
+  );
 }


### PR DESCRIPTION
Make migrate and update commands to patch Capacitor plugins that have not been updated to move their package from `AndroidManifest.xml` to `build.gradle`.

Also changed the regular expression for finding the package as it was not working if the package was before the schema or the manifest tag had multiple lines, now just search for the package and deletes that text.
