### PR TITLE
chore(ci): Remove unneeded action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Latest
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
I saw the ci action was showing a warning because this action was for node 12 so I was going to update it, but in the repository the author said that we "probably don't need this action" and that we should use `concurrency` instead, so I was going to replace it with a `concurrency` entry, but [Mike already added it a few months ago,](https://github.com/ionic-team/capacitor/blob/787244dc9a6fe9c6c86092e8cfcecc9ffaf0c488/.github/workflows/ci.yml#L14) so the action shouldn't be needed anymore.
