### PR TITLE
Add support for setting allowBackForwardNavigationGestures on iOS Webview

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -288,6 +288,7 @@ extension CAPBridgeViewController {
         aWebView.scrollView.contentInsetAdjustmentBehavior = configuration.contentInsetAdjustmentBehavior
         aWebView.allowsLinkPreview = configuration.allowLinkPreviews
         aWebView.scrollView.isScrollEnabled = configuration.scrollingEnabled
+        aWebView..allowBackForwardNavigationGestures = configuration.allowBackForwardNavigationGestures
         if let overrideUserAgent = configuration.overridenUserAgentString {
             aWebView.customUserAgent = overrideUserAgent
         }

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -29,6 +29,7 @@
                 break;
         }
         _scrollingEnabled = descriptor.scrollingEnabled;
+        _allowBackForwardNavigationGestures = descriptor.allowBackForwardNavigationGestures;
         _allowLinkPreviews = descriptor.allowLinkPreviews;
         _handleApplicationNotifications = descriptor.handleApplicationNotifications;
         _contentInsetAdjustmentBehavior = descriptor.contentInsetAdjustmentBehavior;
@@ -66,6 +67,7 @@
         _pluginConfigurations = [[configuration pluginConfigurations] copy];
         _loggingEnabled = configuration.loggingEnabled;
         _scrollingEnabled = configuration.scrollingEnabled;
+        _allowBackForwardNavigationGestures = configuration.allowBackForwardNavigationGestures;
         _allowLinkPreviews = configuration.allowLinkPreviews;
         _handleApplicationNotifications = configuration.handleApplicationNotifications;
         _isWebDebuggable = configuration.isWebDebuggable;

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -84,6 +84,11 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, assign) BOOL scrollingEnabled;
 /**
+ @brief Whether or not the user can navigate through forward and backward gestures.
+ @discussion Set by @c ios.allowBackForwardNavigationGestures in the configuration file. Corresponds to @c allowBackForwardNavigationGestures on WKWebView.
+ */
+@property (nonatomic, assign) BOOL allowBackForwardNavigationGestures;
+/**
  @brief Whether or not the web view will preview links.
  @discussion Set by @c ios.allowsLinkPreview in the configuration file. Corresponds to @c allowsLinkPreview on WKWebView.
  */

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
@@ -37,6 +37,7 @@ NSString* const CAPInstanceDescriptorDefaultHostname = @"localhost";
     _legacyConfig = @{};
     _loggingBehavior = CAPInstanceLoggingBehaviorDebug;
     _scrollingEnabled = YES;
+    _allowBackForwardNavigationGestures = NO;
     _allowLinkPreviews = YES;
     _handleApplicationNotifications = YES;
     _isWebDebuggable = NO;

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -114,6 +114,11 @@ internal extension InstanceDescriptor {
             if let scrollEnabled = config[keyPath: "ios.scrollEnabled"] as? Bool {
                 scrollingEnabled = scrollEnabled
             }
+
+            if let allowBackForwardNav = config[keyPath: "ios.allowsBackForwardNavigationGestures"] as? Bool {
+                allowsBackForwardNavigationGestures = allowBackForwardNav
+            }
+            
             if let pluginConfig = config[keyPath: "plugins"] as? JSObject {
                 pluginConfigurations = pluginConfig
             }

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -158,6 +158,7 @@ extension CAPWebView {
         webView.scrollView.contentInsetAdjustmentBehavior = configuration.contentInsetAdjustmentBehavior
         webView.allowsLinkPreview = configuration.allowLinkPreviews
         webView.scrollView.isScrollEnabled = configuration.scrollingEnabled
+        webview.allowBackForwardNavigationGestures = configuration.allowBackForwardNavigationGestures
 
         if let overrideUserAgent = configuration.overridenUserAgentString {
             webView.customUserAgent = overrideUserAgent

--- a/ios/Capacitor/CapacitorTests/ConfigurationTests.swift
+++ b/ios/Capacitor/CapacitorTests/ConfigurationTests.swift
@@ -57,6 +57,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(descriptor.urlHostname, "localhost")
         XCTAssertNil(descriptor.serverURL)
         XCTAssertTrue(descriptor.scrollingEnabled)
+        XCTAssertTrue(descriptor.allowBackForwardNavigationGestures)
         XCTAssertEqual(descriptor.loggingBehavior, .debug)
         XCTAssertTrue(descriptor.allowLinkPreviews)
         XCTAssertEqual(descriptor.contentInsetAdjustmentBehavior, .never)
@@ -91,6 +92,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(descriptor.appendedUserAgentString, "level 2 append")
         XCTAssertEqual(descriptor.loggingBehavior, .none)
         XCTAssertFalse(descriptor.scrollingEnabled)
+        XCTAssertFalse(descriptor.allowBackForwardNavigationGestures)
         XCTAssertEqual(descriptor.contentInsetAdjustmentBehavior, .scrollableAxes)
     }
     


### PR DESCRIPTION
Hey,

I haven't verified that this works yet, but this PR aims to add support for the `allowBackForwardNavigationGestures` setting on an iOS WebView, The settings allows setting it to `true` so the user can navigate back and forth in the application with gestures if so desired (through `ios.allowBackForwardNavigationGestures` setting). The default is `false`.

What do you think?