### PR TITLE
fix(ios): Remove CocoaPods Xcode 15 workaround that causes issues

### DIFF
--- a/ios/scripts/pods_helpers.rb
+++ b/ios/scripts/pods_helpers.rb
@@ -7,12 +7,6 @@ def assertDeploymentTarget(installer)
       if should_upgrade
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       end
-      # workaround for Xcode 15 and Cocoapods 1.21.1
-      # Should not be needed after Cocoapods 1.13.0
-      xcconfig_path = config.base_configuration_reference.real_path
-      xcconfig = File.read(xcconfig_path)
-      xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
-      File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
     end
   end
 end


### PR DESCRIPTION
Note: We have to document that Capacitor 6 requires CocoaPods 1.13.0 or greater


closes https://github.com/ionic-team/capacitor/issues/6939