### PR TITLE
feat: export buildRequestInit function so we can use for downloadFile

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -20,7 +20,12 @@ export { Capacitor, registerPlugin } from './global';
 export { WebPlugin, WebPluginConfig, ListenerCallback } from './web-plugin';
 
 // Core Plugins APIs
-export { CapacitorCookies, CapacitorHttp, WebView, buildRequestInit } from './core-plugins';
+export {
+  CapacitorCookies,
+  CapacitorHttp,
+  WebView,
+  buildRequestInit,
+} from './core-plugins';
 
 // Core Plugin definitions
 export type {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -20,7 +20,7 @@ export { Capacitor, registerPlugin } from './global';
 export { WebPlugin, WebPluginConfig, ListenerCallback } from './web-plugin';
 
 // Core Plugins APIs
-export { CapacitorCookies, CapacitorHttp, WebView } from './core-plugins';
+export { CapacitorCookies, CapacitorHttp, WebView, buildRequestInit } from './core-plugins';
 
 // Core Plugin definitions
 export type {


### PR DESCRIPTION
This PR exports the `buildRequestInit` function from the core `CapacitorHttp` plugin so that `downloadFile` (and other libraries) can use the utility function.