### PR TITLE
feat(ios): CAPPluginMethod selector-based initializer

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		A38C3D7B2848BE6F004B3680 /* CapacitorCookieManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38C3D7A2848BE6F004B3680 /* CapacitorCookieManager.swift */; };
 		A71289E627F380A500DADDF3 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71289E527F380A500DADDF3 /* Router.swift */; };
 		A71289EB27F380FD00DADDF3 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71289EA27F380FD00DADDF3 /* RouterTests.swift */; };
+		A7187FD22BD1CB7D00093C45 /* CAPPluginMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */; };
 		A76739792B98E09700795F7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */; };
 		A7BE62CC2B486A5400165ACB /* KeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */; };
 		A7D8B3522B238A840003FAD6 /* JSValueEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */; };
@@ -241,6 +242,7 @@
 		A38C3D7A2848BE6F004B3680 /* CapacitorCookieManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapacitorCookieManager.swift; sourceTree = "<group>"; };
 		A71289E527F380A500DADDF3 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		A71289EA27F380FD00DADDF3 /* RouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
+		A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAPPluginMethod.swift; sourceTree = "<group>"; };
 		A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStore.swift; sourceTree = "<group>"; };
 		A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueEncoder.swift; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 				A7DB03AB29B001E300888AE9 /* CAPBridgedPlugin+getMethod.swift */,
 				62959B092524DA7700A3D7F1 /* CAPPluginMethod.h */,
 				62959AE82524DA7700A3D7F1 /* CAPPluginMethod.m */,
+				A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */,
 				62959AE22524DA7700A3D7F1 /* CAPPluginCall.h */,
 				62959B062524DA7700A3D7F1 /* CAPPluginCall.m */,
 				62959AE62524DA7700A3D7F1 /* CAPPluginCall.swift */,
@@ -700,6 +703,7 @@
 				62D43AF02581817500673C24 /* WKWebView+Capacitor.swift in Sources */,
 				62959B432524DA7800A3D7F1 /* Data+Capacitor.swift in Sources */,
 				62E207AE2588234500A78983 /* WebViewDelegationHandler.swift in Sources */,
+				A7187FD22BD1CB7D00093C45 /* CAPPluginMethod.swift in Sources */,
 				621ECCBC2542046400D3D615 /* JSTypes.swift in Sources */,
 				621ECCDA254205C400D3D615 /* CapacitorBridge.swift in Sources */,
 				62959B382524DA7800A3D7F1 /* CAPPluginCall.m in Sources */,

--- a/ios/Capacitor/Capacitor/CAPPluginMethod.h
+++ b/ios/Capacitor/Capacitor/CAPPluginMethod.h
@@ -31,6 +31,6 @@ typedef NSString CAPPluginReturnType;
 @property (nonatomic, strong) CAPPluginReturnType *returnType; // Return type of method (i.e. callback/promise/sync)
 
 - (instancetype)initWithName:(NSString *)name returnType:(CAPPluginReturnType *)returnType;
-
+- (instancetype)initWithSelector:(SEL)selector returnType:(CAPPluginReturnType *)returnType;
 
 @end

--- a/ios/Capacitor/Capacitor/CAPPluginMethod.m
+++ b/ios/Capacitor/Capacitor/CAPPluginMethod.m
@@ -31,6 +31,14 @@ typedef void(^CAPCallback)(id _arg, NSInteger index);
   return self;
 }
 
+-(instancetype)initWithSelector:(SEL) selector returnType:(CAPPluginReturnType *)returnType {
+    // need to drop the : from the selector string
+    NSString* rawSelString = NSStringFromSelector(selector);
+    self.name = [rawSelString substringToIndex:[rawSelString length] - 1];
+    self.selector = selector;
+    self.returnType = returnType;
+    return self;
+}
 
 @end
 

--- a/ios/Capacitor/Capacitor/CAPPluginMethod.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginMethod.swift
@@ -8,7 +8,7 @@
 
 extension CAPPluginMethod {
     public enum ReturnType: String {
-        case promise, callback
+        case promise, callback, none
     }
 
     public convenience init(_ selector: Selector, returnType: ReturnType = .promise) {

--- a/ios/Capacitor/Capacitor/CAPPluginMethod.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginMethod.swift
@@ -1,0 +1,17 @@
+//
+//  CAPPluginMethod.swift
+//  Capacitor
+//
+//  Created by Steven Sherry on 4/18/24.
+//  Copyright © 2024 Drifty Co. All rights reserved.
+//
+
+extension CAPPluginMethod {
+    public enum ReturnType: String {
+        case promise, callback
+    }
+
+    public convenience init(_ selector: Selector, returnType: ReturnType = .promise) {
+        self.init(selector: selector, returnType: returnType.rawValue)
+    }
+}


### PR DESCRIPTION
Add secondary initializer for CAPPluginMethod that takes a selector. Creates a convenience initializer as well with a Swift enum to avoid having to rely on global string values in the style of CAPPluginReturnPromise. For a pure Swift plugin implementation, it makes the definition potentially go from:
```swift
class MyPlugin: CAPPlugin, CAPBridgedPlugin {
  let pluginMethods: [CAPPluginMethod] = [
    .init(name: "promiseMethod", returnType: CAPPluginReturnPromise),
    .init(name: "callbackMethod", returnType: CAPPluginReturnCallback)
  ]

  @objc func promiseMethod(_ call: CAPPluginCall) {}
  @objc func callbackMethod(_ call: CAPPluginCall) {}
}
```

to this:
```swift
class MyPlugin: CAPPlugin, CAPBridgedPlugin {
  let pluginMethods: [CAPPluginMethod] = [
    .init(#selector(promiseMethod)),
    .init(#selector(callbackMethod), returnType: .callback)
  ]

  @objc func promiseMethod(_ call: CAPPluginCall) {}
  @objc func callbackMethod(_ call: CAPPluginCall) {}
}
```

A benefit of this approach include removing the need to stringify the name of the function. This will also validate the selector at compile time, so if it has not been annotated with `@objc` it will be a compiler error.