### PR TITLE
fix(cli): Use latest native-run

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "debug": "^4.3.4",
     "env-paths": "^2.2.0",
     "kleur": "^4.1.4",
-    "native-run": "^1.7.3",
+    "native-run": "^2.0.0",
     "open": "^8.4.0",
     "plist": "^3.0.5",
     "prompts": "^2.4.2",


### PR DESCRIPTION
I've released native-run 2.0.0, so make the CLI use that version since it fixes the SDK 34 problem.