### PR TITLE
chore(ci): run lib lint for podspec verification

### DIFF
--- a/scripts/native-podspec.sh
+++ b/scripts/native-podspec.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env sh
 set -eo pipefail
 
-export NATIVE_PUBLISH=true
-
 case $1 in
      lint) 
-       pod spec lint ios/CapacitorCordova.podspec --allow-warnings
-       pod spec lint ios/Capacitor.podspec --allow-warnings;;
+       pod lib lint ios/CapacitorCordova.podspec --allow-warnings
+       pod lib lint ios/Capacitor.podspec --allow-warnings;;
 
      publish) 
+       export NATIVE_PUBLISH=true
        pod trunk push ios/CapacitorCordova.podspec --allow-warnings
        pod trunk push ios/Capacitor.podspec --allow-warnings;;
 


### PR DESCRIPTION
run `pod lib lint` instead of `pod spec lint` for local podspec verification