### PR TITLE
fix(android): UTF-8 encode form data value

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -275,7 +275,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                     if (type.equals("string")) {
                         os.writeBytes(twoHyphens + boundary + lineEnd);
                         os.writeBytes("Content-Disposition: form-data; name=\"" + key + "\"" + lineEnd + lineEnd);
-                        os.write(value.getBytes("UTF-8"));
+                        os.write(value.getBytes(StandardCharsets.UTF_8));
                         os.writeBytes(lineEnd);
                     } else if (type.equals("base64File")) {
                         String fileName = entry.getString("fileName");

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -275,7 +275,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
                     if (type.equals("string")) {
                         os.writeBytes(twoHyphens + boundary + lineEnd);
                         os.writeBytes("Content-Disposition: form-data; name=\"" + key + "\"" + lineEnd + lineEnd);
-                        os.writeBytes(value);
+                        os.write(value.getBytes("UTF-8"));
                         os.writeBytes(lineEnd);
                     } else if (type.equals("base64File")) {
                         String fileName = entry.getString("fileName");


### PR DESCRIPTION
When using multipart/form-data in a POST request on Android, the values are not encoded, which is problematic when the values contain accents or emojis for example
This merge request proposes to encode values in UTF-8, similar to what is done when encoding other POST requests body

Fixes #7526 
closes https://github.com/ionic-team/capacitor/pull/7219
closes https://github.com/ionic-team/capacitor/pull/6730