### PR TITLE
fix(android): make local urls use unpatched fetch

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -425,15 +425,14 @@ var nativeBridge = (function (exports) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
                         const request = new Request(resource, options);
-                        if (!(request.url.startsWith('http:') ||
-                            request.url.startsWith('https:'))) {
+                        if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
                             return win.CapacitorWebFetch(resource, options);
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);
                         try {
                             const { body, method } = request;
-                            const { data: requestData, type, headers } = await convertBody(body || undefined);
+                            const { data: requestData, type, headers, } = await convertBody(body || undefined);
                             const optionHeaders = Object.fromEntries(request.headers.entries());
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: request.url,

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -473,13 +473,7 @@ const initBridge = (w: any): void => {
           options?: RequestInit,
         ) => {
           const request = new Request(resource, options);
-
-          if (
-            !(
-              request.url.startsWith('http:') ||
-              request.url.startsWith('https:')
-            )
-          ) {
+          if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
             return win.CapacitorWebFetch(resource, options);
           }
 

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -425,15 +425,14 @@ var nativeBridge = (function (exports) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
                         const request = new Request(resource, options);
-                        if (!(request.url.startsWith('http:') ||
-                            request.url.startsWith('https:'))) {
+                        if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
                             return win.CapacitorWebFetch(resource, options);
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);
                         try {
                             const { body, method } = request;
-                            const { data: requestData, type, headers } = await convertBody(body || undefined);
+                            const { data: requestData, type, headers, } = await convertBody(body || undefined);
                             const optionHeaders = Object.fromEntries(request.headers.entries());
                             const nativeResponse = await cap.nativePromise('CapacitorHttp', 'request', {
                                 url: request.url,


### PR DESCRIPTION
Converting the resource object to a Request object makes the url absolute, so all the resources are going through the patched fetch even if resource was a relative url before the conversion to Request.
Instead of checking if the url starts with http/https, as all are now, check if the url starts with the server url value, as if it starts with the server url value it should be a local request. 
I'm adding a `/` at the end of the server url so request to the same url but with a different port don't get intercepted.

closes https://github.com/ionic-team/capacitor/issues/6944