### PR TITLE
chore(ci): Re enable pod validation failures

### DIFF
--- a/ios/package.json
+++ b/ios/package.json
@@ -20,7 +20,7 @@
     "scripts/pods_helpers.rb"
   ],
   "scripts": {
-    "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova && pod lib lint --allow-warnings Capacitor.podspec && pod lib lint --allow-warnings CapacitorCordova.podspec",
+    "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova",
     "xc:build:Capacitor": "cd Capacitor && xcodebuild -workspace Capacitor.xcworkspace -scheme Capacitor && cd ..",
     "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd ..",
     "xc:build:xcframework": "scripts/build.sh xcframework"

--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env sh
-set -eo pipefail
-
-export NATIVE_PUBLISH=true
+-set -eo pipefail
 
 case $1 in
      lint) 
@@ -9,6 +7,7 @@ case $1 in
        pod lib lint ios/Capacitor.podspec --allow-warnings;;
 
      publish) 
+       export NATIVE_PUBLISH=true
        pod trunk push ios/CapacitorCordova.podspec --allow-warnings
        pod trunk push ios/Capacitor.podspec --allow-warnings;;
 

--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -5,8 +5,8 @@ export NATIVE_PUBLISH=true
 
 case $1 in
      lint) 
-       pod spec lint ios/CapacitorCordova.podspec --allow-warnings
-       pod spec lint ios/Capacitor.podspec --allow-warnings;;
+       pod lib lint ios/CapacitorCordova.podspec --allow-warnings
+       pod lib lint ios/Capacitor.podspec --allow-warnings;;
 
      publish) 
        pod trunk push ios/CapacitorCordova.podspec --allow-warnings

--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -eo pipefail
 
 export NATIVE_PUBLISH=true
 


### PR DESCRIPTION
We are doing pod spec lint on pull requests, but the errors got disabled at some point, probably because we were doing `pod spec lint` (published changes) while we should be doing `pod lib lint` (local changes) and that made some change fail.

And since we disabled the errors I added the `pod lib lint` in the verify script as some errors went through.

This PR reenables the errors and uses `pod lib lint` instead of `pod spec lint` and removes the `pod lib lint` from the verify script since we already run it in the `native-podspec.sh` script.