### PR TITLE
fix(http): don't override readyState for non POST requests

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -565,20 +565,7 @@ var nativeBridge = (function (exports) {
                                 value: xhr.method,
                                 writable: true,
                             },
-                            readyState: {
-                                get: function () {
-                                    var _a;
-                                    return (_a = this._readyState) !== null && _a !== void 0 ? _a : 0;
-                                },
-                                set: function (val) {
-                                    this._readyState = val;
-                                    setTimeout(() => {
-                                        this.dispatchEvent(new Event('readystatechange'));
-                                    });
-                                },
-                            },
                         });
-                        xhr.readyState = 0;
                         const prototype = win.CapacitorWebXMLHttpRequest.prototype;
                         const isProgressEventAvailable = () => typeof ProgressEvent !== 'undefined' &&
                             ProgressEvent.prototype instanceof Event;
@@ -608,6 +595,20 @@ var nativeBridge = (function (exports) {
                                 this._url = createProxyUrl(this._url, win);
                                 return win.CapacitorWebXMLHttpRequest.open.call(this, method, this._url);
                             }
+                            Object.defineProperties(this, {
+                                readyState: {
+                                    get: function () {
+                                        var _a;
+                                        return (_a = this._readyState) !== null && _a !== void 0 ? _a : 0;
+                                    },
+                                    set: function (val) {
+                                        this._readyState = val;
+                                        setTimeout(() => {
+                                            this.dispatchEvent(new Event('readystatechange'));
+                                        });
+                                    },
+                                },
+                            });
                             setTimeout(() => {
                                 this.dispatchEvent(new Event('loadstart'));
                             });

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -650,20 +650,7 @@ const initBridge = (w: any): void => {
               value: xhr.method,
               writable: true,
             },
-            readyState: {
-              get: function () {
-                return this._readyState ?? 0;
-              },
-              set: function (val: number) {
-                this._readyState = val;
-                setTimeout(() => {
-                  this.dispatchEvent(new Event('readystatechange'));
-                });
-              },
-            },
           });
-
-          xhr.readyState = 0;
           const prototype = win.CapacitorWebXMLHttpRequest.prototype;
 
           const isProgressEventAvailable = () =>
@@ -710,7 +697,19 @@ const initBridge = (w: any): void => {
                 this._url,
               );
             }
-
+            Object.defineProperties(this, {
+              readyState: {
+                get: function () {
+                  return this._readyState ?? 0;
+                },
+                set: function (val: number) {
+                  this._readyState = val;
+                  setTimeout(() => {
+                    this.dispatchEvent(new Event('readystatechange'));
+                  });
+                },
+              },
+            });
             setTimeout(() => {
               this.dispatchEvent(new Event('loadstart'));
             });

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -565,20 +565,7 @@ var nativeBridge = (function (exports) {
                                 value: xhr.method,
                                 writable: true,
                             },
-                            readyState: {
-                                get: function () {
-                                    var _a;
-                                    return (_a = this._readyState) !== null && _a !== void 0 ? _a : 0;
-                                },
-                                set: function (val) {
-                                    this._readyState = val;
-                                    setTimeout(() => {
-                                        this.dispatchEvent(new Event('readystatechange'));
-                                    });
-                                },
-                            },
                         });
-                        xhr.readyState = 0;
                         const prototype = win.CapacitorWebXMLHttpRequest.prototype;
                         const isProgressEventAvailable = () => typeof ProgressEvent !== 'undefined' &&
                             ProgressEvent.prototype instanceof Event;
@@ -608,6 +595,20 @@ var nativeBridge = (function (exports) {
                                 this._url = createProxyUrl(this._url, win);
                                 return win.CapacitorWebXMLHttpRequest.open.call(this, method, this._url);
                             }
+                            Object.defineProperties(this, {
+                                readyState: {
+                                    get: function () {
+                                        var _a;
+                                        return (_a = this._readyState) !== null && _a !== void 0 ? _a : 0;
+                                    },
+                                    set: function (val) {
+                                        this._readyState = val;
+                                        setTimeout(() => {
+                                            this.dispatchEvent(new Event('readystatechange'));
+                                        });
+                                    },
+                                },
+                            });
                             setTimeout(() => {
                                 this.dispatchEvent(new Event('loadstart'));
                             });


### PR DESCRIPTION
Move readyState override to open method and do it only for POST requests as the others don't use the overridden XHR object and the override messes with the original object. 

closes RDMR-132
closes https://github.com/ionic-team/capacitor/issues/7417