### PR TITLE
fix(ios): Revert server url addition for CAPWebView.

### DIFF
--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -28,7 +28,6 @@ open class CAPWebView: UIView {
     private lazy var assetHandler: WebViewAssetHandler = {
         let handler = WebViewAssetHandler(router: router)
         handler.setAssetPath(configuration.appLocation.path)
-        handler.setServerUrl(bridge.config.serverURL)
         return handler
     }()
 

--- a/ios/Capacitor/Capacitor/CAPWebView.swift
+++ b/ios/Capacitor/Capacitor/CAPWebView.swift
@@ -28,6 +28,7 @@ open class CAPWebView: UIView {
     private lazy var assetHandler: WebViewAssetHandler = {
         let handler = WebViewAssetHandler(router: router)
         handler.setAssetPath(configuration.appLocation.path)
+        handler.setServerUrl(configuration.serverURL)
         return handler
     }()
 


### PR DESCRIPTION
Cyclic reference between lazy `assetHandler` and lazy `bridge` variables causes a crash