### PR TITLE
Fix initial scale of webview to 100%

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -269,6 +269,9 @@ public class Bridge {
 
         webView.setWebChromeClient(new BridgeWebChromeClient(this));
         webView.setWebViewClient(this.webViewClient);
+        webView.getSettings().setBuiltInZoomControls(true);
+        webView.setInitialScale(100);
+        webView.setPadding(0, 0, 0, 0);
 
         if (!isDeployDisabled() && !isNewBinary()) {
             SharedPreferences prefs = getContext()


### PR DESCRIPTION
On Android building, the webview scale is not setting to 100% for 2x displays.
