### PR TITLE
Fix status bar overlap issue for ios phones that doesnt have notch

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -359,11 +359,21 @@ extension CAPBridgeViewController {
 }
 
 extension CAPBridgeViewController: CAPBridgeDelegate {
-    public var bridgedWebView: WKWebView? {
-        return webView
-    }
+        internal var hasNotch: Bool {
+            let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return keyWindow?.safeAreaInsets.bottom ?? 0 > 0
+        }
 
-    public var bridgedViewController: UIViewController? {
-        return self
-    }
+        public var bridgedWebView: WKWebView? {
+            // Check if the device has a notch based on the `hasNotch` variable
+            if !(hasNotch) {
+                webView?.frame.origin = CGPoint(x: 0, y: UIApplication.shared.statusBarFrame.size.height)
+                webView?.frame.size.height = UIScreen.main.bounds.size.height - UIApplication.shared.statusBarFrame.size.height
+            }
+            return webView
+        }
+
+        public var bridgedViewController: UIViewController? {
+            return self
+        }
 }


### PR DESCRIPTION
status bar overlap issue on ios fixed for the models does not have notch.

before the change;
![IMG_6712](https://github.com/ionic-team/capacitor/assets/34776010/5bc0acfb-a17d-4a07-92ea-f35cdf0079e6)

after the change;
![IMG_6715](https://github.com/ionic-team/capacitor/assets/34776010/6028e243-5c0a-4741-afd4-0bd70dd566e0)

example of from other developers: https://stackoverflow.com/questions/74027958/capacitor-js-status-bar-overlaps-in-ios

Issue produced over this dependencies:
{
  "name": "App",
  "version": "0.1.0",
  "private": true,
  "dependencies": {
    "@capacitor/android": "^5.2.2",
    "@capacitor/app": "^5.0.6",
    "@capacitor/app-launcher": "^5.0.6",
    "@capacitor/browser": "^5.0.6",
    "@capacitor/core": "^5.2.2",
    "@capacitor/geolocation": "^5.0.6",
    "@capacitor/ios": "^5.2.2",
    "@capacitor/network": "^5.0.6",
    "@capacitor/status-bar": "^5.0.6",
    "@date-io/date-fns": "1.x",
    "@emotion/react": "^11.7.1",
    "@emotion/styled": "^11.6.0",
    "@material-ui/core": "^4.11.0",
    "@material-ui/icons": "^4.5.1",
    "@material-ui/lab": "^4.0.0-alpha.56",
    "@material-ui/pickers": "^3.2.7",
    "@material-ui/styles": "^4.6.0",
    "@material-ui/system": "^4.5.2",
    "@material-ui/types": "^4.1.1",
    "@mui/icons-material": "^5.10.3",
    "@mui/material": "^5.10.5",
    "@react-google-maps/api": "2.13.1",
    "@types/jest": "24.0.20",
    "@types/node": "12.11.7",
    "@types/react": "^17.0.26",
    "@types/react-dates": "^17.1.10",
    "@types/react-dom": "16.9.3",
    "@types/react-image-gallery": "^0.9.3",
    "@types/react-pdf": "^4.0.5",
    "@types/react-places-autocomplete": "^7.2.6",
    "@types/webpack-env": "^1.16.4",
    "axios": "^0.19.0",
    "cordova-plugin-screen-orientation": "^3.0.3",
    "date-fns": "^2.9.0",
    "env-cmd": "^10.1.0",
    "firebase": "^7.4.0",
    "i18next": "^19.0.0",
    "i18next-browser-languagedetector": "^4.0.1",
    "material-ui-image": "^3.3.0",
    "material-ui-phone-number": "^2.2.6",
    "react": "^17.0.2",
    "react-cookie-consent": "^5.1.3",
    "react-country-flag": "^3.0.2",
    "react-cropper": "^2.1.8",
    "react-dates": "^21.8.0",
    "react-dom": "^17.0.2",
    "react-dropzone": "^12.0.1",
    "react-google-maps": "^9.4.5",
    "react-hook-form": "^6.1.2",
    "react-i18next": "^11.2.1",
    "react-image-gallery": "^1.0.7",
    "react-inlinesvg": "^1.2.0",
    "react-mobile-picker-scroll": "0.2.14",
    "react-pdf": "^5.0.0",
    "react-places-autocomplete": "^7.2.1",
    "react-query": "^3.34.16",
    "react-router-dom": "^5.1.2",
    "react-scripts": "^4.0.3",
    "react-scroll-parallax": "^3.2.0",
    "source-map-explorer": "^2.5.2",
    "typescript": "^4.4.4",
    "zustand": "^3.6.9"
  },
  "scripts": {
    "postinstall": "patch-package",
    "analyze": "source-map-explorer 'dist/deployment/public/static/js/*.js'",
    "start": "env-cmd -f .env.development react-scripts start",
    "build": "BUILD_PATH='./dist/deployment/public' react-scripts build",
    "test": "react-scripts test",
    "eject": "react-scripts eject",
    "ionic:build": "npm run build",
    "ionic:serve": "npm run start"
  },
  "eslintConfig": {
    "plugins": [
      "react-hooks"
    ],
    "extends": "react-app",
    "rules": {
      "react-hooks/rules-of-hooks": "error",
      "react-hooks/exhaustive-deps": "off"
    }
  },
  "browserslist": {
    "production": [
      ">0.2%",
      "not dead",
      "not op_mini all"
    ],
    "development": [
      "last 1 chrome version",
      "last 1 firefox version",
      "last 1 safari version"
    ]
  },
  "devDependencies": {
    "@capacitor/cli": "^5.2.2",
    "@types/deep-equal": "^1.0.1",
    "@types/react-router-dom": "^5.3.0",
    "patch-package": "^8.0.0"
  }
}