### PR TITLE
chore(ios): format the new codable classes

### DIFF
--- a/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
@@ -31,8 +31,8 @@ public final class JSValueDecoder: TopLevelDecoder {
 typealias CodingUserInfo = [CodingUserInfoKey: Any]
 
 private final class _JSValueDecoder {
-    internal var codingPath: [CodingKey] = []
-    internal var userInfo: CodingUserInfo = [:]
+    var codingPath: [CodingKey] = []
+    var userInfo: CodingUserInfo = [:]
     fileprivate var data: JSValue
 
     init(data: JSValue) {

--- a/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
@@ -123,7 +123,7 @@ extension Array: JSValueEncodingContainer where Element == EncodingContainer {
     var data: JSValue? {
         guard count != 0 else { return nil }
         guard count != 1 else { return self[0].data }
-        var data: (any JSValue)? = nil
+        var data: (any JSValue)?
 
         for container in self {
             if data == nil {
@@ -189,7 +189,7 @@ extension _JSValueEncoder: Encoder {
     }
 }
 
-fileprivate final class KeyedContainer<Key> where Key: CodingKey {
+private final class KeyedContainer<Key> where Key: CodingKey {
     var object: JSObject? {
         encodedKeyedValue?.reduce(into: [:]) { obj, next in
             let (key, value) = next
@@ -239,7 +239,7 @@ extension KeyedContainer: KeyedEncodingContainerProtocol {
 
     // This is a perectly valid name for this method. The underscore is to avoid a conflict with the
     // protocol requirement.
-    //swiftlint:disable:next identifier_name
+    // swiftlint:disable:next identifier_name
     func _encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T: Encodable {
         switch optionalEncodingStrategy {
         case .explicitNulls:

--- a/ios/Capacitor/CodableTests/CodableTests.swift
+++ b/ios/Capacitor/CodableTests/CodableTests.swift
@@ -22,7 +22,6 @@ private struct Person: Codable, Equatable {
     var family: [Person]?
 }
 
-
 private let rawPet: JSObject = [
     "name": "Penny",
     "breed": "Chihuahua",
@@ -58,7 +57,6 @@ private let person = Person(
         Person(name: "Leia", age: 20)
     ]
 )
-
 
 final class JSValueDecoderTest: XCTestCase {
     func testDecode_when_provided_a_valid_keyed_container_for_the_target_type__decoding_is_successful() throws {
@@ -185,7 +183,7 @@ final class JSValueEncoderTest: XCTestCase {
 
     func testEncode__when_nil_is_present_in_value__and_optional_encoding_is_set_to_explicit_nulls__it_is_encoded_as_nsnull() throws {
         struct Test: Encodable {
-            var name: String? = nil
+            var name: String?
         }
 
         let explicitEncoder = JSValueEncoder(optionalEncodingStrategy: .explicitNulls)

--- a/ios/Capacitor/CodableTests/NestedCodableTests.swift
+++ b/ios/Capacitor/CodableTests/NestedCodableTests.swift
@@ -113,7 +113,7 @@ extension Flattened: Encodable {
         var infoContainer = userContainer.nestedContainer(keyedBy: RealInfoKeys.self, forKey: .realInfo)
         try infoContainer.encode(fullName, forKey: .fullName)
         var reviewsContainer = topLevelContainer.nestedUnkeyedContainer(forKey: .reviewCount)
-        
+
         try reviewsContainer.encode(["count": reviewCount])
     }
 }

--- a/ios/Capacitor/CodableTests/SuperCodableTests.swift
+++ b/ios/Capacitor/CodableTests/SuperCodableTests.swift
@@ -242,7 +242,7 @@ private class UnkeyedSubSuper: UnkeyedBase {
         self.bool = bool
         super.init(number: 0, string: "empty")
     }
-    
+
     required init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         bool = try container.decode(Bool.self)


### PR DESCRIPTION
running `npm run fmt` with swiftlint 0.53.0 does this changes, not sure if it was missed or was using a different version