### PR TITLE
refactor(cli)!: remove definitions to decouple fedcap and liveupdates plugins

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -578,22 +578,6 @@ export interface CapacitorConfig {
   includePlugins?: string[];
 }
 
-export interface FederatedApp {
-  name: string;
-  webDir: string;
-  liveUpdateConfig?: LiveUpdateConfig;
-}
-
-export interface LiveUpdateConfig {
-  appId: string;
-  channel: string;
-  autoUpdateMethod: AutoUpdateMethod;
-  maxVersions?: number;
-  key?: string;
-}
-
-export type AutoUpdateMethod = 'none' | 'background';
-
 export interface PluginsConfig {
   /**
    * Plugin configuration by class name.
@@ -605,24 +589,6 @@ export interface PluginsConfig {
         [key: string]: any;
       }
     | undefined;
-
-  /**
-   * FederatedCapacitor plugin configuration
-   *
-   * @since 5.0.0
-   */
-  FederatedCapacitor?: {
-    shell: Omit<FederatedApp, 'webDir'>;
-    apps: FederatedApp[];
-    liveUpdatesKey?: string;
-  };
-
-  /**
-   * Capacitor Live Updates plugin configuration
-   *
-   * @since 4.2.0
-   */
-  LiveUpdates?: LiveUpdateConfig;
 
   /**
    * Capacitor Cookies plugin configuration

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -15,7 +15,6 @@ import {
   handleCordovaPluginsJS,
   writeCordovaAndroidManifest,
 } from '../cordova';
-import type { FederatedApp } from '../declarations';
 import type { Config } from '../definitions';
 import { isFatal } from '../errors';
 import { logger } from '../log';
@@ -356,4 +355,26 @@ async function copySSLCert(
       return Promise.all(promises);
     },
   );
+}
+
+interface LiveUpdateConfig {
+  key?: string;
+}
+
+interface FederatedApp {
+  name: string;
+  webDir: string;
+}
+
+interface FederatedCapacitor {
+  shell: Omit<FederatedApp, 'webDir'>;
+  apps: FederatedApp[];
+  liveUpdatesKey?: string;
+}
+
+declare module '../declarations' {
+  interface PluginsConfig {
+    LiveUpdates?: LiveUpdateConfig;
+    FederatedCapacitor?: FederatedCapacitor;
+  }
 }


### PR DESCRIPTION
Same as #6870 but for 5.x