### PR TITLE
fix(http): return xhr response headers case insensitive

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -595,7 +595,7 @@ var nativeBridge = (function (exports) {
                                             }
                                             else if (this.responseType === 'blob') {
                                                 this.response = new Blob([responseString], {
-                                                    type: "application/json",
+                                                    type: 'application/json',
                                                 });
                                             }
                                             else if (this.responseType === 'arraybuffer') {
@@ -668,7 +668,7 @@ var nativeBridge = (function (exports) {
                             }
                             let returnString = '';
                             for (const key in this._headers) {
-                                if (key != 'Set-Cookie') {
+                                if (key.toLowerCase() !== 'set-cookie') {
                                     returnString += key + ': ' + this._headers[key] + '\r\n';
                                 }
                             }
@@ -679,7 +679,12 @@ var nativeBridge = (function (exports) {
                             if (isRelativeURL(this._url)) {
                                 return win.CapacitorWebXMLHttpRequest.getResponseHeader.call(this, name);
                             }
-                            return this._headers[name];
+                            for (const key in this._headers) {
+                                if (key.toLowerCase() === name.toLowerCase()) {
+                                    return this._headers[key];
+                                }
+                            }
+                            return null;
                         };
                         Object.setPrototypeOf(xhr, prototype);
                         return xhr;

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -787,7 +787,7 @@ const initBridge = (w: any): void => {
 
             let returnString = '';
             for (const key in this._headers) {
-              if (key != 'Set-Cookie') {
+              if (key.toLowerCase() !== 'set-cookie') {
                 returnString += key + ': ' + this._headers[key] + '\r\n';
               }
             }
@@ -802,7 +802,12 @@ const initBridge = (w: any): void => {
                 name,
               );
             }
-            return this._headers[name];
+            for (const key in this._headers) {
+              if (key.toLowerCase() === name.toLowerCase()) {
+                return this._headers[key];
+              }
+            }
+            return null;
           };
 
           Object.setPrototypeOf(xhr, prototype);

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -595,7 +595,7 @@ var nativeBridge = (function (exports) {
                                             }
                                             else if (this.responseType === 'blob') {
                                                 this.response = new Blob([responseString], {
-                                                    type: "application/json",
+                                                    type: 'application/json',
                                                 });
                                             }
                                             else if (this.responseType === 'arraybuffer') {
@@ -668,7 +668,7 @@ var nativeBridge = (function (exports) {
                             }
                             let returnString = '';
                             for (const key in this._headers) {
-                                if (key != 'Set-Cookie') {
+                                if (key.toLowerCase() !== 'set-cookie') {
                                     returnString += key + ': ' + this._headers[key] + '\r\n';
                                 }
                             }
@@ -679,7 +679,12 @@ var nativeBridge = (function (exports) {
                             if (isRelativeURL(this._url)) {
                                 return win.CapacitorWebXMLHttpRequest.getResponseHeader.call(this, name);
                             }
-                            return this._headers[name];
+                            for (const key in this._headers) {
+                                if (key.toLowerCase() === name.toLowerCase()) {
+                                    return this._headers[key];
+                                }
+                            }
+                            return null;
                         };
                         Object.setPrototypeOf(xhr, prototype);
                         return xhr;


### PR DESCRIPTION
closes #6855 

This PR fixes XHR `getAllResponseHeaders()` and `getResponseHeader()` to be case-insensitive to match the spec.