### PR TITLE
java version fix

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -536,7 +536,7 @@ export function resolvePlatform(
 }
 
 export async function checkJDKMajorVersion(): Promise<number> {
-  const string = await runCommand('java', ['--version']);
+  const string = await runCommand('java', ['-version']);
   const versionRegex = RegExp(/([0-9]+)\.?([0-9]*)\.?([0-9]*)/);
   const versionMatch = versionRegex.exec(string);
 


### PR DESCRIPTION
`npx cap migrate` breaks with `java --version`