### PR TITLE
fix(cookies): remove session cookies when initializing the cookie manager

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookieManager.java
@@ -47,6 +47,10 @@ public class CapacitorCookieManager extends CookieManager {
         this.serverUrl = bridge.getServerUrl();
     }
 
+    public void removeSessionCookies() {
+        this.webkitCookieManager.removeSessionCookies(null);
+    }
+
     public String getSanitizedDomain(String url) throws URISyntaxException {
         if (url == null || url.isEmpty()) {
             url = this.serverUrl;

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorCookies.java
@@ -22,8 +22,15 @@ public class CapacitorCookies extends Plugin {
     public void load() {
         this.bridge.getWebView().addJavascriptInterface(this, "CapacitorCookiesAndroidInterface");
         this.cookieManager = new CapacitorCookieManager(null, java.net.CookiePolicy.ACCEPT_ALL, this.bridge);
+        this.cookieManager.removeSessionCookies();
         CookieHandler.setDefault(this.cookieManager);
         super.load();
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        super.handleOnDestroy();
+        this.cookieManager.removeSessionCookies();
     }
 
     @JavascriptInterface


### PR DESCRIPTION
Closes #6809

This PR adjusts the behavior of Android WebView "session" cookies to be cleared when the Cookie Manager is initialized.
See https://github.com/ionic-team/capacitor/issues/6809#issuecomment-1679733197 for more information.