### PR TITLE
Update native-bridge.ts

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -683,8 +683,8 @@ const initBridge = (w: any): void => {
                         this.dispatchEvent(
                           new ProgressEvent('progress', {
                             lengthComputable: true,
-                            loaded: nativeResponse.data.length,
-                            total: nativeResponse.data.length,
+                            loaded: nativeResponse.data == null ? 0 : nativeResponse.data.length,
+                            total: nativeResponse.data == null ? 0 : nativeResponse.data.length,
                           }),
                         );
                       }


### PR DESCRIPTION
Fixes bug: Capacitor http request failed on native platforms when response body is null (js null value) and Content-Type is application/json #6947