### PR TITLE
Update WebColor.java

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/util/WebColor.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/WebColor.java
@@ -11,7 +11,7 @@ public class WebColor {
      */
     public static int parseColor(String colorString) {
         String formattedColor = colorString;
-        if (colorString.charAt(0) != '#') {
+        if (colorString.length() > 0 && colorString.charAt(0) != '#') {
             formattedColor = "#" + formattedColor;
         }
 


### PR DESCRIPTION
fix for 

```
Exception java.lang.StringIndexOutOfBoundsException: length=0; index=0
  at java.lang.String.charAt
  at com.getcapacitor.util.WebColor.parseColor (WebColor.java:14)
  at com.capacitorjs.plugins.statusbar.StatusBarPlugin.lambda$setBackgroundColor$1 (StatusBarPlugin.java:50)
  at com.capacitorjs.plugins.statusbar.StatusBarPlugin.$r8$lambda$tHQPGfYR1VFm1Kl2P_TawKGDpX4
  at com.capacitorjs.plugins.statusbar.StatusBarPlugin$$ExternalSyntheticLambda0.run
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:240)
  at android.os.Looper.loop (Looper.java:351)
  at android.app.ActivityThread.main (ActivityThread.java:8381)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:584)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1013)
````