### PR TITLE
feat(android): allow developers to provide logic for onRenderProcessGone in WebViewListener

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -102,7 +102,7 @@ public class BridgeWebViewClient extends WebViewClient {
         List<WebViewListener> webViewListeners = bridge.getWebViewListeners();
         if (webViewListeners != null) {
             for (WebViewListener listener : bridge.getWebViewListeners()) {
-                result = result || listener.onRenderProcessGone(view, detail);
+                result = listener.onRenderProcessGone(view, detail) || result;
             }
         }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -97,15 +97,15 @@ public class BridgeWebViewClient extends WebViewClient {
     @Override
     public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
         super.onRenderProcessGone(view, detail);
+        boolean result = false;
+
         List<WebViewListener> webViewListeners = bridge.getWebViewListeners();
         if (webViewListeners != null) {
             for (WebViewListener listener : bridge.getWebViewListeners()) {
-                if (listener.onRenderProcessGone(view, detail)) {
-                    return true;
-                }
+                result = result || listener.onRenderProcessGone(view, detail);
             }
         }
 
-        return false;
+        return result;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -98,13 +98,12 @@ public class BridgeWebViewClient extends WebViewClient {
     public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
         super.onRenderProcessGone(view, detail);
         List<WebViewListener> webViewListeners = bridge.getWebViewListeners();
-
         if (webViewListeners != null) {
             for (WebViewListener listener : bridge.getWebViewListeners()) {
-                listener.onRenderProcessGone(view, detail);
+                if (listener.onRenderProcessGone(view, detail)) {
+                    return true;
+                }
             }
-
-            return true;
         }
 
         return false;

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -2,6 +2,7 @@ package com.getcapacitor;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -91,5 +92,21 @@ public class BridgeWebViewClient extends WebViewClient {
         if (errorPath != null && request.isForMainFrame()) {
             view.loadUrl(errorPath);
         }
+    }
+
+    @Override
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        super.onRenderProcessGone(view, detail);
+        List<WebViewListener> webViewListeners = bridge.getWebViewListeners();
+
+        if (webViewListeners != null) {
+            for (WebViewListener listener : bridge.getWebViewListeners()) {
+                listener.onRenderProcessGone(view, detail);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
@@ -45,11 +45,13 @@ public abstract class WebViewListener {
     }
 
     /**
-     * Callback for render process gone event.
+     * Callback for render process gone event. Return true if the state is handled.
      *
      * @param webView The WebView that loaded
+     * @return returns false by default if the listener is not overridden and used
      */
-    public void onRenderProcessGone(WebView webView, RenderProcessGoneDetail detail) {
+    public boolean onRenderProcessGone(WebView webView, RenderProcessGoneDetail detail) {
         // Override me to add behavior to the web view render process gone event
+        return false;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
@@ -1,5 +1,6 @@
 package com.getcapacitor;
 
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebView;
 
 /**
@@ -41,5 +42,14 @@ public abstract class WebViewListener {
      */
     public void onPageStarted(WebView webView) {
         // Override me to add behavior to the page started event
+    }
+
+    /**
+     * Callback for render process gone event.
+     *
+     * @param webView The WebView that loaded
+     */
+    public void onRenderProcessGone(WebView webView, RenderProcessGoneDetail detail) {
+        // Override me to add behavior to the web view render process gone event
     }
 }


### PR DESCRIPTION
Portals developer app was crashing because they don't have a way to override this method in the WebViewClient in Capacitor. This adds the method to the interface so that it can be overridden via Portals. Not a breaking change.