### PR TITLE
chore(android): Mock Log class for tests

### DIFF
--- a/android/capacitor/src/test/java/android/util/Log.java
+++ b/android/capacitor/src/test/java/android/util/Log.java
@@ -1,0 +1,29 @@
+package android.util;
+
+public class Log {
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int v(String tag, String msg) {
+        System.out.println("VERBOSE: " + tag + ": " + msg);
+        return 0;
+    }
+    
+}

--- a/android/capacitor/src/test/java/android/util/Log.java
+++ b/android/capacitor/src/test/java/android/util/Log.java
@@ -1,6 +1,7 @@
 package android.util;
 
 public class Log {
+
     public static int d(String tag, String msg) {
         System.out.println("DEBUG: " + tag + ": " + msg);
         return 0;
@@ -25,5 +26,4 @@ public class Log {
         System.out.println("VERBOSE: " + tag + ": " + msg);
         return 0;
     }
-    
 }


### PR DESCRIPTION
If tests call code that has Logger calls (like https://github.com/ionic-team/capacitor/pull/6983) they fail because Logger calls Log internally and it's not available on tests.
This mocks Log class so tests don't break.