### PR TITLE
 fix(cli): Don't downgrade variables on migrate

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -1,7 +1,7 @@
 import { writeFileSync, readFileSync, existsSync } from '@ionic/utils-fs';
 import { join } from 'path';
 import rimraf from 'rimraf';
-import { coerce, gt, gte } from 'semver';
+import { coerce, gt, gte, lt } from 'semver';
 
 import { getAndroidPlugins } from '../android/common';
 import c from '../colors';
@@ -276,35 +276,48 @@ export async function migrateCommand(
             for (const variable of Object.keys(
               variablesAndClasspaths.variables,
             )) {
+              let replaceStart = `${variable} = '`;
+              let replaceEnd = `'\n`;
               if (
-                !(await updateFile(
-                  config,
-                  variablesPath,
-                  `${variable} = '`,
-                  `'`,
-                  variablesAndClasspaths.variables[variable].toString(),
-                  true,
-                ))
+                typeof variablesAndClasspaths.variables[variable] === 'number'
               ) {
-                const didWork = await updateFile(
-                  config,
-                  variablesPath,
-                  `${variable} = `,
-                  `\n`,
-                  variablesAndClasspaths.variables[variable].toString(),
-                  true,
+                replaceStart = `${variable} = `;
+                replaceEnd = `\n`;
+              }
+
+              if (txt.includes(replaceStart)) {
+                const first = txt.indexOf(replaceStart) + replaceStart.length;
+                const value = txt.substring(
+                  first,
+                  txt.indexOf(replaceEnd, first),
                 );
-                if (!didWork) {
-                  let file = readFile(variablesPath);
-                  if (file) {
-                    file = file.replace(
-                      '}',
-                      `    ${variable} = '${variablesAndClasspaths.variables[
-                        variable
-                      ].toString()}'\n}`,
-                    );
-                    writeFileSync(variablesPath, file);
-                  }
+                if (
+                  (typeof variablesAndClasspaths.variables[variable] ===
+                    'number' &&
+                    value <= variablesAndClasspaths.variables[variable]) ||
+                  (typeof variablesAndClasspaths.variables[variable] ===
+                    'string' &&
+                    lt(value, variablesAndClasspaths.variables[variable]))
+                ) {
+                  await updateFile(
+                    config,
+                    variablesPath,
+                    replaceStart,
+                    replaceEnd,
+                    variablesAndClasspaths.variables[variable].toString(),
+                    true,
+                  );
+                }
+              } else {
+                let file = readFile(variablesPath);
+                if (file) {
+                  file = file.replace(
+                    '}',
+                    `    ${replaceStart}${variablesAndClasspaths.variables[
+                      variable
+                    ].toString()}${replaceEnd}}`,
+                  );
+                  writeFileSync(variablesPath, file);
                 }
               }
             }


### PR DESCRIPTION
Checking the new barcode plugin[ I noticed](https://github.com/ionic-team/capacitor-barcode-scanner/pull/9) that in the example app the `minSdkVersion` was downgraded from the required 26 to 22, so I checked if this was caused by migrate command, and it was, it changes any version in the `variables.gradle` to match the default Capacitor ones, even if that means downgrading it.

This PR checks the version and only update them if the value in `variables.gradle` is smaller.

