### PR TITLE
docs(core): Add missing information to http/cookies files

### DIFF
--- a/core/cookies.md
+++ b/core/cookies.md
@@ -131,6 +131,8 @@ getCookies(options?: GetCookieOptions) => Promise<HttpCookieMap>
 setCookie(options: SetCookieOptions) => Promise<void>
 ```
 
+Write a cookie to the device.
+
 | Param         | Type                                                          |
 | ------------- | ------------------------------------------------------------- |
 | **`options`** | <code><a href="#setcookieoptions">SetCookieOptions</a></code> |
@@ -143,6 +145,8 @@ setCookie(options: SetCookieOptions) => Promise<void>
 ```typescript
 deleteCookie(options: DeleteCookieOptions) => Promise<void>
 ```
+
+Delete a cookie from the device.
 
 | Param         | Type                                                                |
 | ------------- | ------------------------------------------------------------------- |
@@ -157,6 +161,8 @@ deleteCookie(options: DeleteCookieOptions) => Promise<void>
 clearCookies(options: ClearCookieOptions) => Promise<void>
 ```
 
+Clear cookies from the device at a given URL.
+
 | Param         | Type                                                              |
 | ------------- | ----------------------------------------------------------------- |
 | **`options`** | <code><a href="#clearcookieoptions">ClearCookieOptions</a></code> |
@@ -170,6 +176,8 @@ clearCookies(options: ClearCookieOptions) => Promise<void>
 clearAllCookies() => Promise<void>
 ```
 
+Clear all cookies on the device.
+
 --------------------
 
 
@@ -181,19 +189,19 @@ clearAllCookies() => Promise<void>
 
 #### HttpCookie
 
-| Prop        | Type                |
-| ----------- | ------------------- |
-| **`url`**   | <code>string</code> |
-| **`key`**   | <code>string</code> |
-| **`value`** | <code>string</code> |
+| Prop        | Type                | Description              |
+| ----------- | ------------------- | ------------------------ |
+| **`url`**   | <code>string</code> | The URL of the cookie.   |
+| **`key`**   | <code>string</code> | The key of the cookie.   |
+| **`value`** | <code>string</code> | The value of the cookie. |
 
 
 #### HttpCookieExtras
 
-| Prop          | Type                |
-| ------------- | ------------------- |
-| **`path`**    | <code>string</code> |
-| **`expires`** | <code>string</code> |
+| Prop          | Type                | Description                      |
+| ------------- | ------------------- | -------------------------------- |
+| **`path`**    | <code>string</code> | The path to write the cookie to. |
+| **`expires`** | <code>string</code> | The date to expire the cookie.   |
 
 
 ### Type Aliases

--- a/core/http.md
+++ b/core/http.md
@@ -106,6 +106,8 @@ Due to the nature of the bridge, parsing and transferring large amount of data f
 request(options: HttpOptions) => Promise<HttpResponse>
 ```
 
+Make a Http Request to a server using native libraries.
+
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
 | **`options`** | <code><a href="#httpoptions">HttpOptions</a></code> |
@@ -120,6 +122,8 @@ request(options: HttpOptions) => Promise<HttpResponse>
 ```typescript
 get(options: HttpOptions) => Promise<HttpResponse>
 ```
+
+Make a Http GET Request to a server using native libraries.
 
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
@@ -136,6 +140,8 @@ get(options: HttpOptions) => Promise<HttpResponse>
 post(options: HttpOptions) => Promise<HttpResponse>
 ```
 
+Make a Http POST Request to a server using native libraries.
+
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
 | **`options`** | <code><a href="#httpoptions">HttpOptions</a></code> |
@@ -150,6 +156,8 @@ post(options: HttpOptions) => Promise<HttpResponse>
 ```typescript
 put(options: HttpOptions) => Promise<HttpResponse>
 ```
+
+Make a Http PUT Request to a server using native libraries.
 
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
@@ -166,6 +174,8 @@ put(options: HttpOptions) => Promise<HttpResponse>
 patch(options: HttpOptions) => Promise<HttpResponse>
 ```
 
+Make a Http PATCH Request to a server using native libraries.
+
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
 | **`options`** | <code><a href="#httpoptions">HttpOptions</a></code> |
@@ -181,6 +191,8 @@ patch(options: HttpOptions) => Promise<HttpResponse>
 delete(options: HttpOptions) => Promise<HttpResponse>
 ```
 
+Make a Http DELETE Request to a server using native libraries.
+
 | Param         | Type                                                |
 | ------------- | --------------------------------------------------- |
 | **`options`** | <code><a href="#httpoptions">HttpOptions</a></code> |
@@ -195,12 +207,12 @@ delete(options: HttpOptions) => Promise<HttpResponse>
 
 #### HttpResponse
 
-| Prop          | Type                                                |
-| ------------- | --------------------------------------------------- |
-| **`data`**    | <code>any</code>                                    |
-| **`status`**  | <code>number</code>                                 |
-| **`headers`** | <code><a href="#httpheaders">HttpHeaders</a></code> |
-| **`url`**     | <code>string</code>                                 |
+| Prop          | Type                                                | Description                                       |
+| ------------- | --------------------------------------------------- | ------------------------------------------------- |
+| **`data`**    | <code>any</code>                                    | Additional data received with the Http response.  |
+| **`status`**  | <code>number</code>                                 | The status code received from the Http response.  |
+| **`headers`** | <code><a href="#httpheaders">HttpHeaders</a></code> | The headers received from the Http response.      |
+| **`url`**     | <code>string</code>                                 | The response URL recieved from the Http response. |
 
 
 #### HttpHeaders
@@ -210,11 +222,11 @@ delete(options: HttpOptions) => Promise<HttpResponse>
 
 | Prop                        | Type                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`url`**                   | <code>string</code>                                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| **`method`**                | <code>string</code>                                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| **`params`**                | <code><a href="#httpparams">HttpParams</a></code>             |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **`url`**                   | <code>string</code>                                           | The URL to send the request to.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **`method`**                | <code>string</code>                                           | The Http Request method to run. (Default is GET)                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **`params`**                | <code><a href="#httpparams">HttpParams</a></code>             | URL parameters to append to the request.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | **`data`**                  | <code>any</code>                                              | Note: On Android and iOS, data can only be a string or a JSON. FormData, <a href="#blob">Blob</a>, <a href="#arraybuffer">ArrayBuffer</a>, and other complex types are only directly supported on web or through enabling `CapacitorHttp` in the config and using the patched `window.fetch` or `XMLHttpRequest`. If you need to send a complex type, you should serialize the data to base64 and set the `headers["Content-Type"]` and `dataType` attributes accordingly. |
-| **`headers`**               | <code><a href="#httpheaders">HttpHeaders</a></code>           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **`headers`**               | <code><a href="#httpheaders">HttpHeaders</a></code>           | Http Request headers to send with the request.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | **`readTimeout`**           | <code>number</code>                                           | How long to wait to read additional data in milliseconds. Resets each time new data is received.                                                                                                                                                                                                                                                                                                                                                                           |
 | **`connectTimeout`**        | <code>number</code>                                           | How long to wait for the initial connection in milliseconds.                                                                                                                                                                                                                                                                                                                                                                                                               |
 | **`disableRedirects`**      | <code>boolean</code>                                          | Sets whether automatic HTTP redirects should be disabled                                                                                                                                                                                                                                                                                                                                                                                                                   |
@@ -644,9 +656,7 @@ This Fetch API interface allows you to perform various actions on HTTP request a
 
 Construct a type with a set of properties K of type T
 
-<code>{
- [P in K]: T;
- }</code>
+<code>{ [P in K]: T; }</code>
 
 
 #### RequestMode
@@ -665,6 +675,8 @@ Construct a type with a set of properties K of type T
 
 
 #### HttpResponseType
+
+How to parse the Http response before returning it to the client.
 
 <code>'arraybuffer' | 'blob' | 'json' | 'text' | 'document'</code>
 

--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -36,15 +36,36 @@ const decode = (str: string): string =>
 
 export interface CapacitorCookiesPlugin {
   getCookies(options?: GetCookieOptions): Promise<HttpCookieMap>;
+  /**
+   * Write a cookie to the device.
+   */
   setCookie(options: SetCookieOptions): Promise<void>;
+  /**
+   * Delete a cookie from the device.
+   */
   deleteCookie(options: DeleteCookieOptions): Promise<void>;
+  /**
+   * Clear cookies from the device at a given URL.
+   */
   clearCookies(options: ClearCookieOptions): Promise<void>;
+  /**
+   * Clear all cookies on the device.
+   */
   clearAllCookies(): Promise<void>;
 }
 
 interface HttpCookie {
+  /**
+   * The URL of the cookie.
+   */
   url?: string;
+  /**
+   * The key of the cookie.
+   */
   key: string;
+  /**
+   * The value of the cookie.
+   */
   value: string;
 }
 
@@ -53,7 +74,13 @@ interface HttpCookieMap {
 }
 
 interface HttpCookieExtras {
+  /**
+   * The path to write the cookie to.
+   */
   path?: string;
+  /**
+   * The date to expire the cookie.
+   */
   expires?: string;
 }
 
@@ -147,14 +174,35 @@ export const CapacitorCookies = registerPlugin<CapacitorCookiesPlugin>(
 
 /******** HTTP PLUGIN ********/
 export interface CapacitorHttpPlugin {
+  /**
+   * Make a Http Request to a server using native libraries.
+   */
   request(options: HttpOptions): Promise<HttpResponse>;
+  /**
+   * Make a Http GET Request to a server using native libraries.
+   */
   get(options: HttpOptions): Promise<HttpResponse>;
+  /**
+   * Make a Http POST Request to a server using native libraries.
+   */
   post(options: HttpOptions): Promise<HttpResponse>;
+  /**
+   * Make a Http PUT Request to a server using native libraries.
+   */
   put(options: HttpOptions): Promise<HttpResponse>;
+  /**
+   * Make a Http PATCH Request to a server using native libraries.
+   */
   patch(options: HttpOptions): Promise<HttpResponse>;
+  /**
+   * Make a Http DELETE Request to a server using native libraries.
+   */
   delete(options: HttpOptions): Promise<HttpResponse>;
 }
 
+/**
+ * How to parse the Http response before returning it to the client.
+ */
 export type HttpResponseType =
   | 'arraybuffer'
   | 'blob'
@@ -163,8 +211,17 @@ export type HttpResponseType =
   | 'document';
 
 export interface HttpOptions {
+  /**
+   * The URL to send the request to.
+   */
   url: string;
+  /**
+   * The Http Request method to run. (Default is GET)
+   */
   method?: string;
+  /**
+   * URL parameters to append to the request.
+   */
   params?: HttpParams;
   /**
    * Note: On Android and iOS, data can only be a string or a JSON.
@@ -175,6 +232,9 @@ export interface HttpOptions {
    * and set the `headers["Content-Type"]` and `dataType` attributes accordingly.
    */
   data?: any;
+  /**
+   * Http Request headers to send with the request.
+   */
   headers?: HttpHeaders;
   /**
    * How long to wait to read additional data in milliseconds.
@@ -211,17 +271,35 @@ export interface HttpOptions {
 }
 
 export interface HttpParams {
+  /**
+   * A key/value dictionary of URL parameters to set.
+   */
   [key: string]: string | string[];
 }
 
 export interface HttpHeaders {
+  /**
+   * A key/value dictionary of Http headers.
+   */
   [key: string]: string;
 }
 
 export interface HttpResponse {
+  /**
+   * Additional data received with the Http response.
+   */
   data: any;
+  /**
+   * The status code received from the Http response.
+   */
   status: number;
+  /**
+   * The headers received from the Http response.
+   */
   headers: HttpHeaders;
+  /**
+   * The response URL recieved from the Http response.
+   */
   url: string;
 }
 


### PR DESCRIPTION
https://github.com/ionic-team/capacitor-docs/blob/main/docs/apis/cookies.md and https://github.com/ionic-team/capacitor-docs/blob/main/docs/apis/http.md files have more information than the ones generated in core.

Add the missing information to core-plugins.ts and generate the files again