### PR TITLE
Clarify when server.url should be configured

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -483,9 +483,8 @@ export interface CapacitorConfig {
     /**
      * Load an external URL in the Web View.
      *
-     * This is intended for use with live-reload servers.
-     *
-     * **This is not intended for use in production.**
+     * This is intended for use with live-reload servers, and server-side
+     * rendered apps that aren't exportable to static files.
      *
      * @since 1.0.0
      */


### PR DESCRIPTION
The recommendation of not using server.url in production seems to be out of date.

The Capacitor templates for Remix explicitly recommend using it in production: "When deploying your application to the App Store, be sure to set your server.url variable to a hosted server"
https://github.com/ionic-team/capacitor-remix-templates#setting-your-serverurl-variable

(I'm not an expert on the pros and cons of using server-side rendered apps with Capacitor, so please correct me if I'm wrong.)