### PR TITLE
fix(cli): force latest native-run version for iOS 17 support

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "debug": "^4.3.4",
     "env-paths": "^2.2.0",
     "kleur": "^4.1.4",
-    "native-run": "^1.7.2",
+    "native-run": "^1.7.3",
     "open": "^8.4.0",
     "plist": "^3.0.5",
     "prompts": "^2.4.2",


### PR DESCRIPTION
in case the users have 1.7.2 already installed, force 1.7.3 or newer