### PR TITLE
fix(http): set port for proxy url

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -148,7 +148,8 @@ var nativeBridge = (function (exports) {
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
         proxyUrl.protocol = bridgeUrl.protocol;
-        proxyUrl.host = bridgeUrl.host;
+        proxyUrl.hostname = bridgeUrl.hostname;
+        proxyUrl.port = bridgeUrl.port;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -138,7 +138,8 @@ const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   const originalHost = encodeURIComponent(proxyUrl.host);
   const originalPathname = proxyUrl.pathname;
   proxyUrl.protocol = bridgeUrl.protocol;
-  proxyUrl.host = bridgeUrl.host;
+  proxyUrl.hostname = bridgeUrl.hostname;
+  proxyUrl.port = bridgeUrl.port;
   proxyUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
   }/${originalHost}${originalPathname}`;

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -148,7 +148,8 @@ var nativeBridge = (function (exports) {
         const originalHost = encodeURIComponent(proxyUrl.host);
         const originalPathname = proxyUrl.pathname;
         proxyUrl.protocol = bridgeUrl.protocol;
-        proxyUrl.host = bridgeUrl.host;
+        proxyUrl.hostname = bridgeUrl.hostname;
+        proxyUrl.port = bridgeUrl.port;
         proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
         return proxyUrl.toString();
     };


### PR DESCRIPTION
Despite `host` includes both `hostname` and `port`, setting the `host` to an url without `port` doesn't remove the existing `port` if there is one, turning the proxy url into an invalid one.
So set the `hostname` and `port` separately to match the capacitor bridge url `hostname`/`port`