### PR TITLE
chore(android): Replace deprecated compileSdkVersion with compileSdk

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -42,7 +42,7 @@ if (System.getenv("CAP_PUBLISH") == "true") {
 
 android {
     namespace "com.getcapacitor.android"
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace "capacitor.cordova.android.plugins"
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34


### PR DESCRIPTION
`compileSdkVersion` is deprecated in gradle 7, replace it with `compileSdk`.

I've only replaced the gradle keyword, not sure if we also want to make the variable we use to have the same name or keep the old one.
