### PR TITLE
chore(cli): remove androidScheme initialization

### DIFF
--- a/cli/src/tasks/init.ts
+++ b/cli/src/tasks/init.ts
@@ -50,8 +50,6 @@ export async function initCommand(
       () => checkAppId(config, appId),
     ]);
 
-    const androidScheme = config.app.extConfig.server?.androidScheme ?? 'https';
-
     const cordova = await getCordovaPreferences(config);
 
     await runMergeConfig(
@@ -60,9 +58,6 @@ export async function initCommand(
         appId,
         appName,
         webDir,
-        server: {
-          androidScheme: androidScheme,
-        },
         cordova,
       },
       isNewConfig && tsInstalled ? 'ts' : 'json',


### PR DESCRIPTION
Since capacitor android uses https by default now, init doesn't need to add the androidScheme configuration anymore on init command