### PR TITLE
fix(http): handle proxy urls with port

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -144,10 +144,10 @@ var nativeBridge = (function (exports) {
             return url;
         let proxyUrl = new URL(url);
         const isHttps = proxyUrl.protocol === 'https:';
-        const originalHostname = proxyUrl.hostname;
+        const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
         proxyUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
-        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHostname}${originalPathname}`;
+        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };
     const initBridge = (w) => {
@@ -678,7 +678,8 @@ var nativeBridge = (function (exports) {
                                             else {
                                                 this.response = nativeResponse.data;
                                             }
-                                            this.responseText = ((_a = (nativeResponse.headers['Content-Type'] || nativeResponse.headers['content-type'])) === null || _a === void 0 ? void 0 : _a.startsWith('application/json'))
+                                            this.responseText = ((_a = (nativeResponse.headers['Content-Type'] ||
+                                                nativeResponse.headers['content-type'])) === null || _a === void 0 ? void 0 : _a.startsWith('application/json'))
                                                 ? JSON.stringify(nativeResponse.data)
                                                 : nativeResponse.data;
                                             this.responseURL = nativeResponse.url;

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -266,6 +267,7 @@ public class WebViewLocalServer {
             .replace(bridge.getLocalUrl(), isHttps ? "https:/" : "http:/")
             .replace(Bridge.CAPACITOR_HTTP_INTERCEPTOR_START, "")
             .replace(Bridge.CAPACITOR_HTTPS_INTERCEPTOR_START, "");
+        urlString = URLDecoder.decode(urlString, "UTF-8");
         URL url = new URL(urlString);
         JSObject headers = new JSObject();
 

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -134,13 +134,13 @@ const createProxyUrl = (url: string, win: WindowCapacitor): string => {
 
   let proxyUrl = new URL(url);
   const isHttps = proxyUrl.protocol === 'https:';
-  const originalHostname = proxyUrl.hostname;
+  const originalHost = encodeURIComponent(proxyUrl.host);
   const originalPathname = proxyUrl.pathname;
   proxyUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
 
   proxyUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
-  }/${originalHostname}${originalPathname}`;
+  }/${originalHost}${originalPathname}`;
   return proxyUrl.toString();
 };
 

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -141,7 +141,6 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
         var targetUrl = url.absoluteString
             .replacingOccurrences(of: CapacitorBridge.httpInterceptorStartIdentifier, with: "")
             .replacingOccurrences(of: CapacitorBridge.httpsInterceptorStartIdentifier, with: "")
-
         // Only replace first occurrence of the scheme
         if let range = targetUrl.range(of: localUrl.scheme ?? InstanceDescriptorDefaults.scheme) {
             targetUrl = targetUrl.replacingCharacters(in: range, with: isHttpsRequest ? "https" : "http")
@@ -152,7 +151,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             targetUrl = targetUrl.replacingCharacters(in: range, with: "")
         }
 
-        urlRequest.url = URL(string: targetUrl)
+        urlRequest.url = URL(string: targetUrl.removingPercentEncoding ?? targetUrl)
 
         let urlSession = URLSession.shared
         let task = urlSession.dataTask(with: urlRequest) { (data, response, error) in

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -144,10 +144,10 @@ var nativeBridge = (function (exports) {
             return url;
         let proxyUrl = new URL(url);
         const isHttps = proxyUrl.protocol === 'https:';
-        const originalHostname = proxyUrl.hostname;
+        const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
         proxyUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
-        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHostname}${originalPathname}`;
+        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };
     const initBridge = (w) => {
@@ -678,7 +678,8 @@ var nativeBridge = (function (exports) {
                                             else {
                                                 this.response = nativeResponse.data;
                                             }
-                                            this.responseText = ((_a = (nativeResponse.headers['Content-Type'] || nativeResponse.headers['content-type'])) === null || _a === void 0 ? void 0 : _a.startsWith('application/json'))
+                                            this.responseText = ((_a = (nativeResponse.headers['Content-Type'] ||
+                                                nativeResponse.headers['content-type'])) === null || _a === void 0 ? void 0 : _a.startsWith('application/json'))
                                                 ? JSON.stringify(nativeResponse.data)
                                                 : nativeResponse.data;
                                             this.responseURL = nativeResponse.url;
@@ -751,9 +752,7 @@ var nativeBridge = (function (exports) {
                             if (isRelativeOrProxyUrl(this._url)) {
                                 return win.CapacitorWebXMLHttpRequest.getResponseHeader.call(this, name);
                             }
-                            // The search for the name is case insenstive. The Swift Code makes sure that the keys
-                            // in the headers dictionary are already lowercased.
-                            return this._headers[name.toLowerCase()];
+                            return this._headers[name];
                         };
                         Object.setPrototypeOf(xhr, prototype);
                         return xhr;


### PR DESCRIPTION
I've encoded the host because if if has a port, the `:` will be in the url path and it's not a valid character for the path, despite it works without encoding in the devices I've tested, so it might break in the future. Then I had to decode the url in native side.


