### PR TITLE
fix(http): return numbers and booleans as-is when application/json is the content type

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -302,14 +302,18 @@ public class HttpRequestHandler {
             if ("null".equals(input.trim())) {
                 return JSONObject.NULL;
             } else if ("true".equals(input.trim())) {
-                return new JSONObject().put("flag", "true");
+                return true;
             } else if ("false".equals(input.trim())) {
-                return new JSONObject().put("flag", "false");
+                return false;
             } else if (input.trim().length() <= 0) {
                 return "";
             } else if (input.trim().matches("^\".*\"$")) {
                 // a string enclosed in " " is a json value, return the string without the quotes
                 return input.trim().substring(1, input.trim().length() - 1);
+            } else if (input.trim().matches("^-?\\d+(\\.\\d+)?$")) {
+                return Double.parseDouble(input.trim());
+            } else if (input.trim().matches("^-?\\d+$")) {
+                return Integer.parseInt(input.trim());
             } else {
                 try {
                     return new JSObject(input);
@@ -318,7 +322,7 @@ public class HttpRequestHandler {
                 }
             }
         } catch (JSONException e) {
-            return new JSArray(input);
+            return input;
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -310,10 +310,10 @@ public class HttpRequestHandler {
             } else if (input.trim().matches("^\".*\"$")) {
                 // a string enclosed in " " is a json value, return the string without the quotes
                 return input.trim().substring(1, input.trim().length() - 1);
-            } else if (input.trim().matches("^-?\\d+(\\.\\d+)?$")) {
-                return Double.parseDouble(input.trim());
             } else if (input.trim().matches("^-?\\d+$")) {
                 return Integer.parseInt(input.trim());
+            } else if (input.trim().matches("^-?\\d+(\\.\\d+)?$")) {
+                return Double.parseDouble(input.trim());
             } else {
                 try {
                     return new JSObject(input);


### PR DESCRIPTION
Closes #6819

This PR fixes an issue on Android where `parseJSON` would try to force convert booleans and numbers to JSON objects instead of returning them as-is.