### PR TITLE
Fix cors errors with local files when developing / live reloading on android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -98,6 +98,8 @@ public class WebViewLocalServer {
                 tempResponseHeaders = responseHeaders;
             }
             tempResponseHeaders.put("Cache-Control", "no-cache");
+            tempResponseHeaders.put("Access-Control-Allow-Origin", "*");
+            tempResponseHeaders.put("Access-Control-Allow-Methods", "GET, OPTIONS");
             this.responseHeaders = tempResponseHeaders;
         }
 


### PR DESCRIPTION
This fixes cors errors on android that happen if you try to load local files while serving with live reload. Something like that:
https://ip:8102/_capacitor_file_/data/user/0/package.name/files/7a44b042-2371-41f5-9c84-56e11fdd1d40.mp3