### PR TITLE
Update CAPApplicationDelegateProxy.swift to prevent warning in Xcode

### DIFF
--- a/ios/Capacitor/Capacitor/CAPApplicationDelegateProxy.swift
+++ b/ios/Capacitor/Capacitor/CAPApplicationDelegateProxy.swift
@@ -10,7 +10,7 @@ public class ApplicationDelegateProxy: NSObject, UIApplicationDelegate {
         NotificationCenter.default.post(name: .capacitorOpenURL, object: [
             "url": url,
             "options": options
-        ])
+        ] as [String : Any])
         NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: url)
         lastURL = url
         return true


### PR DESCRIPTION
Xcode complains with a warning for this line, this removes the warning