### PR TITLE
fix missing \r\n after Content-Disposition in iOS

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -132,6 +132,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
             } else if type == "string" {
                 data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
                 data.append("Content-Disposition: form-data; name=\"\(key!)\"\r\n".data(using: .utf8)!)
+                data.append("\r\n".data(using: .utf8)!)
                 data.append(value.data(using: .utf8)!)
                 data.append("\r\n".data(using: .utf8)!)
             }


### PR DESCRIPTION
This is related on feat(http): support for FormData requests #6708

When comparing FormData with the type string and base64File we see that in the case string a second \r\n is missing after content disposition in iOS. This leads to the fact that we receive a 400 Bad Request from the server with a request from iOS.

<img width="727" alt="image" src="https://github.com/ionic-team/capacitor/assets/2557532/e365108c-da2b-4180-9db1-f522b4b6cc58">


> In HTTP version 1.x, header fields are transmitted after the request line (in case of a request HTTP message) or the response line (in case of a response HTTP message), which is the first line of a message. Header fields are colon-separated key-value pairs in clear-text string format, terminated by a carriage return (CR) and line feed (LF) character sequence. **The end of the header section is indicated by an empty field line, resulting in the transmission of two consecutive CR-LF pairs.**
https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
