### PR TITLE
Fix Android JSInjector replacing all <head> tags

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/JSInjector.java
@@ -69,12 +69,12 @@ class JSInjector {
      * @return
      */
     public InputStream getInjectedStream(InputStream responseStream) {
-        String js = "<script type=\"text/javascript\">" + getScriptString() + "</script>";
+        String js = "<script type=\"text/javascript\">" + getScriptString().replace("${", "\\${") + "</script>";
         String html = this.readAssetStream(responseStream);
         if (html.contains("<head>")) {
-            html = html.replace("<head>", "<head>\n" + js + "\n");
+            html = html.replaceFirst("<head>", "<head>\n" + js + "\n");
         } else if (html.contains("</head>")) {
-            html = html.replace("</head>", js + "\n" + "</head>");
+            html = html.replaceFirst("</head>", js + "\n" + "</head>");
         } else {
             Logger.error("Unable to inject Capacitor, Plugins won't work");
         }


### PR DESCRIPTION
If an HTML page (local or proxied) contains more than one `<head>` or `</head>` string, they will all be replaced. While these should normally be escaped as `&lt;head&gt;` in HTML, it is possible that an inline script tag could correctly include this string. This is currently the case for calendly.com, where they have an inline script tag that injects additional content into the `<head>`.

When JSInjector attempts to insert the native bridge into this page, it will replace _all_ instances of the string, instead of just the first instance (the actual tag). This PR changes it to use `String.replaceFirst`, which accepts a regex pattern and match. As `<head>` and `</head>` are safe to use in Regex, nothing needs to be done to them, however the native bridge includes JS templates like `${Date.now()}`, and `${...}` will reference a matched group if used in the replacement string. This escapes `${` to be `\${` so that it isn't used as a match group.

I have pushed a simple reproduction to https://github.com/SpenserJ/capacitor/tree/repro/android-duplicate-head-injection, which should display an alert box with `<head>`, but without this patch it will corrupt the HTML and leave a `);` visible at the bottom of the page with no alert shown.

1. Clone https://github.com/SpenserJ/capacitor/tree/repro/android-duplicate-head-injection
2. Run `npm ci`
3. Run `npm run build
4. Run `npx cap sync`
5. Run `npx cap open android` and launch the app on your device
6. You should see an alert box with `<head>` ✅ 
7. Disable the patch by renaming `./patches` to anything else, and then running `npm ci` again
8. Rerun the application and you will _not_ see an alert, and you will see a trailing `);`