### PR TITLE
refactor(ios)!: Remove unused plugin return types

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgedPlugin.h
+++ b/ios/Capacitor/Capacitor/CAPBridgedPlugin.h
@@ -9,8 +9,6 @@
 #define CAPPluginReturnNone @"none"
 #define CAPPluginReturnCallback @"callback"
 #define CAPPluginReturnPromise @"promise"
-#define CAPPluginReturnWatch @"watch"
-#define CAPPluginReturnSync @"sync" // not used
 
 @class CAPPluginCall;
 @class CAPPlugin;


### PR DESCRIPTION
marking as breaking just in case, but those two are iOS only and we don't use them on any of our plugins nor have any special code for handling those types