### PR TITLE
fix(http): fix encoding issue in multipart/form-data requests

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -275,7 +275,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                     if (type.equals("string")) {
                         os.writeBytes(twoHyphens + boundary + lineEnd);
                         os.writeBytes("Content-Disposition: form-data; name=\"" + key + "\"" + lineEnd + lineEnd);
-                        os.writeBytes(value);
+                        os.write(value.getBytes(StandardCharsets.UTF_8));
                         os.writeBytes(lineEnd);
                     } else if (type.equals("base64File")) {
                         String fileName = entry.getString("fileName");


### PR DESCRIPTION
This PR addresses the issue of handling special characters in FormData requests (e.g. `ü`, `ö`, and `ä`). To provide a clearer understanding of the changes, I've prepared a code snippet, which you can view here: [tutorialspoint snippet](http://tpcg.io/_KVY8AE)