### PR TITLE
fix(http): add support for Request objects in fetch

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -423,22 +423,21 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
-                        if (!(resource.toString().startsWith('http:') ||
-                            resource.toString().startsWith('https:'))) {
+                        const request = new Request(resource, options);
+                        if (!(request.url.startsWith('http:') ||
+                            request.url.startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);
                         try {
                             // intercept request & pass to the bridge
-                            const { data: requestData, type, headers, } = await convertBody((options === null || options === void 0 ? void 0 : options.body) || undefined);
-                            let optionHeaders = options === null || options === void 0 ? void 0 : options.headers;
-                            if ((options === null || options === void 0 ? void 0 : options.headers) instanceof Headers) {
-                                optionHeaders = Object.fromEntries(options.headers.entries());
-                            }
+                            const { body, method } = request;
+                            const { data: requestData, type, headers, } = await convertBody(body || undefined);
+                            const optionHeaders = Object.fromEntries(request.headers.entries());
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
-                                url: resource,
-                                method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
+                                url: request.url,
+                                method: method,
                                 data: requestData,
                                 dataType: type,
                                 headers: Object.assign(Object.assign({}, headers), optionHeaders),

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -471,10 +471,12 @@ const initBridge = (w: any): void => {
           resource: RequestInfo | URL,
           options?: RequestInit,
         ) => {
+          const request = new Request(resource, options);
+
           if (
             !(
-              resource.toString().startsWith('http:') ||
-              resource.toString().startsWith('https:')
+              request.url.startsWith('http:') ||
+              request.url.startsWith('https:')
             )
           ) {
             return win.CapacitorWebFetch(resource, options);
@@ -484,23 +486,19 @@ const initBridge = (w: any): void => {
           console.time(tag);
           try {
             // intercept request & pass to the bridge
+            const { body, method } = request;
             const {
               data: requestData,
               type,
               headers,
-            } = await convertBody(options?.body || undefined);
-            let optionHeaders = options?.headers;
-            if (options?.headers instanceof Headers) {
-              optionHeaders = Object.fromEntries(
-                (options.headers as any).entries(),
-              );
-            }
+            } = await convertBody(body || undefined);
+            const optionHeaders = Object.fromEntries(request.headers.entries());
             const nativeResponse: HttpResponse = await cap.nativePromise(
               'CapacitorHttp',
               'request',
               {
-                url: resource,
-                method: options?.method ? options.method : undefined,
+                url: request.url,
+                method: method,
                 data: requestData,
                 dataType: type,
                 headers: {

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -423,22 +423,21 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
-                        if (!(resource.toString().startsWith('http:') ||
-                            resource.toString().startsWith('https:'))) {
+                        const request = new Request(resource, options);
+                        if (!(request.url.startsWith('http:') ||
+                            request.url.startsWith('https:'))) {
                             return win.CapacitorWebFetch(resource, options);
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);
                         try {
                             // intercept request & pass to the bridge
-                            const { data: requestData, type, headers, } = await convertBody((options === null || options === void 0 ? void 0 : options.body) || undefined);
-                            let optionHeaders = options === null || options === void 0 ? void 0 : options.headers;
-                            if ((options === null || options === void 0 ? void 0 : options.headers) instanceof Headers) {
-                                optionHeaders = Object.fromEntries(options.headers.entries());
-                            }
+                            const { body, method } = request;
+                            const { data: requestData, type, headers, } = await convertBody(body || undefined);
+                            const optionHeaders = Object.fromEntries(request.headers.entries());
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
-                                url: resource,
-                                method: (options === null || options === void 0 ? void 0 : options.method) ? options.method : undefined,
+                                url: request.url,
+                                method: method,
                                 data: requestData,
                                 dataType: type,
                                 headers: Object.assign(Object.assign({}, headers), optionHeaders),


### PR DESCRIPTION
Closes https://github.com/ionic-team/capacitor/issues/6174

This PR fixes fetch requests failing when using a Request object as the resource