### PR TITLE
fix(ios): overwrite CORS headers on livereload

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -172,7 +172,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
                     ]
                 }
 
-                if let mergedHeaders = existingHeaders.merging(newHeaders, uniquingKeysWith: { (_ , newHeaders) in newHeaders }) as? [String: String] {
+                if let mergedHeaders = existingHeaders.merging(newHeaders, uniquingKeysWith: { (_, newHeaders) in newHeaders }) as? [String: String] {
 
                     if let responseUrl = response.url {
                         if let modifiedResponse = HTTPURLResponse(

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -172,7 +172,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
                     ]
                 }
 
-                if let mergedHeaders = existingHeaders.merging(newHeaders, uniquingKeysWith: { (current, _) in current }) as? [String: String] {
+                if let mergedHeaders = existingHeaders.merging(newHeaders, uniquingKeysWith: { (_ , newHeaders) in newHeaders }) as? [String: String] {
 
                     if let responseUrl = response.url {
                         if let modifiedResponse = HTTPURLResponse(


### PR DESCRIPTION
If the proxied request already had CORS headers, we are using the original headers when using live reload, which doesn't work since the request goes from the live reload server to the `capacitor://` scheme.
So this PR forces the CORS headers we add for live reload instead of the original ones.

closes https://github.com/ionic-team/capacitor/issues/7334