### PR TITLE
fix: allow single parameter on setRequestBody

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -175,6 +175,15 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
      * @throws JSONException
      * @throws IOException
      */
+    public void setRequestBody(PluginCall call, JSValue body) throws JSONException, IOException {
+        setRequestBody(call, body, null);
+    }
+    /**
+     *
+     * @param call
+     * @throws JSONException
+     * @throws IOException
+     */
     public void setRequestBody(PluginCall call, JSValue body, String bodyType) throws JSONException, IOException {
         String contentType = connection.getRequestProperty("Content-Type");
         String dataString = "";
@@ -194,14 +203,14 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                 dataString = call.getString("data");
             }
             this.writeRequestBody(dataString != null ? dataString : "");
-        } else if (bodyType.equals("file")) {
+        } else if (bodyType != null && bodyType.equals("file")) {
             try (DataOutputStream os = new DataOutputStream(connection.getOutputStream())) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     os.write(Base64.getDecoder().decode(body.toString()));
                 }
                 os.flush();
             }
-        } else if (bodyType.equals("formData")) {
+        } else if (bodyType != null && bodyType.equals("formData")) {
             this.writeFormDataRequestBody(contentType, body.toJSArray());
         } else {
             this.writeRequestBody(body.toString());

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -144,7 +144,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         return data
     }
 
-    public func getRequestData(_ body: JSValue, _ contentType: String, _ dataType: String) throws -> Data? {
+    public func getRequestData(_ body: JSValue, _ contentType: String, _ dataType: String? = nil) throws -> Data? {
         if dataType == "file" {
             guard let stringData = body as? String else {
                 throw CapacitorUrlRequestError.serializationError("[ data ] argument could not be parsed as string")
@@ -185,7 +185,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         }
     }
 
-    public func setRequestBody(_ body: JSValue, _ dataType: String) throws {
+    public func setRequestBody(_ body: JSValue, _ dataType: String? = nil) throws {
         let contentType = self.getRequestHeader("Content-Type") as? String
 
         if contentType != nil {


### PR DESCRIPTION
The public setRequestBody method was modified to add a new parameter, but since it's public it can break (and breaks on iOS) plugins or custom user code using the method with less parameters.

This PR allows to keep using the previous number of parameters.

Also adds a null check on Android for `bodyType` as you can't call `.equals` on a null object and `bodyType` can be `null` since it's marked as optional on the types, so the call to `getString()` where it gets the value could return `null`.

closes https://github.com/ionic-team/capacitor/issues/6727
closes https://github.com/ionic-team/capacitor-plugins/issues/1682