### PR TITLE
refactor: move the Xcode 15 patch from the template to @capacitor/ios

### DIFF
--- a/ios-template/App/Podfile
+++ b/ios-template/App/Podfile
@@ -1,18 +1,5 @@
 require_relative '../../node_modules/@capacitor/ios/scripts/pods_helpers'
 
-# workaround for Xcode 15 and Cocoapods 1.21.1
-# Should not be needed after Cocoapods 1.13.0
-def fixToolChainDirectory(installer)
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      xcconfig_path = config.base_configuration_reference.real_path
-      xcconfig = File.read(xcconfig_path)
-      xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
-      File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
-    end
-  end
-end
-
 platform :ios, '13.0'
 use_frameworks!
 
@@ -33,5 +20,4 @@ end
 
 post_install do |installer|
   assertDeploymentTarget(installer)
-  fixToolChainDirectory(installer)
 end

--- a/ios/scripts/pods_helpers.rb
+++ b/ios/scripts/pods_helpers.rb
@@ -7,6 +7,12 @@ def assertDeploymentTarget(installer)
       if should_upgrade
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       end
+      # workaround for Xcode 15 and Cocoapods 1.21.1
+      # Should not be needed after Cocoapods 1.13.0
+      xcconfig_path = config.base_configuration_reference.real_path
+      xcconfig = File.read(xcconfig_path)
+      xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
+      File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
     end
   end
 end


### PR DESCRIPTION
`assertDeploymentTarget` was moved back to the `pods_helpers.rb` file, but the Xcode 15 patch is still in the users `Podfile`. So better move the code to `@capacitor/ios` so we can remove or edit it if needed without requiring users to edit their code or without the need of making migrate command to write that block of code for the Capacitor 6 migration.