### PR TITLE
fix(cli): also generate packageClassList on copy

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -31,11 +31,7 @@ import {
 import type { Plugin } from '../plugin';
 import { copy as copyTask } from '../tasks/copy';
 import { convertToUnixPath } from '../util/fs';
-import {
-  getPluginFiles,
-  findPluginClasses,
-  writePluginJSON,
-} from '../util/iosplugin';
+import { generateIOSPackageJSON } from '../util/iosplugin';
 import { resolveNode } from '../util/node';
 import { checkPackageManager, generatePackageFile } from '../util/spm';
 import { runCommand, isInstalled } from '../util/subprocess';
@@ -178,15 +174,6 @@ end`,
       'Unable to find "xcodebuild". Skipping xcodebuild clean step...',
     );
   }
-}
-
-async function generateIOSPackageJSON(
-  config: Config,
-  plugins: Plugin[],
-): Promise<void> {
-  const fileList = await getPluginFiles(plugins);
-  const classList = await findPluginClasses(fileList);
-  writePluginJSON(config, classList);
 }
 
 async function getRelativeCapacitoriOSPath(config: Config) {

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -17,8 +17,10 @@ import {
 } from '../cordova';
 import type { Config } from '../definitions';
 import { isFatal } from '../errors';
+import { getIOSPlugins } from '../ios/common';
 import { logger } from '../log';
 import { getPlugins } from '../plugin';
+import { generateIOSPackageJSON } from '../util/iosplugin';
 import { allSerial } from '../util/promise';
 import { copyWeb } from '../web/copy';
 
@@ -135,6 +137,8 @@ export async function copy(
       await copyCapacitorConfig(config, config.ios.nativeTargetDirAbs);
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
       await handleCordovaPluginsJS(cordovaPlugins, config, platformName);
+      const iosPlugins = await getIOSPlugins(allPlugins);
+      await generateIOSPackageJSON(config, iosPlugins);
     } else if (platformName === config.android.name) {
       if (usesFederatedCapacitor) {
         await copyFederatedWebDirs(config, config.android.webDirAbs);

--- a/cli/src/util/iosplugin.ts
+++ b/cli/src/util/iosplugin.ts
@@ -68,3 +68,12 @@ export async function writePluginJSON(
   capJSON['packageClassList'] = classList;
   writeJSONSync(capJSONFile, capJSON, { spaces: '\t' });
 }
+
+export async function generateIOSPackageJSON(
+  config: Config,
+  plugins: Plugin[],
+): Promise<void> {
+  const fileList = await getPluginFiles(plugins);
+  const classList = await findPluginClasses(fileList);
+  writePluginJSON(config, classList);
+}


### PR DESCRIPTION
`npx cap update` generates the `packageClassList`, but `npx cap copy` does not, which cause the plugins to not work after running `npx cap copy` since they don't get registered.

This PR also runs the `generateIOSPackageJSON` function on copy so the `packageClassList` is always present.