### PR TITLE
fix(cli): Don't remove jetifier if some plugin needs it

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -31,7 +31,10 @@ import {
 } from '../plugin';
 import type { Plugin } from '../plugin';
 import { copy as copyTask } from '../tasks/copy';
-import { patchOldCapacitorPlugins } from '../tasks/migrate';
+import {
+  patchOldCapacitorPlugins,
+  updateGradleProperties,
+} from '../tasks/migrate';
 import { convertToUnixPath } from '../util/fs';
 import { resolveNode } from '../util/node';
 import { extractTemplate } from '../util/template';
@@ -56,6 +59,7 @@ export async function updateAndroid(config: Config): Promise<void> {
     p => getPluginType(p, platform) === PluginType.Cordova,
   );
   await patchOldCapacitorPlugins(config);
+  await updateGradleProperties(config);
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
   }

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -630,8 +630,9 @@ export async function updateGradleProperties(config: Config): Promise<void> {
   if (txt.includes(jetifierText) && !(await needsJetifier(config))) {
     txt = txt.replace(jetifierText, '').replace(commentText, '');
   } else if (!txt.includes(jetifierText) && (await needsJetifier(config))) {
-    txt = txt.concat(commentText).concat(jetifierText);
-    logger.info(`gradle.properties was modified to add ${jetifierText}`);
+    logger.warn(
+      `Some of your plugins require jetifier to be enabled. Add the following line to android/gradle.properties:\n${jetifierText}`,
+    );
   }
   writeFileSync(filename, txt, { encoding: 'utf-8' });
 }


### PR DESCRIPTION
So far it only checks for `@ionic-enterprise/identity-vault`, but made it an array so we can easily add more plugins if needed.

Migrate won't remove the jetifier lines if the plugin is present, update will also remove or add the lines if needed if the plugin gets uninstalled or installed.