### PR TITLE
feat!: Configurable WebView Zoom Setting

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -551,6 +551,9 @@ public class Bridge {
             Logger.debug("WebView background color not applied");
         }
 
+        settings.setDisplayZoomControls(false);
+        settings.setBuiltInZoomControls(this.config.isZoomableWebView());
+
         if (config.isInitialFocus()) {
             webView.requestFocusFromTouch();
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -273,7 +273,7 @@ public class CapConfig {
         captureInput = JSONUtils.getBoolean(configJSON, "android.captureInput", captureInput);
         useLegacyBridge = JSONUtils.getBoolean(configJSON, "android.useLegacyBridge", useLegacyBridge);
         webContentsDebuggingEnabled = JSONUtils.getBoolean(configJSON, "android.webContentsDebuggingEnabled", isDebug);
-        zoomableWebView = JSONUtils.getBoolean(configJSON, "android.zoomableWebView", JSONUtils.getBoolean(configJSON, "zoomableWebView", false));
+        zoomableWebView = JSONUtils.getBoolean(configJSON, "android.zoomEnabled", JSONUtils.getBoolean(configJSON, "zoomEnabled", false));
 
         String logBehavior = JSONUtils.getString(
             configJSON,

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -359,7 +359,9 @@ public class CapConfig {
         return webContentsDebuggingEnabled;
     }
 
-    public boolean isZoomableWebView() { return zoomableWebView; }
+    public boolean isZoomableWebView() {
+        return zoomableWebView;
+    }
 
     public boolean isLoggingEnabled() {
         return loggingEnabled;

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -52,6 +52,7 @@ public class CapConfig {
     private int minWebViewVersion = DEFAULT_ANDROID_WEBVIEW_VERSION;
     private int minHuaweiWebViewVersion = DEFAULT_HUAWEI_WEBVIEW_VERSION;
     private String errorPath;
+    private boolean zoomableWebView = false;
 
     // Embedded
     private String startPath;
@@ -177,6 +178,7 @@ public class CapConfig {
         this.minWebViewVersion = builder.minWebViewVersion;
         this.minHuaweiWebViewVersion = builder.minHuaweiWebViewVersion;
         this.errorPath = builder.errorPath;
+        this.zoomableWebView = builder.zoomableWebView;
 
         // Embedded
         this.startPath = builder.startPath;
@@ -271,6 +273,7 @@ public class CapConfig {
         captureInput = JSONUtils.getBoolean(configJSON, "android.captureInput", captureInput);
         useLegacyBridge = JSONUtils.getBoolean(configJSON, "android.useLegacyBridge", useLegacyBridge);
         webContentsDebuggingEnabled = JSONUtils.getBoolean(configJSON, "android.webContentsDebuggingEnabled", isDebug);
+        zoomableWebView = JSONUtils.getBoolean(configJSON, "android.zoomableWebView", JSONUtils.getBoolean(configJSON, "zoomableWebView", false));
 
         String logBehavior = JSONUtils.getString(
             configJSON,
@@ -355,6 +358,8 @@ public class CapConfig {
     public boolean isWebContentsDebuggingEnabled() {
         return webContentsDebuggingEnabled;
     }
+
+    public boolean isZoomableWebView() { return zoomableWebView; }
 
     public boolean isLoggingEnabled() {
         return loggingEnabled;
@@ -546,6 +551,7 @@ public class CapConfig {
         private boolean useLegacyBridge = false;
         private int minWebViewVersion = DEFAULT_ANDROID_WEBVIEW_VERSION;
         private int minHuaweiWebViewVersion = DEFAULT_HUAWEI_WEBVIEW_VERSION;
+        private boolean zoomableWebView = false;
 
         // Embedded
         private String startPath = null;
@@ -647,6 +653,11 @@ public class CapConfig {
 
         public Builder setWebContentsDebuggingEnabled(boolean webContentsDebuggingEnabled) {
             this.webContentsDebuggingEnabled = webContentsDebuggingEnabled;
+            return this;
+        }
+
+        public Builder setZoomableWebView(boolean zoomableWebView) {
+            this.zoomableWebView = zoomableWebView;
             return this;
         }
 

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -51,6 +51,7 @@ public class ConfigBuildingTest {
                     .setOverriddenUserAgentString("test-user-agent")
                     .setAppendedUserAgentString("test-append")
                     .setWebContentsDebuggingEnabled(true)
+                    .setZoomableWebView(false)
                     .setBackgroundColor("red")
                     .setPluginsConfiguration(pluginConfig)
                     .setServerUrl("http://www.google.com")

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -90,7 +90,7 @@ export interface CapacitorConfig {
    * @default false
    * @since 6.0.0
    */
-  zoomableWebView?: boolean;
+  zoomEnabled?: boolean;
 
   android?: {
     /**
@@ -136,7 +136,7 @@ export interface CapacitorConfig {
      * @default false
      * @since 6.0.0
      */
-    zoomableWebView?: boolean;
+    zoomEnabled?: boolean;
 
     /**
      * Enable mixed content in the Capacitor Web View for Android.
@@ -354,7 +354,7 @@ export interface CapacitorConfig {
      * @default false
      * @since 6.0.0
      */
-    zoomableWebView?: boolean;
+    zoomEnabled?: boolean;
 
     /**
      * Configure the scroll view's content inset adjustment behavior.

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -84,6 +84,14 @@ export interface CapacitorConfig {
    */
   backgroundColor?: string;
 
+  /**
+   * Enable zooming within the Capacitor Web View.
+   *
+   * @default false
+   * @since 6.0.0
+   */
+  zoomableWebView?: boolean;
+
   android?: {
     /**
      * Specify a custom path to the native Android project.
@@ -121,6 +129,14 @@ export interface CapacitorConfig {
      * @since 1.1.0
      */
     backgroundColor?: string;
+
+    /**
+     * Enable zooming within the Capacitor Web View for Android
+     *
+     * @default false
+     * @since 6.0.0
+     */
+    zoomableWebView?: boolean;
 
     /**
      * Enable mixed content in the Capacitor Web View for Android.
@@ -331,6 +347,14 @@ export interface CapacitorConfig {
      * @since 1.1.0
      */
     backgroundColor?: string;
+
+    /**
+     * Enable zooming within the Capacitor Web View for iOS.
+     *
+     * @default false
+     * @since 6.0.0
+     */
+    zoomableWebView?: boolean;
 
     /**
      * Configure the scroll view's content inset adjustment behavior.

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -131,7 +131,7 @@ export interface CapacitorConfig {
     backgroundColor?: string;
 
     /**
-     * Enable zooming within the Capacitor Web View for Android
+     * Enable zooming within the Capacitor Web View for Android.
      *
      * @default false
      * @since 6.0.0

--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -306,6 +306,9 @@ extension CAPBridgeViewController {
         // set our delegates
         aWebView.uiDelegate = delegationHandler
         aWebView.navigationDelegate = delegationHandler
+        if !configuration.zoomingEnabled {
+            aWebView.scrollView.delegate = delegationHandler
+        }
     }
 
     private func updateBinaryVersion() {

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
@@ -17,6 +17,7 @@ NS_SWIFT_NAME(InstanceConfiguration)
 @property (nonatomic, readonly, nonnull) NSDictionary *pluginConfigurations;
 @property (nonatomic, readonly) BOOL loggingEnabled;
 @property (nonatomic, readonly) BOOL scrollingEnabled;
+@property (nonatomic, readonly) BOOL zoomingEnabled;
 @property (nonatomic, readonly) BOOL allowLinkPreviews;
 @property (nonatomic, readonly) BOOL handleApplicationNotifications;
 @property (nonatomic, readonly) BOOL isWebDebuggable;

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -29,6 +29,7 @@
                 break;
         }
         _scrollingEnabled = descriptor.scrollingEnabled;
+        _zoomingEnabled =  descriptor.zoomingEnabled;
         _allowLinkPreviews = descriptor.allowLinkPreviews;
         _handleApplicationNotifications = descriptor.handleApplicationNotifications;
         _contentInsetAdjustmentBehavior = descriptor.contentInsetAdjustmentBehavior;
@@ -66,6 +67,7 @@
         _pluginConfigurations = [[configuration pluginConfigurations] copy];
         _loggingEnabled = configuration.loggingEnabled;
         _scrollingEnabled = configuration.scrollingEnabled;
+        _zoomingEnabled = configuration.zoomingEnabled;
         _allowLinkPreviews = configuration.allowLinkPreviews;
         _handleApplicationNotifications = configuration.handleApplicationNotifications;
         _isWebDebuggable = configuration.isWebDebuggable;

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -84,6 +84,11 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, assign) BOOL scrollingEnabled;
 /**
+ @brief Whether or not the web view can zoom.
+ @discussion Set by @c ios.zoomEnabled in the configuration file.
+ */
+@property (nonatomic, assign) BOOL zoomingEnabled;
+/**
  @brief Whether or not the web view will preview links.
  @discussion Set by @c ios.allowsLinkPreview in the configuration file. Corresponds to @c allowsLinkPreview on WKWebView.
  */

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -85,7 +85,7 @@ NS_SWIFT_NAME(InstanceDescriptor)
 @property (nonatomic, assign) BOOL scrollingEnabled;
 /**
  @brief Whether or not the web view can zoom.
- @discussion Set by @c ios.zoomEnabled in the configuration file.
+ @discussion Set by @c zoomEnabled in the configuration file.
  */
 @property (nonatomic, assign) BOOL zoomingEnabled;
 /**

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.m
@@ -37,6 +37,7 @@ NSString* const CAPInstanceDescriptorDefaultHostname = @"localhost";
     _legacyConfig = @{};
     _loggingBehavior = CAPInstanceLoggingBehaviorDebug;
     _scrollingEnabled = YES;
+    _zoomingEnabled = NO;
     _allowLinkPreviews = YES;
     _handleApplicationNotifications = YES;
     _isWebDebuggable = NO;

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -114,6 +114,9 @@ internal extension InstanceDescriptor {
             if let scrollEnabled = config[keyPath: "ios.scrollEnabled"] as? Bool {
                 scrollingEnabled = scrollEnabled
             }
+            if let zoomEnabled = (config[keyPath: "ios.zoomEnabled"] as? Bool) ?? (config[keyPath: "zoomEnabled"] as? Bool) {
+                zoomingEnabled = zoomEnabled
+            }
             if let pluginConfig = config[keyPath: "plugins"] as? JSObject {
                 pluginConfigurations = pluginConfig
             }

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -60,9 +60,9 @@ public class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDeleg
 
     @available(iOS 15, *)
     public func webView(_ webView: WKWebView,
-                 requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
-                 initiatedByFrame frame: WKFrameInfo,
-                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+                        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+                        initiatedByFrame frame: WKFrameInfo,
+                        decisionHandler: @escaping (WKPermissionDecision) -> Void) {
         decisionHandler(.grant)
     }
 
@@ -311,9 +311,9 @@ public class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDeleg
         }
         return nil
     }
-    
+
     // MARK: - UIScrollViewDelegate
-    
+
     // disable zooming in WKWebView ScrollView
     public func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
         scrollView.pinchGestureRecognizer?.isEnabled = false

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -4,7 +4,7 @@ import WebKit
 // adopting a public protocol in an internal class is by design
 // swiftlint:disable lower_acl_than_parent
 @objc(CAPWebViewDelegationHandler)
-public class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
+public class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, UIScrollViewDelegate {
     weak var bridge: CapacitorBridge?
     public fileprivate(set) var contentController = WKUserContentController()
     enum WebViewLoadingState {
@@ -310,6 +310,13 @@ public class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDeleg
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
         return nil
+    }
+    
+    // MARK: - UIScrollViewDelegate
+    
+    // disable zooming in WKWebView ScrollView
+    public func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+        scrollView.pinchGestureRecognizer?.isEnabled = false
     }
 
     // MARK: - Private


### PR DESCRIPTION
This PR creates a new `zoomEnabled` setting to control the zoomability of the Capacitor WebView, and sets the default `zoomEnabled` setting on iOS and Android to `false`.

fixes: https://github.com/ionic-team/capacitor/issues/4620