### PR TITLE
chore(cli): Pin @types/babel__traverse version to fix build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -63,6 +63,7 @@
     "xml2js": "^0.5.0"
   },
   "devDependencies": {
+    "@types/babel__traverse": "7.17.1",
     "@types/debug": "^4.1.7",
     "@types/jest": "^26.0.4",
     "@types/node": "18.11.18",


### PR DESCRIPTION
babel types are making cli to throw some errors on cli build on 4.x branch
https://github.com/ionic-team/capacitor/pull/6686
