### PR TITLE
fix(cli): correct migration of package from AndroidManifest.xml to build.gradle

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -690,7 +690,7 @@ async function movePackageFromManifestToBuildGradle(
   }
 
   let packageName: string;
-  const manifestRegEx = new RegExp(/package="(.+)"/);
+  const manifestRegEx = new RegExp(/package="([^"]+)"/);
   const manifestResults = manifestRegEx.exec(manifestText);
 
   if (manifestResults === null) {


### PR DESCRIPTION
When AndroidManifest.xml contains other attributes after the package, the regex matches all attributes and writes all of them into build.gradle.

If AndroidManifest.xml contains:
<manifest package="com.example.app" xmlns:android="http://schemas.android.com/apk/res/android">

app/build.gradle will contains xmlns:android property and 'Upgrading gradle wrapper files' fails
 android {
    namespace "com.example.app" xmlns:android="http://schemas.android.com/apk/res/android"