### PR TITLE
fix(android): allow single input file selection from samsumg gallery

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -425,11 +425,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
                 activityResult -> {
                     Uri[] result;
                     Intent resultIntent = activityResult.getData();
-                    if (
-                        activityResult.getResultCode() == Activity.RESULT_OK &&
-                        resultIntent.getClipData() != null &&
-                        resultIntent.getClipData().getItemCount() > 1
-                    ) {
+                    if (activityResult.getResultCode() == Activity.RESULT_OK && resultIntent.getClipData() != null) {
                         final int numFiles = resultIntent.getClipData().getItemCount();
                         result = new Uri[numFiles];
                         for (int i = 0; i < numFiles; i++) {


### PR DESCRIPTION
`WebChromeClient.FileChooserParams.parseResult` doesn't work fine when other gallery apps are used for the input file with multiple attribute if the user only picks a single image, so always handle the file picking ourselves if `resultIntent.getClipData() != null`, no matter how many elements it contains.

closes https://github.com/ionic-team/capacitor/issues/6758