### PR TITLE
fix(cli): Empty fallback if no non-dev dependencies

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -414,7 +414,7 @@ async function installLatestLibs(
       pkgJson['devDependencies'][devDepKey] = pluginVersion;
     }
   }
-  for (const depKey of Object.keys(pkgJson['dependencies'])) {
+  for (const depKey of Object.keys(pkgJson['dependencies'] || {})) {
     if (libs.includes(depKey)) {
       pkgJson['dependencies'][depKey] = coreVersion;
     } else if (plugins.includes(depKey)) {


### PR DESCRIPTION
Migration was throwing an error because I only had dev dependencies.

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at installLatestLibs (/Users/pete/Development/GitHub/acimce-kit/node_modules/@capacitor/cli/dist/tasks/migrate.js:257:33)
```