### PR TITLE
fix(http): change proxy url generation

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -141,13 +141,10 @@ var nativeBridge = (function (exports) {
         const proxyUrl = new URL(url);
         const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
-        const originalHost = encodeURIComponent(proxyUrl.host);
-        const originalPathname = proxyUrl.pathname;
-        proxyUrl.protocol = bridgeUrl.protocol;
-        proxyUrl.hostname = bridgeUrl.hostname;
-        proxyUrl.port = bridgeUrl.port;
-        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
-        return proxyUrl.toString();
+        bridgeUrl.search = proxyUrl.search;
+        bridgeUrl.hash = proxyUrl.hash;
+        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+        return bridgeUrl.toString();
     };
     const initBridge = (w) => {
         const getPlatformId = (win) => {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -131,15 +131,12 @@ const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   const proxyUrl = new URL(url);
   const bridgeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
   const isHttps = proxyUrl.protocol === 'https:';
-  const originalHost = encodeURIComponent(proxyUrl.host);
-  const originalPathname = proxyUrl.pathname;
-  proxyUrl.protocol = bridgeUrl.protocol;
-  proxyUrl.hostname = bridgeUrl.hostname;
-  proxyUrl.port = bridgeUrl.port;
-  proxyUrl.pathname = `${
+  bridgeUrl.search = proxyUrl.search;
+  bridgeUrl.hash = proxyUrl.hash;
+  bridgeUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
-  }/${originalHost}${originalPathname}`;
-  return proxyUrl.toString();
+  }/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+  return bridgeUrl.toString();
 };
 
 const initBridge = (w: any): void => {

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -141,13 +141,10 @@ var nativeBridge = (function (exports) {
         const proxyUrl = new URL(url);
         const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
-        const originalHost = encodeURIComponent(proxyUrl.host);
-        const originalPathname = proxyUrl.pathname;
-        proxyUrl.protocol = bridgeUrl.protocol;
-        proxyUrl.hostname = bridgeUrl.hostname;
-        proxyUrl.port = bridgeUrl.port;
-        proxyUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${originalHost}${originalPathname}`;
-        return proxyUrl.toString();
+        bridgeUrl.search = proxyUrl.search;
+        bridgeUrl.hash = proxyUrl.hash;
+        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+        return bridgeUrl.toString();
     };
     const initBridge = (w) => {
         const getPlatformId = (win) => {


### PR DESCRIPTION
On iOS >= 17.2, the `proxyUrl.protocol = bridgeUrl.protocol;` is not changing the protocol of the proxy url.
Change the `proxyUrl` generation to return the `bridgeUrl`, which already has the `capacitor` protocol and add the other relevant `proxyUrl` parameters and modified `pathname`.

closes https://github.com/ionic-team/capacitor/issues/7352