### PR TITLE
fix(cookies): hide httpOnly cookies from client

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -349,6 +349,7 @@ var nativeBridge = (function (exports) {
                 if (doPatchCookies) {
                     Object.defineProperty(document, 'cookie', {
                         get: function () {
+                            var _a, _b, _c;
                             if (platform === 'ios') {
                                 // Use prompt to synchronously get cookies.
                                 // https://stackoverflow.com/questions/29249132/wkwebview-complex-communication-between-javascript-native-code/49474323#49474323
@@ -359,7 +360,8 @@ var nativeBridge = (function (exports) {
                                 return res;
                             }
                             else if (typeof win.CapacitorCookiesAndroidInterface !== 'undefined') {
-                                return win.CapacitorCookiesAndroidInterface.getCookies();
+                                // return original document.cookie since Android does not support filtering of `httpOnly` cookies
+                                return (_c = (_b = (_a = win.CapacitorCookiesDescriptor) === null || _a === void 0 ? void 0 : _a.get) === null || _b === void 0 ? void 0 : _b.call(document)) !== null && _c !== void 0 ? _c : '';
                             }
                         },
                         set: function (val) {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -394,7 +394,8 @@ const initBridge = (w: any): void => {
             } else if (
               typeof win.CapacitorCookiesAndroidInterface !== 'undefined'
             ) {
-              return win.CapacitorCookiesAndroidInterface.getCookies();
+              // return original document.cookie since Android does not support filtering of `httpOnly` cookies
+              return win.CapacitorCookiesDescriptor?.get?.call(document) ?? '';
             }
           },
           set: function (val) {

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
@@ -77,7 +77,9 @@ public class CapacitorCookieManager {
         let jar = HTTPCookieStorage.shared
         if let cookies = jar.cookies(for: url) {
             for cookie in cookies {
-                cookiesMap[cookie.name] = cookie.value
+                if !cookie.isHTTPOnly {
+                    cookiesMap[cookie.name] = cookie.value
+                }
             }
         }
         return cookiesMap
@@ -88,7 +90,8 @@ public class CapacitorCookieManager {
         let jar = HTTPCookieStorage.shared
         guard let url = self.getServerUrl() else { return "" }
         guard let cookies = jar.cookies(for: url) else { return "" }
-        return cookies.map({"\($0.name)=\($0.value)"}).joined(separator: "; ")
+        let filteredCookies = cookies.filter { !$0.isHTTPOnly }
+        return filteredCookies.map({"\($0.name)=\($0.value)"}).joined(separator: "; ")
     }
 
     public func deleteCookie(_ url: URL, _ key: String) {

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -349,6 +349,7 @@ var nativeBridge = (function (exports) {
                 if (doPatchCookies) {
                     Object.defineProperty(document, 'cookie', {
                         get: function () {
+                            var _a, _b, _c;
                             if (platform === 'ios') {
                                 // Use prompt to synchronously get cookies.
                                 // https://stackoverflow.com/questions/29249132/wkwebview-complex-communication-between-javascript-native-code/49474323#49474323
@@ -359,7 +360,8 @@ var nativeBridge = (function (exports) {
                                 return res;
                             }
                             else if (typeof win.CapacitorCookiesAndroidInterface !== 'undefined') {
-                                return win.CapacitorCookiesAndroidInterface.getCookies();
+                                // return original document.cookie since Android does not support filtering of `httpOnly` cookies
+                                return (_c = (_b = (_a = win.CapacitorCookiesDescriptor) === null || _a === void 0 ? void 0 : _a.get) === null || _b === void 0 ? void 0 : _b.call(document)) !== null && _c !== void 0 ? _c : '';
                             }
                         },
                         set: function (val) {


### PR DESCRIPTION
This PR prevents cookies with the `httpOnly` attribute from being accessed by the client to align with web restrictions (https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).