### PR TITLE
chore(ci): Remove automatic platform labels

### DIFF
--- a/.github/bot.yml
+++ b/.github/bot.yml
@@ -13,10 +13,6 @@ tasks:
     config:
       label: 'needs reply'
       exclude-labeler: true
-  - name: add-platform-labels
-    on:
-      issues:
-        types: [opened, edited]
   - name: add-contributors
     on:
       push:


### PR DESCRIPTION
It's adding all the platforms instead of just the affected one and also removing the triage label, so best remove the whole thing