### PR TITLE
fix(http): disconnect active connections if call or bridge is destroyed

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -52,6 +52,10 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
         return connection;
     }
 
+    public void disconnect() {
+        connection.disconnect();
+    }
+
     /**
      * Set the value of the {@code allowUserInteraction} field of
      * this {@code URLConnection}.

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -411,9 +411,15 @@ public class HttpRequestHandler {
             }
         }
 
+        call.getData().put("activeCapacitorHttpUrlConnection", connection);
         connection.connect();
 
-        return buildResponse(connection, responseType);
+        JSObject response = buildResponse(connection, responseType);
+
+        connection.disconnect();
+        call.getData().remove("activeCapacitorHttpUrlConnection");
+
+        return response;
     }
 
     private static Boolean isDomainExcludedFromSSL(Bridge bridge, URL url) {


### PR DESCRIPTION
Closes #6795

This PR handles cleanup of Http connections when the bridge is destroyed. The issue referenced contains a test app. 