### PR TITLE
fix(http): Make proxy work with Request objects

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -500,9 +500,13 @@ var nativeBridge = (function (exports) {
                             options.method.toLocaleUpperCase() === 'HEAD' ||
                             options.method.toLocaleUpperCase() === 'OPTIONS' ||
                             options.method.toLocaleUpperCase() === 'TRACE') {
-                            const modifiedResource = createProxyUrl(resource.toString(), win);
-                            const response = await win.CapacitorWebFetch(modifiedResource, options);
-                            return response;
+                            if (typeof resource === 'string') {
+                                return await win.CapacitorWebFetch(createProxyUrl(resource, win), options);
+                            }
+                            else if (resource instanceof Request) {
+                                const modifiedRequest = new Request(createProxyUrl(resource.url, win), resource);
+                                return await win.CapacitorWebFetch(modifiedRequest, options);
+                            }
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -554,13 +554,18 @@ const initBridge = (w: any): void => {
             options.method.toLocaleUpperCase() === 'OPTIONS' ||
             options.method.toLocaleUpperCase() === 'TRACE'
           ) {
-            const modifiedResource = createProxyUrl(resource.toString(), win);
-            const response = await win.CapacitorWebFetch(
-              modifiedResource,
-              options,
-            );
-
-            return response;
+            if (typeof resource === 'string') {
+              return await win.CapacitorWebFetch(
+                createProxyUrl(resource, win),
+                options,
+              );
+            } else if (resource instanceof Request) {
+              const modifiedRequest = new Request(
+                createProxyUrl(resource.url, win),
+                resource,
+              );
+              return await win.CapacitorWebFetch(modifiedRequest, options);
+            }
           }
 
           const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -500,9 +500,13 @@ var nativeBridge = (function (exports) {
                             options.method.toLocaleUpperCase() === 'HEAD' ||
                             options.method.toLocaleUpperCase() === 'OPTIONS' ||
                             options.method.toLocaleUpperCase() === 'TRACE') {
-                            const modifiedResource = createProxyUrl(resource.toString(), win);
-                            const response = await win.CapacitorWebFetch(modifiedResource, options);
-                            return response;
+                            if (typeof resource === 'string') {
+                                return await win.CapacitorWebFetch(createProxyUrl(resource, win), options);
+                            }
+                            else if (resource instanceof Request) {
+                                const modifiedRequest = new Request(createProxyUrl(resource.url, win), resource);
+                                return await win.CapacitorWebFetch(modifiedRequest, options);
+                            }
                         }
                         const tag = `CapacitorHttp fetch ${Date.now()} ${resource}`;
                         console.time(tag);


### PR DESCRIPTION
At the moment trying to create a proxy url from a Request object ends up with a `[object Object]` as path.

This PR detects if the first param is a Request object and creates a new Request with the proxied url