### PR TITLE
fix(cli): Run sync before updating gradle

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -12,7 +12,7 @@ import { logger, logPrompt, logSuccess } from '../log';
 import { getPlugins } from '../plugin';
 import { deleteFolderRecursive } from '../util/fs';
 import { resolveNode } from '../util/node';
-import { runCommand, getCommandOutput } from '../util/subprocess';
+import { runCommand } from '../util/subprocess';
 import { extractTemplate } from '../util/template';
 
 // eslint-disable-next-line prefer-const
@@ -184,6 +184,14 @@ export async function migrateCommand(
         );
       }
 
+      if (!installFailed) {
+        await runTask(`Running cap sync.`, () => {
+          return runCommand('npx', ['cap', 'sync']);
+        });
+      } else {
+        logger.warn('Skipped Running cap sync.');
+      }
+
       if (
         allDependencies['@capacitor/android'] &&
         existsSync(config.android.platformDirAbs)
@@ -349,15 +357,6 @@ export async function migrateCommand(
             'Skipped migrating package from Manifest to build.gradle in Capacitor plugins',
           );
         }
-      }
-
-      if (!installFailed) {
-        // Run Cap Sync
-        await runTask(`Running cap sync.`, () => {
-          return getCommandOutput('npx', ['cap', 'sync']);
-        });
-      } else {
-        logger.warn('Skipped Running cap sync.');
       }
 
       // Write all breaking changes


### PR DESCRIPTION
If the Android project is in not buildable state, gradle will fail to update the files because the project needs to build to update gradle.
Running `npx cap sync` before updating the gradle files will generate other non committed gradle files that are needed to build the project and that are not there in case the project was just checked out from github and never ran `npx cap sync` before on the project.

Also error the migration if `npx cap sync` failed to run, `getCommandOutput` doesn't error and reports the command as a success despite it failed, by using `runCommand` instead, it will fail the migration if `npx cap sync` fails.

closes https://github.com/ionic-team/capacitor/issues/7489