### PR TITLE
fix(cli): use correct pass signature for apksigner signing

### DIFF
--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -111,7 +111,7 @@ async function signWithApkSigner(
   }
 
   if (buildOptions.keystorealiaspass) {
-    signingArgs.push('--key-pass', buildOptions.keystorealiaspass);
+    signingArgs.push('--key-pass', `pass:${buildOptions.keystorealiaspass}`);
   }
 
   await runTask('Signing Release', async () => {


### PR DESCRIPTION
Passwords for apksigner require `pass:` signature before the actual password.
The initial commit on https://github.com/ionic-team/capacitor/pull/7073 had it like that, but when changes were requested the `pass:` part got deleted inadvertently.


closes https://github.com/ionic-team/capacitor/issues/7299