### PR TITLE
fix(android): Remove path from allowedOriginRules

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -254,7 +254,12 @@ public class Bridge {
         // Start the local web server
         JSInjector injector = getJSInjector();
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
-            WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(appUrl));
+            String allowedOrigin = appUrl;
+            Uri appUri = Uri.parse(appUrl);
+            if (appUri.getPath() != null) {
+                allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
+            }
+            WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
             injector = null;
         }
         localServer = new WebViewLocalServer(context, this, injector, authorities, html5mode);


### PR DESCRIPTION
`addDocumentStartJavaScript`'s `allowedOriginRules` expect urls without paths, if the `server.url` contain paths, remove it from the url passed as  `allowedOriginRules`

closes https://github.com/ionic-team/capacitor/issues/7289