### PR TITLE
fix: add default value for dataType

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -392,7 +392,7 @@ public class HttpRequestHandler {
         Boolean disableRedirects = call.getBoolean("disableRedirects");
         Boolean shouldEncode = call.getBoolean("shouldEncodeUrlParams", true);
         ResponseType responseType = ResponseType.parse(call.getString("responseType"));
-        String dataType = call.getString("dataType");
+        String dataType = call.getString("dataType", "application/json");
 
         String method = httpMethod != null ? httpMethod.toUpperCase(Locale.ROOT) : call.getString("method", "GET").toUpperCase(Locale.ROOT);
 


### PR DESCRIPTION
This PR adds a default value for `dataType` in the request function to ensure it is handled properly when not provided. This ensures consistent request behavior.

Fixes #7245 