### PR TITLE
fix(http): inherit object properties on window.XMLHttpRequest

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -394,6 +394,7 @@ var nativeBridge = (function (exports) {
                 win.CapacitorWebXMLHttpRequest = {
                     abort: window.XMLHttpRequest.prototype.abort,
                     constructor: window.XMLHttpRequest.prototype.constructor,
+                    fullObject: window.XMLHttpRequest,
                     getAllResponseHeaders: window.XMLHttpRequest.prototype.getAllResponseHeaders,
                     getResponseHeader: window.XMLHttpRequest.prototype.getResponseHeader,
                     open: window.XMLHttpRequest.prototype.open,
@@ -674,6 +675,7 @@ var nativeBridge = (function (exports) {
                         Object.setPrototypeOf(xhr, prototype);
                         return xhr;
                     };
+                    Object.assign(window.XMLHttpRequest, win.CapacitorWebXMLHttpRequest.fullObject);
                 }
             }
             // patch window.console on iOS and store original console fns

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -434,6 +434,7 @@ const initBridge = (w: any): void => {
       win.CapacitorWebXMLHttpRequest = {
         abort: window.XMLHttpRequest.prototype.abort,
         constructor: window.XMLHttpRequest.prototype.constructor,
+        fullObject: window.XMLHttpRequest,
         getAllResponseHeaders:
           window.XMLHttpRequest.prototype.getAllResponseHeaders,
         getResponseHeader: window.XMLHttpRequest.prototype.getResponseHeader,
@@ -798,6 +799,11 @@ const initBridge = (w: any): void => {
           Object.setPrototypeOf(xhr, prototype);
           return xhr;
         } as unknown as PatchedXMLHttpRequestConstructor;
+
+        Object.assign(
+          window.XMLHttpRequest,
+          win.CapacitorWebXMLHttpRequest.fullObject,
+        );
       }
     }
 

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -394,6 +394,7 @@ var nativeBridge = (function (exports) {
                 win.CapacitorWebXMLHttpRequest = {
                     abort: window.XMLHttpRequest.prototype.abort,
                     constructor: window.XMLHttpRequest.prototype.constructor,
+                    fullObject: window.XMLHttpRequest,
                     getAllResponseHeaders: window.XMLHttpRequest.prototype.getAllResponseHeaders,
                     getResponseHeader: window.XMLHttpRequest.prototype.getResponseHeader,
                     open: window.XMLHttpRequest.prototype.open,
@@ -674,6 +675,7 @@ var nativeBridge = (function (exports) {
                         Object.setPrototypeOf(xhr, prototype);
                         return xhr;
                     };
+                    Object.assign(window.XMLHttpRequest, win.CapacitorWebXMLHttpRequest.fullObject);
                 }
             }
             // patch window.console on iOS and store original console fns


### PR DESCRIPTION
This PR fixes an issue where only a constructed XHR object inherited native properties such as DONE, and not the window.XMLHttpRequest object itself.

For example:
```
xhr.onreadystatechange = () => {
    if (xhr.readyState === 4) {
      alert(`xhr.DONE is ${xhr.DONE}`); // This was defined
      alert(`XMLHttpRequest.DONE is ${XMLHttpRequest.DONE}`); // This was undefined
    }
 };
 ```