### PR TITLE
fix(cli): remove certificate file extension check on copy

### DIFF
--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -323,14 +323,6 @@ async function copySSLCert(
   const validCertPaths: string[] = [];
   for (const sslCertPath of sslCertPaths) {
     const certAbsFromPath = join(rootDir, sslCertPath);
-    if (!/^.+\.(cer)$/.test(certAbsFromPath)) {
-      logger.warn(
-        `Cannot copy file from ${c.strong(certAbsFromPath)}\n` +
-          `The file is not a .cer SSL Certificate file.`,
-      );
-
-      return;
-    }
     if (!(await pathExists(certAbsFromPath))) {
       logger.warn(
         `Cannot copy SSL Certificate file from ${c.strong(certAbsFromPath)}\n` +


### PR DESCRIPTION
At the moment the SSL pinning plugin only supports DER formatted certificates (binary) on iOS, which should have `.der` extension, not `.cer`, and other formats are not supported at the moment, so the error message is confusing for users.
And on Android it supports multiple formats and extensions.

I'm working on adding support for base64 formatted certificates to the SSL pinning plugin and also make the plugin log if there was a problem with any of the certificates, because at the moment it fails silently, so I think the `.cer` extension check can be removed.

An alternative if we don't want to remove the check would be to expand the file extension list.