### PR TITLE
fix(ios): remove new line character in multipart/form-data requests

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -127,14 +127,12 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
                 data.append("\r\n".data(using: .utf8)!)
 
                 data.append(Data(base64Encoded: value)!)
-
-                data.append("\r\n".data(using: .utf8)!)
             } else if type == "string" {
                 data.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
                 data.append("Content-Disposition: form-data; name=\"\(key!)\"\r\n".data(using: .utf8)!)
                 data.append("\r\n".data(using: .utf8)!)
+
                 data.append(value.data(using: .utf8)!)
-                data.append("\r\n".data(using: .utf8)!)
             }
 
         }


### PR DESCRIPTION
Removes new line characters `\r\n` which are incorrectly appended to the data of multipart/form-data requests. This change removes these new line characters in order to comply with the specifications, as defined here: https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2

Fixes: ionic-team/capacitor#6748

Note, these changes were originally suggested by @hyrex here: https://github.com/heyrex/capacitor-heyrex/pull/1 and in [the related issue](https://github.com/ionic-team/capacitor/issues/6748#issuecomment-1643028088) that is linked to this pull request. 

Since this problem is a big deal for developers and buried deep in iOS logic this should be addressed as soon as possible which is why I want to put more attention on this.  