### PR TITLE
feat(cli): run plugin hooks

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -6,6 +6,7 @@ import c from './colors';
 import type { Config, PackageJson } from './definitions';
 import { fatal } from './errors';
 import { output, logger } from './log';
+import { getPlugins } from './plugin';
 import { findNXMonorepoRoot, isNXMonorepo } from './util/monorepotools';
 import { resolveNode } from './util/node';
 import { runCommand } from './util/subprocess';
@@ -160,6 +161,20 @@ export async function checkAppName(
 
 export async function wait(time: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, time));
+}
+
+export async function runHooks(
+  config: Config,
+  platformName: string,
+  dir: string,
+  hook: string,
+): Promise<void> {
+  await runPlatformHook(config, platformName, dir, hook);
+
+  const allPlugins = await getPlugins(config, platformName);
+  allPlugins.forEach(async p => {
+    await runPlatformHook(config, platformName, p.rootPath, hook);
+  });
 }
 
 export async function runPlatformHook(

--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -5,6 +5,7 @@ import c from '../colors';
 import {
   checkWebDir,
   resolvePlatform,
+  runHooks,
   runPlatformHook,
   runTask,
   isValidPlatform,
@@ -70,7 +71,7 @@ export async function copy(
       throw result;
     }
 
-    await runPlatformHook(
+    await runHooks(
       config,
       platformName,
       config.app.rootDir,
@@ -190,7 +191,7 @@ export async function copy(
     }
   });
 
-  await runPlatformHook(
+  await runHooks(
     config,
     platformName,
     config.app.rootDir,

--- a/cli/src/tasks/sync.ts
+++ b/cli/src/tasks/sync.ts
@@ -4,7 +4,7 @@ import {
   checkWebDir,
   selectPlatforms,
   isValidPlatform,
-  runPlatformHook,
+  runHooks,
 } from '../common';
 import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
@@ -63,7 +63,7 @@ export async function sync(
   deployment: boolean,
   inline = false,
 ): Promise<void> {
-  await runPlatformHook(
+  await runHooks(
     config,
     platformName,
     config.app.rootDir,
@@ -77,7 +77,7 @@ export async function sync(
   }
   await update(config, platformName, deployment);
 
-  await runPlatformHook(
+  await runHooks(
     config,
     platformName,
     config.app.rootDir,

--- a/cli/src/tasks/update.ts
+++ b/cli/src/tasks/update.ts
@@ -4,6 +4,7 @@ import {
   check,
   checkPackage,
   resolvePlatform,
+  runHooks,
   runPlatformHook,
   runTask,
   selectPlatforms,
@@ -84,7 +85,7 @@ export async function update(
   deployment: boolean,
 ): Promise<void> {
   await runTask(c.success(c.strong(`update ${platformName}`)), async () => {
-    await runPlatformHook(
+    await runHooks(
       config,
       platformName,
       config.app.rootDir,
@@ -97,7 +98,7 @@ export async function update(
       await updateAndroid(config);
     }
 
-    await runPlatformHook(
+    await runHooks(
       config,
       platformName,
       config.app.rootDir,


### PR DESCRIPTION
Also run `capacitor:copy:before`, `capacitor:copy:after`, `capacitor:update:before`, `capacitor:update:after`, `capacitor:sync:before` and `capacitor:sync:after` hooks in Capacitor and Cordova plugins if present in their `package.json` file.

This way Cordova plugins can have separate hooks from the Cordova ones to be run in Capacitor apps as their logic will most likely need to be different in Capacitor projects.





