### PR TITLE
feat(android): Load alternative layout when no WebView

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -24,7 +24,13 @@ public class BridgeActivity extends AppCompatActivity {
         bridgeBuilder.setInstanceState(savedInstanceState);
         getApplication().setTheme(R.style.AppTheme_NoActionBar);
         setTheme(R.style.AppTheme_NoActionBar);
-        setContentView(R.layout.bridge_layout_main);
+        try {
+            setContentView(R.layout.bridge_layout_main);
+        } catch (Exception ex) {
+            setContentView(R.layout.no_webview);
+            return;
+        }
+
         PluginManager loader = new PluginManager(getAssets());
 
         try {
@@ -67,8 +73,10 @@ public class BridgeActivity extends AppCompatActivity {
     public void onStart() {
         super.onStart();
         activityDepth++;
-        this.bridge.onStart();
-        Logger.debug("App started");
+        if (this.bridge != null) {
+            this.bridge.onStart();
+            Logger.debug("App started");
+        }
     }
 
     @Override
@@ -81,36 +89,43 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
-        bridge.getApp().fireStatusChange(true);
-        this.bridge.onResume();
-        Logger.debug("App resumed");
+        if (bridge != null) {
+            bridge.getApp().fireStatusChange(true);
+            this.bridge.onResume();
+            Logger.debug("App resumed");
+        }
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        this.bridge.onPause();
-        Logger.debug("App paused");
+        if (bridge != null) {
+            this.bridge.onPause();
+            Logger.debug("App paused");
+        }
     }
 
     @Override
     public void onStop() {
         super.onStop();
+        if (bridge != null) {
+            activityDepth = Math.max(0, activityDepth - 1);
+            if (activityDepth == 0) {
+                bridge.getApp().fireStatusChange(false);
+            }
 
-        activityDepth = Math.max(0, activityDepth - 1);
-        if (activityDepth == 0) {
-            bridge.getApp().fireStatusChange(false);
+            this.bridge.onStop();
+            Logger.debug("App stopped");
         }
-
-        this.bridge.onStop();
-        Logger.debug("App stopped");
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        this.bridge.onDestroy();
-        Logger.debug("App destroyed");
+        if (this.bridge != null) {
+            this.bridge.onDestroy();
+            Logger.debug("App destroyed");
+        }
     }
 
     @Override

--- a/android/capacitor/src/main/res/layout/no_webview.xml
+++ b/android/capacitor/src/main/res/layout/no_webview.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:text="@string/no_webview_text"
+        android:gravity="center"
+        android:textSize="48sp" />
+</LinearLayout>

--- a/android/capacitor/src/main/res/values/strings.xml
+++ b/android/capacitor/src/main/res/values/strings.xml
@@ -1,2 +1,3 @@
 <resources>
+    <string name="no_webview_text">This app requires a WebView to work</string>
 </resources>


### PR DESCRIPTION
Add a basic layout with a text error message for when there is no WebView installed on the device or is disabled.

Users can use their own text by adding a `<string name="no_webview_text">custom text</string>` entry in their `strings.xml`, or create their own `no_webview.xml` layout that would replace Capacitor's default one.

Added some `bridge != null` checks as if the app fails to create the WebView, the `bridge` will be null and crash.

closes https://github.com/ionic-team/capacitor/issues/5257