### PR TITLE
chore(ios): Clean up podspec for source files

### DIFF
--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -16,8 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }
   s.source = { git: 'https://github.com/ionic-team/capacitor.git', tag: package['version'] }
-  s.source_files = "#{prefix}Capacitor/Capacitor/*.{swift,h,m}", "#{prefix}Capacitor/Capacitor/Codable/*.{swift,h,m}",
-                   "#{prefix}Capacitor/Capacitor/Plugins/*.{swift,h,m}", "#{prefix}Capacitor/Capacitor/Plugins/**/*.{swift,h,m}"
+  s.source_files = "#{prefix}Capacitor/Capacitor/**/*.{swift,h,m}"
   s.module_map = "#{prefix}Capacitor/Capacitor/Capacitor.modulemap"
   s.resources = ["#{prefix}Capacitor/Capacitor/assets/native-bridge.js"]
   s.dependency 'CapacitorCordova'


### PR DESCRIPTION
This will allow for more sub-folders to be added without having to explicitly declare them in the podspec.