### PR TITLE
fix(android): avoid crash if server url ends in /

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -257,7 +257,11 @@ public class Bridge {
             String allowedOrigin = appUrl;
             Uri appUri = Uri.parse(appUrl);
             if (appUri.getPath() != null) {
-                allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
+                if (appUri.getPath().equals("/")) {
+                    allowedOrigin = appUrl.substring(0, appUrl.length() - 1);
+                } else {
+                    allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
+                }
             }
             WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
             injector = null;


### PR DESCRIPTION
If the server url ends in `/` the app crash because the path replacement messes with the other `/` in the url.
Instead replace the last character from the url.

Closes https://github.com/ionic-team/capacitor/issues/7423
