### PR TITLE
chore(android): Deprecate PluginCall hasOption

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -370,6 +370,13 @@ public class PluginCall {
         return defaultValue;
     }
 
+    /**
+     * @param name of the option to check
+     * @return boolean indicating if the plugin call has an option for the provided name.
+     * @deprecated Presence of a key should not be considered significant.
+     * Use typed accessors to check the value instead.
+     */
+    @Deprecated
     public boolean hasOption(String name) {
         return this.data.has(name);
     }


### PR DESCRIPTION
Deprecate hasOptions since it's deprecated on iOS

closes https://github.com/ionic-team/capacitor/issues/6696