### PR TITLE
chore: Add bot comment on triaged issues

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -14,6 +14,6 @@ comment:
   labels:
     - label: "type: bug"
     message: >
-    This issue has been labeled as `type: bug`. This label is added to issues
-    that that have been reproduced and are being tracked in our internal issue tracker.
-  dryRun: false
+      This issue has been labeled as `type: bug`. This label is added to issues
+      that that have been reproduced and are being tracked in our internal issue tracker.
+    dryRun: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -16,3 +16,4 @@ comment:
     message: >
     This issue has been labeled as `type: bug`. This label is added to issues
     that that have been reproduced and are being tracked in our internal issue tracker.
+  dryRun: false

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -9,3 +9,10 @@ lockClosed:
     Thanks for the issue! This issue is being locked to prevent comments that are not relevant to the original issue.
     If this is still an issue with the latest version of Capacitor, please create a new issue and ensure the template is fully filled out.
   dryRun: false
+
+comment:
+  labels:
+    - label: "type: bug"
+    message: >
+    This issue has been labeled as `type: bug`. This label is added to issues
+    that that have been reproduced and are being tracked in our internal issue tracker.


### PR DESCRIPTION
Whenever we add the "type: bug" label, the bot will add a comment so users know the issue is real and it's being tracked.