### PR TITLE
fix(http): add fallback for XHR progress emitter stub

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -573,11 +573,16 @@ var nativeBridge = (function (exports) {
                                         // intercept & parse response before returning
                                         if (this.readyState == 2) {
                                             //TODO: Add progress event emission on native side
-                                            this.dispatchEvent(new ProgressEvent('progress', {
-                                                lengthComputable: true,
-                                                loaded: nativeResponse.data.length,
-                                                total: nativeResponse.data.length,
-                                            }));
+                                            if (typeof ProgressEvent !== 'undefined') {
+                                                this.dispatchEvent(new ProgressEvent('progress', {
+                                                    lengthComputable: true,
+                                                    loaded: nativeResponse.data.length,
+                                                    total: nativeResponse.data.length,
+                                                }));
+                                            }
+                                            else {
+                                                this.dispatchEvent(new Event('progress'));
+                                            }
                                             this._headers = nativeResponse.headers;
                                             this.status = nativeResponse.status;
                                             if (this.responseType === '' ||
@@ -609,11 +614,16 @@ var nativeBridge = (function (exports) {
                                         this.responseText = JSON.stringify(error.data);
                                         this.responseURL = error.url;
                                         this.readyState = 4;
-                                        this.dispatchEvent(new ProgressEvent('progress', {
-                                            lengthComputable: false,
-                                            loaded: 0,
-                                            total: 0,
-                                        }));
+                                        if (typeof ProgressEvent !== 'undefined') {
+                                            this.dispatchEvent(new ProgressEvent('progress', {
+                                                lengthComputable: false,
+                                                loaded: 0,
+                                                total: 0,
+                                            }));
+                                        }
+                                        else {
+                                            this.dispatchEvent(new Event('progress'));
+                                        }
                                         setTimeout(() => {
                                             this.dispatchEvent(new Event('error'));
                                             this.dispatchEvent(new Event('loadend'));
@@ -629,11 +639,16 @@ var nativeBridge = (function (exports) {
                                 this.responseText = error.toString();
                                 this.responseURL = this._url;
                                 this.readyState = 4;
-                                this.dispatchEvent(new ProgressEvent('progress', {
-                                    lengthComputable: false,
-                                    loaded: 0,
-                                    total: 0,
-                                }));
+                                if (typeof ProgressEvent !== 'undefined') {
+                                    this.dispatchEvent(new ProgressEvent('progress', {
+                                        lengthComputable: false,
+                                        loaded: 0,
+                                        total: 0,
+                                    }));
+                                }
+                                else {
+                                    this.dispatchEvent(new Event('progress'));
+                                }
                                 setTimeout(() => {
                                     this.dispatchEvent(new Event('error'));
                                     this.dispatchEvent(new Event('loadend'));

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -684,13 +684,18 @@ const initBridge = (w: any): void => {
                     // intercept & parse response before returning
                     if (this.readyState == 2) {
                       //TODO: Add progress event emission on native side
-                      this.dispatchEvent(
-                        new ProgressEvent('progress', {
-                          lengthComputable: true,
-                          loaded: nativeResponse.data.length,
-                          total: nativeResponse.data.length,
-                        }),
-                      );
+                      if (typeof ProgressEvent !== 'undefined') {
+                        this.dispatchEvent(
+                          new ProgressEvent('progress', {
+                            lengthComputable: true,
+                            loaded: nativeResponse.data.length,
+                            total: nativeResponse.data.length,
+                          }),
+                        );
+                      } else {
+                        this.dispatchEvent(new Event('progress'));
+                      }
+
                       this._headers = nativeResponse.headers;
                       this.status = nativeResponse.status;
                       if (
@@ -725,13 +730,18 @@ const initBridge = (w: any): void => {
                     this.responseText = JSON.stringify(error.data);
                     this.responseURL = error.url;
                     this.readyState = 4;
-                    this.dispatchEvent(
-                      new ProgressEvent('progress', {
-                        lengthComputable: false,
-                        loaded: 0,
-                        total: 0,
-                      }),
-                    );
+                    if (typeof ProgressEvent !== 'undefined') {
+                      this.dispatchEvent(
+                        new ProgressEvent('progress', {
+                          lengthComputable: false,
+                          loaded: 0,
+                          total: 0,
+                        }),
+                      );
+                    } else {
+                      this.dispatchEvent(new Event('progress'));
+                    }
+
                     setTimeout(() => {
                       this.dispatchEvent(new Event('error'));
                       this.dispatchEvent(new Event('loadend'));
@@ -746,13 +756,19 @@ const initBridge = (w: any): void => {
               this.responseText = error.toString();
               this.responseURL = this._url;
               this.readyState = 4;
-              this.dispatchEvent(
-                new ProgressEvent('progress', {
-                  lengthComputable: false,
-                  loaded: 0,
-                  total: 0,
-                }),
-              );
+
+              if (typeof ProgressEvent !== 'undefined') {
+                this.dispatchEvent(
+                  new ProgressEvent('progress', {
+                    lengthComputable: false,
+                    loaded: 0,
+                    total: 0,
+                  }),
+                );
+              } else {
+                this.dispatchEvent(new Event('progress'));
+              }
+
               setTimeout(() => {
                 this.dispatchEvent(new Event('error'));
                 this.dispatchEvent(new Event('loadend'));

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -573,11 +573,16 @@ var nativeBridge = (function (exports) {
                                         // intercept & parse response before returning
                                         if (this.readyState == 2) {
                                             //TODO: Add progress event emission on native side
-                                            this.dispatchEvent(new ProgressEvent('progress', {
-                                                lengthComputable: true,
-                                                loaded: nativeResponse.data.length,
-                                                total: nativeResponse.data.length,
-                                            }));
+                                            if (typeof ProgressEvent !== 'undefined') {
+                                                this.dispatchEvent(new ProgressEvent('progress', {
+                                                    lengthComputable: true,
+                                                    loaded: nativeResponse.data.length,
+                                                    total: nativeResponse.data.length,
+                                                }));
+                                            }
+                                            else {
+                                                this.dispatchEvent(new Event('progress'));
+                                            }
                                             this._headers = nativeResponse.headers;
                                             this.status = nativeResponse.status;
                                             if (this.responseType === '' ||
@@ -609,11 +614,16 @@ var nativeBridge = (function (exports) {
                                         this.responseText = JSON.stringify(error.data);
                                         this.responseURL = error.url;
                                         this.readyState = 4;
-                                        this.dispatchEvent(new ProgressEvent('progress', {
-                                            lengthComputable: false,
-                                            loaded: 0,
-                                            total: 0,
-                                        }));
+                                        if (typeof ProgressEvent !== 'undefined') {
+                                            this.dispatchEvent(new ProgressEvent('progress', {
+                                                lengthComputable: false,
+                                                loaded: 0,
+                                                total: 0,
+                                            }));
+                                        }
+                                        else {
+                                            this.dispatchEvent(new Event('progress'));
+                                        }
                                         setTimeout(() => {
                                             this.dispatchEvent(new Event('error'));
                                             this.dispatchEvent(new Event('loadend'));
@@ -629,11 +639,16 @@ var nativeBridge = (function (exports) {
                                 this.responseText = error.toString();
                                 this.responseURL = this._url;
                                 this.readyState = 4;
-                                this.dispatchEvent(new ProgressEvent('progress', {
-                                    lengthComputable: false,
-                                    loaded: 0,
-                                    total: 0,
-                                }));
+                                if (typeof ProgressEvent !== 'undefined') {
+                                    this.dispatchEvent(new ProgressEvent('progress', {
+                                        lengthComputable: false,
+                                        loaded: 0,
+                                        total: 0,
+                                    }));
+                                }
+                                else {
+                                    this.dispatchEvent(new Event('progress'));
+                                }
                                 setTimeout(() => {
                                     this.dispatchEvent(new Event('error'));
                                     this.dispatchEvent(new Event('loadend'));


### PR DESCRIPTION
This PR adds a fallback for the XHR progress emitter stub in case the polyfill for `ProgressEvent` is not available.

Closes: #6739 