### PR TITLE
Http plugin tests

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -32,6 +32,7 @@ const readFileAsBase64 = (file: File): Promise<string> =>
 
 const convertFormData = async (formData: FormData): Promise<any> => {
   const newFormData: CapFormDataEntry[] = [];
+  // @ts-ignore
   for (const pair of formData.entries()) {
     const [key, value] = pair;
     if (value instanceof File) {
@@ -466,7 +467,7 @@ const initBridge = (w: any): void => {
 
       if (doPatchHttp) {
         // fetch patch
-        window.fetch = async (
+        win.fetch = async (
           resource: RequestInfo | URL,
           options?: RequestInit,
         ) => {
@@ -549,7 +550,7 @@ const initBridge = (w: any): void => {
           new (): XMLHttpRequest;
         }
 
-        window.XMLHttpRequest = function () {
+        win.XMLHttpRequest = function () {
           const xhr = new win.CapacitorWebXMLHttpRequest.constructor();
           Object.defineProperties(xhr, {
             _headers: {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -32,7 +32,6 @@ const readFileAsBase64 = (file: File): Promise<string> =>
 
 const convertFormData = async (formData: FormData): Promise<any> => {
   const newFormData: CapFormDataEntry[] = [];
-  // @ts-ignore
   for (const pair of formData.entries()) {
     const [key, value] = pair;
     if (value instanceof File) {

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -213,6 +213,8 @@ export interface WindowCapacitor {
       exitApp?: () => void;
     };
   };
+  fetch?: typeof window.fetch;
+  XMLHttpRequest?: typeof window.XMLHttpRequest;
 }
 
 export interface CapFormDataEntry {

--- a/core/src/tests/http.spec.ts
+++ b/core/src/tests/http.spec.ts
@@ -1,0 +1,395 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import 'isomorphic-fetch';
+import { initBridge } from '../../native-bridge';
+import { MessageCallData, PluginResult, WindowCapacitor } from '../definitions-internal';
+
+const createMockResponse = (win: WindowCapacitor, response: Partial<PluginResult> = {}) => (m: string) => {
+  const data: MessageCallData = JSON.parse(m);
+  const result = {
+    callbackId: data.callbackId,
+    methodName: data.methodName,
+    pluginId: data.pluginId,
+    success: true,
+    data: {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: {
+        test: 'value',
+      },
+      status: 200,
+    },
+    ...response,
+  };
+
+  setTimeout(() => {
+    if (result.success) {
+      win.androidBridge.onmessage({data: JSON.stringify(result)});
+    } else {
+      win.androidBridge.onmessage({data: JSON.stringify(result)});
+    }
+  });
+};
+
+describe('http', () => {
+  let win: WindowCapacitor;
+  const testFile = new File(['foo'], 'foo.txt', { type: 'text/plain' });
+  const testFileBase64 = 'Zm9v';
+
+  describe('android', () => {
+    let mockPostMessage: jest.Mock<void, [string]>;
+
+    beforeEach(() => {
+      mockPostMessage = jest.fn();
+
+      win = {
+        androidBridge: {
+          postMessage: mockPostMessage,
+        },
+        CapacitorHttpAndroidInterface: {
+          isEnabled: () => true,
+        },
+      };
+
+      initBridge(win);
+    });
+
+    describe('fetch', () => {
+      it('makes a basic request', async () => {
+        mockPostMessage.mockImplementation(createMockResponse(win));
+
+        const response = await win.fetch('https://www.example.com/test');
+
+        expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+          callbackId: expect.any(String),
+          pluginId: 'CapacitorHttp',
+          methodName: 'request',
+          options: {
+            url: 'https://www.example.com/test',
+            dataType: 'json',
+            headers: {},
+          },
+        });
+
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('Content-Type')).toBe('application/json');
+        expect(body).toStrictEqual({ test: 'value' });
+      });
+
+      it('makes a basic request where the response content type is lower case', async () => {
+        mockPostMessage.mockImplementation(createMockResponse(win, {
+          data: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            data: {
+              test: 'value',
+            },
+            status: 200,
+          },
+        }));
+
+        const response = await win.fetch('https://www.example.com/test');
+        const body = await response.json();
+
+        expect(body).toStrictEqual({ test: 'value' });
+      });
+
+      it('handles plain text responses', async () => {
+        mockPostMessage.mockImplementation(createMockResponse(win, {
+          data: {
+            headers: {
+              'Content-Type': 'text/plain',
+            },
+            data: 'I am a plain response',
+            status: 200,
+          },
+        }));
+
+        const response = await win.fetch('https://www.example.com/test');
+        const body = await response.text();
+
+        expect(body).toStrictEqual('I am a plain response');
+      });
+
+      it('handles error responses', async () => {
+        mockPostMessage.mockImplementation(createMockResponse(win, {
+          data: {
+            headers: {
+              'Content-Type': 'text/plain',
+            },
+            data: 'I am a plain response',
+            status: 500,
+          },
+        }));
+
+        const response = await win.fetch('https://www.example.com/test');
+        const body = await response.text();
+
+        expect(body).toStrictEqual('I am a plain response');
+        expect(response.status).toBe(500);
+      });
+
+      describe('request bodies', () => {
+        it('posts json', async () => {
+          mockPostMessage.mockImplementation(createMockResponse(win, {
+            data: {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              data: {
+                test: 'value',
+              },
+              status: 200,
+            },
+          }));
+
+          const response = await win.fetch('https://www.example.com/test', {
+            method: 'POST',
+            body: JSON.stringify({ key: 'value' }),
+          });
+          const body = await response.json();
+
+          expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+            callbackId: expect.any(String),
+            pluginId: 'CapacitorHttp',
+            methodName: 'request',
+            options: {
+              url: 'https://www.example.com/test',
+              method: 'POST',
+              data: JSON.stringify({ key: 'value' }),
+              dataType: 'json',
+              headers: {},
+            },
+          });
+
+          expect(body).toStrictEqual({ test: 'value' });
+        });
+
+        it('handles file objects as the request body', async () => {
+          mockPostMessage.mockImplementation(createMockResponse(win, {
+            data: {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              data: {
+                test: 'value',
+              },
+              status: 200,
+            },
+          }));
+
+          const response = await win.fetch('https://www.example.com/test', {
+            method: 'POST',
+            body: testFile,
+          });
+          const body = await response.json();
+
+          expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+            callbackId: expect.any(String),
+            pluginId: 'CapacitorHttp',
+            methodName: 'request',
+            options: {
+              url: 'https://www.example.com/test',
+              method: 'POST',
+              data: testFileBase64,
+              dataType: 'file',
+              headers: {
+                'Content-Type': 'text/plain',
+              },
+            },
+          });
+
+          expect(body).toStrictEqual({ test: 'value' });
+        });
+
+        it('handles FormData objects as the request body', async () => {
+          mockPostMessage.mockImplementation(createMockResponse(win, {
+            data: {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              status: 200,
+            },
+          }));
+
+          const formData = new FormData();
+          formData.append('key1', 'value1');
+          formData.append('key2', 'value2');
+
+          await win.fetch('https://www.example.com/test', {
+            method: 'POST',
+            body: formData,
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            }
+          });
+
+          expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+            callbackId: expect.any(String),
+            pluginId: 'CapacitorHttp',
+            methodName: 'request',
+            options: {
+              url: 'https://www.example.com/test',
+              method: 'POST',
+              data: [
+                {
+                  key: 'key1',
+                  type: 'string',
+                  value: 'value1',
+                },
+                {
+                  key: 'key2',
+                  type: 'string',
+                  value: 'value2',
+                }
+              ],
+              dataType: 'formData',
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+          });
+        });
+
+        it('handles FormData objects with files as the request body', async () => {
+          mockPostMessage.mockImplementation(createMockResponse(win, {
+            data: {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              status: 200,
+            },
+          }));
+
+          const formData = new FormData();
+          formData.append('key1', 'value1');
+          formData.append('key2', testFile, 'filename.txt');
+
+          await win.fetch('https://www.example.com/test', {
+            method: 'POST',
+            body: formData,
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            }
+          });
+
+          expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+            callbackId: expect.any(String),
+            pluginId: 'CapacitorHttp',
+            methodName: 'request',
+            options: {
+              url: 'https://www.example.com/test',
+              method: 'POST',
+              data: [
+                {
+                  key: 'key1',
+                  type: 'string',
+                  value: 'value1',
+                },
+                {
+                  key: 'key2',
+                  type: 'base64File',
+                  value: testFileBase64,
+                  contentType: 'text/plain',
+                  fileName: 'filename.txt',
+                }
+              ],
+              dataType: 'formData',
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+          });
+        });
+      });
+    });
+
+    describe('XMLHttpRequest', () => {
+      it('makes an XMLHttpRequest', (done) => {
+        mockPostMessage.mockImplementation(createMockResponse(win));
+
+        const req = new win.XMLHttpRequest();
+        req.addEventListener('load', function()  {
+          expect(this.responseText).toStrictEqual('{"test":"value"}');
+          expect(this.status).toBe(200);
+          expect(this.getResponseHeader('Content-Type')).toBe('application/json');
+
+          expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+            callbackId: expect.any(String),
+            pluginId: 'CapacitorHttp',
+            methodName: 'request',
+            options: {
+              url: 'https://www.example.com/test',
+              method: 'GET',
+              dataType: 'json',
+              headers: {
+                'x-test-header': 'something',
+              },
+            },
+          });
+
+          done();
+        });
+        req.open('GET', 'https://www.example.com/test');
+        req.setRequestHeader('x-test-header', 'something');
+        req.send();
+      });
+
+      it('handles errors', (done) => {
+        mockPostMessage.mockImplementation(createMockResponse(win, {
+          error: {
+            message: '',
+            // @ts-ignore
+            status: 500,
+          },
+          success: false,
+        }));
+
+        const req = new win.XMLHttpRequest();
+        req.addEventListener('load', () => done('did not expect XMLHttpRequest to fire done event'));
+        req.addEventListener('error', function()  {
+          expect(this.status).toBe(500);
+
+          done();
+        });
+        req.open('GET', 'https://www.example.com/test');
+        req.setRequestHeader('x-test-header', 'something');
+        req.send();
+      });
+
+      describe('request bodies', () => {
+        it('makes an XMLHttpRequest with a file', (done) => {
+          mockPostMessage.mockImplementation(createMockResponse(win));
+
+          const req = new win.XMLHttpRequest();
+          req.addEventListener('load', function () {
+            expect(JSON.parse(mockPostMessage.mock.lastCall[0])).toStrictEqual({
+              callbackId: expect.any(String),
+              pluginId: 'CapacitorHttp',
+              methodName: 'request',
+              options: {
+                url: 'https://www.example.com/test',
+                method: 'POST',
+                data: testFileBase64,
+                dataType: 'file',
+                headers: {
+                  'Content-Type': 'text/plain',
+                },
+              },
+            });
+
+            done();
+          });
+          req.open('POST', 'https://www.example.com/test');
+          req.send(testFile);
+        });
+      });
+    });
+  });
+});

--- a/core/src/tests/http.spec.ts
+++ b/core/src/tests/http.spec.ts
@@ -6,34 +6,6 @@ import 'isomorphic-fetch';
 import { initBridge } from '../../native-bridge';
 import { MessageCallData, PluginResult, WindowCapacitor } from '../definitions-internal';
 
-const createMockResponse = (win: WindowCapacitor, response: Partial<PluginResult> = {}) => (m: string) => {
-  const data: MessageCallData = JSON.parse(m);
-  const result = {
-    callbackId: data.callbackId,
-    methodName: data.methodName,
-    pluginId: data.pluginId,
-    success: true,
-    data: {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        test: 'value',
-      },
-      status: 200,
-    },
-    ...response,
-  };
-
-  setTimeout(() => {
-    if (result.success) {
-      win.androidBridge.onmessage({data: JSON.stringify(result)});
-    } else {
-      win.androidBridge.onmessage({data: JSON.stringify(result)});
-    }
-  });
-};
-
 describe('http', () => {
   let win: WindowCapacitor;
   const testFile = new File(['foo'], 'foo.txt', { type: 'text/plain' });
@@ -41,6 +13,34 @@ describe('http', () => {
 
   describe('android', () => {
     let mockPostMessage: jest.Mock<void, [string]>;
+
+    const createMockResponse = (win: WindowCapacitor, response: Partial<PluginResult> = {}) => (m: string) => {
+      const data: MessageCallData = JSON.parse(m);
+      const result = {
+        callbackId: data.callbackId,
+        methodName: data.methodName,
+        pluginId: data.pluginId,
+        success: true,
+        data: {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {
+            test: 'value',
+          },
+          status: 200,
+        },
+        ...response,
+      };
+
+      setTimeout(() => {
+        if (result.success) {
+          win.androidBridge.onmessage({data: JSON.stringify(result)});
+        } else {
+          win.androidBridge.onmessage({data: JSON.stringify(result)});
+        }
+      });
+    };
 
     beforeEach(() => {
       mockPostMessage = jest.fn();

--- a/core/src/tests/http.spec.ts
+++ b/core/src/tests/http.spec.ts
@@ -4,7 +4,7 @@
 
 import 'isomorphic-fetch';
 import { initBridge } from '../../native-bridge';
-import { MessageCallData, PluginResult, WindowCapacitor } from '../definitions-internal';
+import type { MessageCallData, PluginResult, WindowCapacitor } from '../definitions-internal';
 
 describe('http', () => {
   let win: WindowCapacitor;
@@ -345,7 +345,8 @@ describe('http', () => {
         mockPostMessage.mockImplementation(createMockResponse(win, {
           error: {
             message: '',
-            // @ts-ignore
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore: Error handling is expecting extra properties here...
             status: 500,
           },
           success: false,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint": "~8.38.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.0",
+    "isomorphic-fetch": "^3.0.0",
     "lerna": "^6.5.1",
     "prettier": "~2.3.0",
     "prettier-plugin-java": "~1.1.1",


### PR DESCRIPTION
Adds some basic unit tests for the Http plugin functionality

Only going to test using the android path - the `bridge.spec.ts` tests handle the underlying implementation on both platforms
 