### PR TITLE
fix(android): let WebView handle errors

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -184,6 +184,7 @@ public class WebViewLocalServer {
                 return handleCapacitorHttpRequest(request);
             } catch (Exception e) {
                 Logger.error(e.getLocalizedMessage());
+                return null;
             }
         }
 


### PR DESCRIPTION
If there was a network error like unknown host or any other error that would cause the request to throw, return `null` so the WebView handles the request itself instead of being intercepted. 