### PR TITLE
fix(android): send FormData on older devices

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -289,6 +289,8 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                             os.write(Base64.getDecoder().decode(value));
+                        } else {
+                            os.write(android.util.Base64.decode(value, android.util.Base64.DEFAULT));
                         }
 
                         os.writeBytes(lineEnd);


### PR DESCRIPTION
formData is only being decoded and sent for Android O and newer, but we support 5.1+, add an else to handle the data on older versions