### PR TITLE
fix(android): revert cookie manager initialization to plugin load for 4.x

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
@@ -20,18 +20,15 @@ public class CapacitorCookies extends Plugin {
     @Override
     public void load() {
         this.bridge.getWebView().addJavascriptInterface(this, "CapacitorCookiesAndroidInterface");
+        this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
+        CookieHandler.setDefault(this.cookieManager);
         super.load();
     }
 
     @JavascriptInterface
     public boolean isEnabled() {
         PluginConfig pluginConfig = getBridge().getConfig().getPluginConfiguration("CapacitorCookies");
-        boolean isEnabled = pluginConfig.getBoolean("enabled", false);
-        if (isEnabled) {
-            this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
-            CookieHandler.setDefault(cookieManager);
-        }
-        return isEnabled;
+        return pluginConfig.getBoolean("enabled", false);
     }
 
     /**


### PR DESCRIPTION
This PR reverts the `CapacitorCookieManager` initialization  to the plugin's `load()` method and fixes the issue where CapacitorCookies plugin methods are throwing NullPointerException when patching document.cookie is disabled.

Addresses: https://github.com/ionic-team/capacitor/issues/6640