### PR TITLE
fix(android): handle http errors on the proxy

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -314,7 +314,10 @@ public class WebViewLocalServer {
             }
         }
 
-        InputStream inputStream = connection.getInputStream();
+        InputStream inputStream = connection.getErrorStream();
+        if (inputStream == null) {
+            inputStream = connection.getInputStream();
+        }
 
         if (null == mimeType) {
             mimeType = getMimeType(request.getUrl().getPath(), inputStream);


### PR DESCRIPTION
On Android, if there is a http error instead of returning it on the regular `getInputStream()`, it's returned on the `getErrorStream()`, so check it and if it's `null` then get the regular `InputStream`.