### PR TITLE
chore: Add missing dependencies

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@ionic/cli-framework-output": "^2.2.5",
     "@ionic/utils-fs": "^3.1.6",
+    "@ionic/utils-process": "^2.1.11",
     "@ionic/utils-subprocess": "^2.1.11",
     "@ionic/utils-terminal": "^2.3.3",
     "commander": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prettier": "~2.3.0",
     "prettier-plugin-java": "~1.1.1",
     "rimraf": "^4.4.1",
+    "semver": "^7.3.7",
     "swiftlint": "^1.0.1",
     "tar": "^6.1.11"
   }


### PR DESCRIPTION
While the build works because the missing dependencies are dependencies of other dependencies, it could break in the future of those dependencies stop adding our missing dependencies as dependencies, so better add them now to prevent possible future issues.

Closes https://github.com/ionic-team/capacitor/issues/7035