### PR TITLE
Update gradlew

### DIFF
--- a/android/gradlew
+++ b/android/gradlew
@@ -119,9 +119,9 @@ CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+    if [ -x "$JAVA_HOME/jbr/sh/java" ] ; then
         # IBM's JDK on AIX uses strange locations for the executables
-        JAVACMD=$JAVA_HOME/jre/sh/java
+        JAVACMD=$JAVA_HOME/jbr/sh/java
     else
         JAVACMD=$JAVA_HOME/bin/java
     fi


### PR DESCRIPTION
As I know in Android Studio Electric Eel, the bundled Java was moved to `/Applications/Android Studio.app/Contents/jbr/Contents/Home` from `/Applications/Android Studio.app/Contents/jre/Contents/Home`.

`jbr` -> `jre`