### PR TITLE
fix: inject cordova files if a cordova plugin is present

### DIFF
--- a/cli/src/util/iosplugin.ts
+++ b/cli/src/util/iosplugin.ts
@@ -7,6 +7,7 @@ import {
 } from '@ionic/utils-fs';
 import { resolve } from 'path';
 
+import { getCordovaPlugins } from '../cordova';
 import type { Config } from '../definitions';
 import type { Plugin } from '../plugin';
 
@@ -75,5 +76,9 @@ export async function generateIOSPackageJSON(
 ): Promise<void> {
   const fileList = await getPluginFiles(plugins);
   const classList = await findPluginClasses(fileList);
+  const cordovaPlugins = await getCordovaPlugins(config, 'ios');
+  if (cordovaPlugins.length > 0) {
+    classList.push('CDVPlugin');
+  }
   writePluginJSON(config, classList);
 }

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -293,10 +293,11 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
                     for plugin in registrationList.packageClassList {
                         if let pluginClass = NSClassFromString(plugin) {
-                            if class_getSuperclass(pluginClass) == CDVPlugin.self {
+                            if pluginClass == CDVPlugin.self {
                                 injectCordovaFiles = true
+                            } else {
+                                pluginList.append(pluginClass)
                             }
-                            pluginList.append(pluginClass)
                         }
                     }
                 }


### PR DESCRIPTION
The Cordova plugins javascript injection is not working because the plugins are now being read from the list that the CLI generates, and the CLI doesn't generate Cordova plugin classes.

Since trying to figure out all the Cordova plugin classes is very complex and the classes are not really needed for injecting the javascript code, I've just edited the CLI to add a generic `CDVPlugin` class to the plugin list if there are cordova plugins installed, and instead of checking the superClass I just check if there is a `CDVPlugin` class in the list, and if there is one, inject the cordova files.