### PR TITLE
fix(android): avoid R8 optimizations remove plugin classes

### DIFF
--- a/android/capacitor/proguard-rules.pro
+++ b/android/capacitor/proguard-rules.pro
@@ -13,6 +13,8 @@
      @com.getcapacitor.PluginMethod public <methods>;
  }
 
+ -keep public class * extends com.getcapacitor.Plugin { *; }
+
 # Rules for Capacitor v2 plugins and annotations
 # These are deprecated but can still be used with Capacitor for now
 -keep @com.getcapacitor.NativePlugin public class * {


### PR DESCRIPTION
With the update to gradle 8, now R8 is being used for code shrinking/obfuscating and current proguard rules don't seem to be enough and it's removing all plugin classes.

I've added a new rule that avoids R8 removing classes that extend `com.getcapacitor.Plugin` class (all Capacitor plugins).
