### PR TITLE
fix(android): migrate command in monorepos

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -842,14 +842,12 @@ export async function patchOldCapacitorPlugins(
     androidPlugins.map(async p => {
       if (p.manifest?.android?.src) {
         const buildGradlePath = resolveNode(
-          config.app.rootDir,
-          p.id,
+          p.rootPath,
           p.manifest.android.src,
           'build.gradle',
         );
         const manifestPath = resolveNode(
-          config.app.rootDir,
-          p.id,
+          p.rootPath,
           p.manifest.android.src,
           'src',
           'main',


### PR DESCRIPTION
Migrating to capacitor 5, I found this migration script not working in a monorepo where the capacitor node_modules were not in the same directory as `rootPath` which is `process.cwd()`. 

Instead, I've changed the module resolution to pull from the module's `rootPath` so it will work however it's installed.