### PR TITLE
fix(http): keep original URL properties on proxy

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -143,10 +143,12 @@ var nativeBridge = (function (exports) {
         if (isRelativeOrProxyUrl(url))
             return url;
         let proxyUrl = new URL(url);
+        const brigeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
-        proxyUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        proxyUrl.protocol = brigeUrl.protocol;
+        proxyUrl.host = brigeUrl.host;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -142,13 +142,13 @@ var nativeBridge = (function (exports) {
         var _a, _b;
         if (isRelativeOrProxyUrl(url))
             return url;
-        let proxyUrl = new URL(url);
-        const brigeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        const proxyUrl = new URL(url);
+        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
-        proxyUrl.protocol = brigeUrl.protocol;
-        proxyUrl.host = brigeUrl.host;
+        proxyUrl.protocol = bridgeUrl.protocol;
+        proxyUrl.host = bridgeUrl.host;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -133,12 +133,12 @@ const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   if (isRelativeOrProxyUrl(url)) return url;
 
   const proxyUrl = new URL(url);
-  const brigeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
+  const bridgeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
   const isHttps = proxyUrl.protocol === 'https:';
   const originalHost = encodeURIComponent(proxyUrl.host);
   const originalPathname = proxyUrl.pathname;
-  proxyUrl.protocol = brigeUrl.protocol;
-  proxyUrl.host = brigeUrl.host;
+  proxyUrl.protocol = bridgeUrl.protocol;
+  proxyUrl.host = bridgeUrl.host;
   proxyUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
   }/${originalHost}${originalPathname}`;

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -132,12 +132,13 @@ const isRelativeOrProxyUrl = (url: string | undefined): boolean =>
 const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   if (isRelativeOrProxyUrl(url)) return url;
 
-  let proxyUrl = new URL(url);
+  const proxyUrl = new URL(url);
+  const brigeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
   const isHttps = proxyUrl.protocol === 'https:';
   const originalHost = encodeURIComponent(proxyUrl.host);
   const originalPathname = proxyUrl.pathname;
-  proxyUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
-
+  proxyUrl.protocol = brigeUrl.protocol;
+  proxyUrl.host = brigeUrl.host;
   proxyUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
   }/${originalHost}${originalPathname}`;

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -143,10 +143,12 @@ var nativeBridge = (function (exports) {
         if (isRelativeOrProxyUrl(url))
             return url;
         let proxyUrl = new URL(url);
+        const brigeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
-        proxyUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        proxyUrl.protocol = brigeUrl.protocol;
+        proxyUrl.host = brigeUrl.host;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -142,13 +142,13 @@ var nativeBridge = (function (exports) {
         var _a, _b;
         if (isRelativeOrProxyUrl(url))
             return url;
-        let proxyUrl = new URL(url);
-        const brigeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        const proxyUrl = new URL(url);
+        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
-        proxyUrl.protocol = brigeUrl.protocol;
-        proxyUrl.host = brigeUrl.host;
+        proxyUrl.protocol = bridgeUrl.protocol;
+        proxyUrl.host = bridgeUrl.host;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };


### PR DESCRIPTION
Instead of creating the proxy url from the bridge url, keep the original url and replace the protocol and host, so other params from the original url such as search or hash don't go missing

closes https://github.com/ionic-team/capacitor/issues/7319