### PR TITLE
fix(cli): correct build path for non flavor builds  (#7281)

### DIFF
--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -38,7 +38,7 @@ export async function buildAndroid(
   const releaseDir = releaseTypeIsAAB
     ? flavor !== ''
       ? `${flavor}Release`
-      : 'Release'
+      : 'release'
     : flavor !== ''
     ? join(flavor, 'release')
     : 'release';


### PR DESCRIPTION
Co-authored-by: Mark Anderson <mark@ionic.io>
(cherry picked from commit 0f9651d99cdd9cb463e494ed016838cd6d4a34c4)