### PR TITLE
fix(cookies): retrieve cookies when using a custom android scheme

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -636,6 +636,14 @@ export interface PluginsConfig {
      * @default false
      */
     enabled?: boolean;
+    /**
+     * Enable `httpOnly` and other insecure cookies to be read and accessed on Android.
+     *
+     * Note: This can potentially be a security risk and is only intended to be used
+     * when your application uses a custom scheme on Android.
+     *
+     */
+    androidCustomSchemeAllowInsecureAccess?: boolean;
   };
 
   /**


### PR DESCRIPTION
This PR fixes a bug introduced after #6787  where cookies are unable to be retrieved at all if using a custom scheme on Android. This is due to WebViews inherently not considering custom schemes as eligible for cookie storage. Therefore, calling `document.cookie` on the WebView was a no-op. However, since the Android cookie store provides no way to access stored cookie properties, there is no way to filter out insecure `httpOnly` cookies when returning them to the WebView. This will add `androidCustomSchemeAllowInsecureAccess` as a config option, which will return ALL cookies from the cookie store at the given url, if set to true.