### PR TITLE
chore(ci): Use v4 actions on publish ios and android

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,13 +27,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: 'main'
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -13,12 +13,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: NPM ^9.5.0
         run: npm i -g npm@^9.5.0 --registry=https://registry.npmjs.org
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: 'main'


### PR DESCRIPTION
actions were updated to v4, but the ones used in publish-ios and publish-android weren't updated