### PR TITLE
fix "TypeError: requiredElementsArray is not iterable" when undefined

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -489,6 +489,9 @@ async function logiOSPlist(configElement: any, config: Config, plugin: Plugin) {
           existingElementsArray: any[],
         ) => {
           for (const requiredElement of requiredElementsArray) {
+            if (requiredElementsArray === undefined) {
+              return false;
+            }
             if (
               requiredElement.name === 'key' ||
               requiredElement.name === 'string'


### PR DESCRIPTION
[fatal] TypeError: requiredElementsArray is not iterable
    at doesContainElements (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:362:51)
    at doesContainElements (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:384:45)
    at doesContainElements (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:384:45)
    at doesContainElements (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:384:45)
    at doesContainElements (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:384:45)
    at logiOSPlist (/path/to/src-capacitor/node_modules/@capacitor/cli/dist/cordova.js:398:22)