### PR TITLE
fix(ios): Return proper MIME Type for local WASM files

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -409,6 +409,7 @@ internal class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
         "vsw": "application/vnd.visio",
         "vsx": "application/vnd.visio",
         "vtx": "application/vnd.visio",
+        "wasm": "application/wasm",
         "wav": "audio/wav",
         "wax": "audio/x-ms-wax",
         "wbmp": "image/vnd.wap.wbmp",


### PR DESCRIPTION
closes https://github.com/ionic-team/capacitor/pull/5585