### PR TITLE
Add method to disable autosuggestion

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapacitorWebView.java
@@ -1,6 +1,7 @@
 package com.getcapacitor;
 
 import android.content.Context;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.inputmethod.BaseInputConnection;
@@ -12,6 +13,7 @@ public class CapacitorWebView extends WebView {
 
     private BaseInputConnection capInputConnection;
     private Bridge bridge;
+    private boolean autosuggestionEnabled = true;
 
     public CapacitorWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -19,6 +21,10 @@ public class CapacitorWebView extends WebView {
 
     public void setBridge(Bridge bridge) {
         this.bridge = bridge;
+    }
+
+    public void setAutosuggestionEnabled(boolean enabled) {
+        autosuggestionEnabled = enabled;
     }
 
     @Override
@@ -31,13 +37,23 @@ public class CapacitorWebView extends WebView {
         }
 
         boolean captureInput = config.isInputCaptured();
+        InputConnection inputConnection;
         if (captureInput) {
             if (capInputConnection == null) {
                 capInputConnection = new BaseInputConnection(this, false);
             }
-            return capInputConnection;
+            inputConnection = capInputConnection;
+        } else {
+            inputConnection = super.onCreateInputConnection(outAttrs);
         }
-        return super.onCreateInputConnection(outAttrs);
+
+        if (!autosuggestionEnabled) {
+            // See https://stackoverflow.com/a/28009054/640584
+            outAttrs.inputType &= ~EditorInfo.TYPE_MASK_VARIATION;
+            outAttrs.inputType |= InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD;
+        }
+
+        return inputConnection;
     }
 
     @Override


### PR DESCRIPTION
We have a use-case where our app is run on a tablet in a public setting.

Thus we would like to disable autosuggestion to prevent the Android keyboard from remembering and suggesting emails of previous users.