### PR TITLE
feat(android): allow developers to provide logic for onRenderProcessGone in WebViewListener

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebViewClient.java
@@ -2,6 +2,7 @@ package com.getcapacitor;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -91,5 +92,20 @@ public class BridgeWebViewClient extends WebViewClient {
         if (errorPath != null && request.isForMainFrame()) {
             view.loadUrl(errorPath);
         }
+    }
+
+    @Override
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        super.onRenderProcessGone(view, detail);
+        boolean result = false;
+
+        List<WebViewListener> webViewListeners = bridge.getWebViewListeners();
+        if (webViewListeners != null) {
+            for (WebViewListener listener : bridge.getWebViewListeners()) {
+                result = listener.onRenderProcessGone(view, detail) || result;
+            }
+        }
+
+        return result;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewListener.java
@@ -1,5 +1,6 @@
 package com.getcapacitor;
 
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebView;
 
 /**
@@ -41,5 +42,16 @@ public abstract class WebViewListener {
      */
     public void onPageStarted(WebView webView) {
         // Override me to add behavior to the page started event
+    }
+
+    /**
+     * Callback for render process gone event. Return true if the state is handled.
+     *
+     * @param webView The WebView that loaded
+     * @return returns false by default if the listener is not overridden and used
+     */
+    public boolean onRenderProcessGone(WebView webView, RenderProcessGoneDetail detail) {
+        // Override me to add behavior to the web view render process gone event
+        return false;
     }
 }


### PR DESCRIPTION
This is the main branch cherry-pick of the recently merged 5.x PR #6946