### PR TITLE
[Bug]: add serial dispatch queue for `storedCalls` to avoid data-race

### DIFF
--- a/ios/Capacitor/Capacitor/KeyValueStore.swift
+++ b/ios/Capacitor/Capacitor/KeyValueStore.swift
@@ -272,7 +272,7 @@ private class InMemoryStore: KeyValueStoreBackend {
     }
 }
 
-private class ConcurrentDictionary<Value> {
+class ConcurrentDictionary<Value> {
     private var storage: [String: Value]
     private let lock = NSLock()
 

--- a/ios/Capacitor/Capacitor/KeyValueStore.swift
+++ b/ios/Capacitor/Capacitor/KeyValueStore.swift
@@ -273,10 +273,11 @@ private class InMemoryStore: KeyValueStoreBackend {
 }
 
 class ConcurrentDictionary<Value> {
-    private var storage: [String: Value]
+    typealias StorageType = [String: Value]
+    private var storage: StorageType
     private let lock = NSLock()
 
-    init(_ initial: [String: Value] = [:]) {
+    init(_ initial: StorageType = [:]) {
         storage = initial
     }
 
@@ -291,6 +292,12 @@ class ConcurrentDictionary<Value> {
             lock.withLock {
                 storage[key] = newValue
             }
+        }
+    }
+
+    func withLock<T>(_ body: (_ storage: inout StorageType) -> T) -> T {
+        lock.withLock {
+            body(&storage)
         }
     }
 }


### PR DESCRIPTION
Accessing `storedCalls` from two different threads causes crash since `Dictionary` is not thread safe that introduces data-race. The serial queue prevents the access to the shared resource by two different threads by queuing the operation and invoking the functions one-by-one.

There is other option to avoid data-race using locks, and top of that, there are two types of locks that can be used here: `NSLock` and the other one is `OSAllocatedUnfairLock`, which is faster than the first one.