### PR TITLE
chore(ci): Run pod lib lint on verify

### DIFF
--- a/ios/package.json
+++ b/ios/package.json
@@ -20,7 +20,7 @@
     "scripts/pods_helpers.rb"
   ],
   "scripts": {
-    "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova",
+    "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova && pod lib lint --allow-warnings Capacitor.podspec && pod lib lint --allow-warnings CapacitorCordova.podspec",
     "xc:build:Capacitor": "cd Capacitor && xcodebuild -workspace Capacitor.xcworkspace -scheme Capacitor && cd ..",
     "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd ..",
     "xc:build:xcframework": "scripts/build.sh xcframework"


### PR DESCRIPTION
We used to run this but was removed because a problem with a podspec change made for supporting portals, but that was fixed long ago, so we can run it again and would help catch issues where the local project builds fine but the pod library doesn't build correctly (as happened with beta 0)