### PR TITLE
Change intent to fix single top issue

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -409,7 +409,8 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     private void showFilePicker(final ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
-        Intent intent = fileChooserParams.createIntent();
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.setType("*/*");
         if (fileChooserParams.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }


### PR DESCRIPTION
Fixes #6943

- #6943

This basically changes the intent type to allow picking files, otherwise nothing happens after you pick a file.
If using the current code with android 13 and singletop mode, that is. It might be that other modes are working as expected.

I know this works for my case and is currently in prodcution, I haven't tested it in other situations though.