### PR TITLE
fix(http): add support for defining xhr and angular http response types

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -586,12 +586,22 @@ var nativeBridge = (function (exports) {
                                             }
                                             this._headers = nativeResponse.headers;
                                             this.status = nativeResponse.status;
+                                            const responseString = typeof nativeResponse.data !== 'string'
+                                                ? JSON.stringify(nativeResponse.data)
+                                                : nativeResponse.data;
                                             if (this.responseType === '' ||
                                                 this.responseType === 'text') {
-                                                this.response =
-                                                    typeof nativeResponse.data !== 'string'
-                                                        ? JSON.stringify(nativeResponse.data)
-                                                        : nativeResponse.data;
+                                                this.response = responseString;
+                                            }
+                                            else if (this.responseType === 'blob') {
+                                                this.response = new Blob([responseString], {
+                                                    type: "application/json",
+                                                });
+                                            }
+                                            else if (this.responseType === 'arraybuffer') {
+                                                const encoder = new TextEncoder();
+                                                const uint8Array = encoder.encode(responseString);
+                                                this.response = uint8Array.buffer;
                                             }
                                             else {
                                                 this.response = nativeResponse.data;

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -695,14 +695,25 @@ const initBridge = (w: any): void => {
                       }
                       this._headers = nativeResponse.headers;
                       this.status = nativeResponse.status;
+
+                      const responseString =
+                        typeof nativeResponse.data !== 'string'
+                          ? JSON.stringify(nativeResponse.data)
+                          : nativeResponse.data;
+
                       if (
                         this.responseType === '' ||
                         this.responseType === 'text'
                       ) {
-                        this.response =
-                          typeof nativeResponse.data !== 'string'
-                            ? JSON.stringify(nativeResponse.data)
-                            : nativeResponse.data;
+                        this.response = responseString;
+                      } else if (this.responseType === 'blob') {
+                        this.response = new Blob([responseString], {
+                          type: 'application/json',
+                        });
+                      } else if (this.responseType === 'arraybuffer') {
+                        const encoder = new TextEncoder();
+                        const uint8Array = encoder.encode(responseString);
+                        this.response = uint8Array.buffer;
                       } else {
                         this.response = nativeResponse.data;
                       }

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -586,12 +586,22 @@ var nativeBridge = (function (exports) {
                                             }
                                             this._headers = nativeResponse.headers;
                                             this.status = nativeResponse.status;
+                                            const responseString = typeof nativeResponse.data !== 'string'
+                                                ? JSON.stringify(nativeResponse.data)
+                                                : nativeResponse.data;
                                             if (this.responseType === '' ||
                                                 this.responseType === 'text') {
-                                                this.response =
-                                                    typeof nativeResponse.data !== 'string'
-                                                        ? JSON.stringify(nativeResponse.data)
-                                                        : nativeResponse.data;
+                                                this.response = responseString;
+                                            }
+                                            else if (this.responseType === 'blob') {
+                                                this.response = new Blob([responseString], {
+                                                    type: "application/json",
+                                                });
+                                            }
+                                            else if (this.responseType === 'arraybuffer') {
+                                                const encoder = new TextEncoder();
+                                                const uint8Array = encoder.encode(responseString);
+                                                this.response = uint8Array.buffer;
                                             }
                                             else {
                                                 this.response = nativeResponse.data;


### PR DESCRIPTION
This PR fixes an issue where `responseType` is ignored on `XMLHttpRequest` / Angular HTTP when it is set to `blob` or `arraybuffer`