### PR TITLE
Bugfix/flavor signing

### DIFF
--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -44,7 +44,7 @@ export async function buildAndroid(
   );
 
   const unsignedReleaseName = `app${
-    config.android.flavor ? `-${config.android.flavor}` : ''
+    flavor !== '' ? `-${flavor}` : ''
   }-release${releaseTypeIsAAB ? '' : '-unsigned'}.${releaseType.toLowerCase()}`;
 
   const signedReleaseName = unsignedReleaseName.replace(


### PR DESCRIPTION
When constructing the unsigned .apk/.aab name, the const `flavor` declared on line 16 should be used and not `config.android.flavor` as this value may be null even though a flavor has been provided

This issue was raised previously for it: https://github.com/ionic-team/capacitor/issues/6215
