### PR TITLE
Fix percent-encoding for patched fetch / xhr requests

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -133,22 +133,18 @@ var nativeBridge = (function (exports) {
         return { data: body, type: 'json' };
     };
     const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
-    const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
     const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
     // TODO: export as Cap function
     const isRelativeOrProxyUrl = (url) => !url ||
         !(url.startsWith('http:') || url.startsWith('https:')) ||
-        url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1 ||
-        url.indexOf(CAPACITOR_HTTPS_INTERCEPTOR) > -1;
+        url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1;
     // TODO: export as Cap function
     const createProxyUrl = (url, win) => {
         var _a, _b;
         if (isRelativeOrProxyUrl(url))
             return url;
-        const proxyUrl = new URL(url);
-        const isHttps = proxyUrl.protocol === 'https:';
         const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
-        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}`;
+        bridgeUrl.pathname = `${CAPACITOR_HTTP_INTERCEPTOR}`;
         // URLSearchParams `append()` method will automatically percent encode the url
         bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
         return bridgeUrl.toString();

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -134,6 +134,7 @@ var nativeBridge = (function (exports) {
     };
     const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
     const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
+    const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
     // TODO: export as Cap function
     const isRelativeOrProxyUrl = (url) => !url ||
         !(url.startsWith('http:') || url.startsWith('https:')) ||
@@ -145,11 +146,11 @@ var nativeBridge = (function (exports) {
         if (isRelativeOrProxyUrl(url))
             return url;
         const proxyUrl = new URL(url);
-        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
-        bridgeUrl.search = proxyUrl.search;
-        bridgeUrl.hash = proxyUrl.hash;
-        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}`;
+        // URLSearchParams `append()` method will automatically percent encode the url
+        bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
         return bridgeUrl.toString();
     };
     const initBridge = (w) => {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -93,6 +93,7 @@ public class Bridge {
     public static final String CAPACITOR_CONTENT_START = "/_capacitor_content_";
     public static final String CAPACITOR_HTTP_INTERCEPTOR_START = "/_capacitor_http_interceptor_";
     public static final String CAPACITOR_HTTPS_INTERCEPTOR_START = "/_capacitor_https_interceptor_";
+    public static final String CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = "u";
 
     public static final int DEFAULT_ANDROID_WEBVIEW_VERSION = 60;
     public static final int MINIMUM_ANDROID_WEBVIEW_VERSION = 55;

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -92,7 +92,6 @@ public class Bridge {
     public static final String CAPACITOR_FILE_START = "/_capacitor_file_";
     public static final String CAPACITOR_CONTENT_START = "/_capacitor_content_";
     public static final String CAPACITOR_HTTP_INTERCEPTOR_START = "/_capacitor_http_interceptor_";
-    public static final String CAPACITOR_HTTPS_INTERCEPTOR_START = "/_capacitor_https_interceptor_";
     public static final String CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = "u";
 
     public static final int DEFAULT_ANDROID_WEBVIEW_VERSION = 60;

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -262,13 +262,10 @@ public class WebViewLocalServer {
         boolean isHttps =
             request.getUrl().getPath() != null && request.getUrl().getPath().startsWith(Bridge.CAPACITOR_HTTPS_INTERCEPTOR_START);
 
-        String urlString = request
-            .getUrl()
-            .toString()
-            .replace(bridge.getLocalUrl(), isHttps ? "https:/" : "http:/")
-            .replace(Bridge.CAPACITOR_HTTP_INTERCEPTOR_START, "")
-            .replace(Bridge.CAPACITOR_HTTPS_INTERCEPTOR_START, "");
-        urlString = URLDecoder.decode(urlString, "UTF-8");
+        Uri uri = Uri.parse(request.getUrl().toString());
+        // `getQueryParameter` method of Android Uri lib already decodes the value automatically
+        String urlString = uri.getQueryParameter(Bridge.CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM);
+
         URL url = new URL(urlString);
         JSObject headers = new JSObject();
 

--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -174,10 +174,7 @@ public class WebViewLocalServer {
 
         if (
             null != loadingUrl.getPath() &&
-            (
-                loadingUrl.getPath().startsWith(Bridge.CAPACITOR_HTTP_INTERCEPTOR_START) ||
-                loadingUrl.getPath().startsWith(Bridge.CAPACITOR_HTTPS_INTERCEPTOR_START)
-            )
+            loadingUrl.getPath().startsWith(Bridge.CAPACITOR_HTTP_INTERCEPTOR_START)
         ) {
             Logger.debug("Handling CapacitorHttp request: " + loadingUrl);
             try {

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -121,6 +121,7 @@ const convertBody = async (
 
 const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
 const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
+const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
 
 // TODO: export as Cap function
 const isRelativeOrProxyUrl = (url: string | undefined): boolean =>
@@ -134,13 +135,14 @@ const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   if (isRelativeOrProxyUrl(url)) return url;
 
   const proxyUrl = new URL(url);
-  const bridgeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
   const isHttps = proxyUrl.protocol === 'https:';
-  bridgeUrl.search = proxyUrl.search;
-  bridgeUrl.hash = proxyUrl.hash;
+  const bridgeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
   bridgeUrl.pathname = `${
     isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
-  }/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+  }`;
+  // URLSearchParams `append()` method will automatically percent encode the url
+  bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
+
   return bridgeUrl.toString();
 };
 

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -120,26 +120,19 @@ const convertBody = async (
 };
 
 const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
-const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
 const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
 
 // TODO: export as Cap function
 const isRelativeOrProxyUrl = (url: string | undefined): boolean =>
   !url ||
   !(url.startsWith('http:') || url.startsWith('https:')) ||
-  url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1 ||
-  url.indexOf(CAPACITOR_HTTPS_INTERCEPTOR) > -1;
+  url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1;
 
 // TODO: export as Cap function
 const createProxyUrl = (url: string, win: WindowCapacitor): string => {
   if (isRelativeOrProxyUrl(url)) return url;
-
-  const proxyUrl = new URL(url);
-  const isHttps = proxyUrl.protocol === 'https:';
   const bridgeUrl = new URL(win.Capacitor?.getServerUrl() ?? '');
-  bridgeUrl.pathname = `${
-    isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR
-  }`;
+  bridgeUrl.pathname = `${CAPACITOR_HTTP_INTERCEPTOR}`;
   // URLSearchParams `append()` method will automatically percent encode the url
   bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -95,7 +95,7 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
     public static let capacitorSite = "https://capacitorjs.com/"
     public static let fileStartIdentifier = "/_capacitor_file_"
     public static let httpInterceptorStartIdentifier = "/_capacitor_http_interceptor_"
-    public static let httpsInterceptorStartIdentifier = "/_capacitor_https_interceptor_"
+    public static let httpInterceptorUrlParam = "u"
     public static let defaultScheme = "capacitor"
 
     public private(set) var webViewAssetHandler: WebViewAssetHandler

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -35,11 +35,6 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             return
         }
 
-        if url.path.starts(with: CapacitorBridge.httpsInterceptorStartIdentifier) {
-            handleCapacitorHttpRequest(urlSchemeTask, localUrl, true)
-            return
-        }
-
         if stringToLoad.starts(with: CapacitorBridge.fileStartIdentifier) {
             startPath = stringToLoad.replacingOccurrences(of: CapacitorBridge.fileStartIdentifier, with: "")
         } else {
@@ -138,20 +133,13 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
     func handleCapacitorHttpRequest(_ urlSchemeTask: WKURLSchemeTask, _ localUrl: URL, _ isHttpsRequest: Bool) {
         var urlRequest = urlSchemeTask.request
         guard let url = urlRequest.url else { return }
-        var targetUrl = url.absoluteString
-            .replacingOccurrences(of: CapacitorBridge.httpInterceptorStartIdentifier, with: "")
-            .replacingOccurrences(of: CapacitorBridge.httpsInterceptorStartIdentifier, with: "")
-        // Only replace first occurrence of the scheme
-        if let range = targetUrl.range(of: localUrl.scheme ?? InstanceDescriptorDefaults.scheme) {
-            targetUrl = targetUrl.replacingCharacters(in: range, with: isHttpsRequest ? "https" : "http")
+        
+        let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let targetUrl = urlComponents?.queryItems?.first(where: { $0.name == CapacitorBridge.httpInterceptorUrlParam })?.value,
+           !targetUrl.isEmpty {
+            // Note that URLComponents are already percent-decoded so we do not need to do this manually
+            urlRequest.url = URL(string: targetUrl)
         }
-
-        // Only replace first occurrence of the hostname
-        if let range = targetUrl.range(of: (localUrl.host ?? InstanceDescriptorDefaults.hostname) + "/") {
-            targetUrl = targetUrl.replacingCharacters(in: range, with: "")
-        }
-
-        urlRequest.url = URL(string: targetUrl.removingPercentEncoding ?? targetUrl)
 
         let urlSession = URLSession.shared
         let task = urlSession.dataTask(with: urlRequest) { (data, response, error) in

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -133,22 +133,18 @@ var nativeBridge = (function (exports) {
         return { data: body, type: 'json' };
     };
     const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
-    const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
     const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
     // TODO: export as Cap function
     const isRelativeOrProxyUrl = (url) => !url ||
         !(url.startsWith('http:') || url.startsWith('https:')) ||
-        url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1 ||
-        url.indexOf(CAPACITOR_HTTPS_INTERCEPTOR) > -1;
+        url.indexOf(CAPACITOR_HTTP_INTERCEPTOR) > -1;
     // TODO: export as Cap function
     const createProxyUrl = (url, win) => {
         var _a, _b;
         if (isRelativeOrProxyUrl(url))
             return url;
-        const proxyUrl = new URL(url);
-        const isHttps = proxyUrl.protocol === 'https:';
         const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
-        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}`;
+        bridgeUrl.pathname = `${CAPACITOR_HTTP_INTERCEPTOR}`;
         // URLSearchParams `append()` method will automatically percent encode the url
         bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
         return bridgeUrl.toString();

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -134,6 +134,7 @@ var nativeBridge = (function (exports) {
     };
     const CAPACITOR_HTTP_INTERCEPTOR = '/_capacitor_http_interceptor_';
     const CAPACITOR_HTTPS_INTERCEPTOR = '/_capacitor_https_interceptor_';
+    const CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = 'u';
     // TODO: export as Cap function
     const isRelativeOrProxyUrl = (url) => !url ||
         !(url.startsWith('http:') || url.startsWith('https:')) ||
@@ -145,11 +146,11 @@ var nativeBridge = (function (exports) {
         if (isRelativeOrProxyUrl(url))
             return url;
         const proxyUrl = new URL(url);
-        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
         const isHttps = proxyUrl.protocol === 'https:';
-        bridgeUrl.search = proxyUrl.search;
-        bridgeUrl.hash = proxyUrl.hash;
-        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}/${encodeURIComponent(proxyUrl.host)}${proxyUrl.pathname}`;
+        const bridgeUrl = new URL((_b = (_a = win.Capacitor) === null || _a === void 0 ? void 0 : _a.getServerUrl()) !== null && _b !== void 0 ? _b : '');
+        bridgeUrl.pathname = `${isHttps ? CAPACITOR_HTTPS_INTERCEPTOR : CAPACITOR_HTTP_INTERCEPTOR}`;
+        // URLSearchParams `append()` method will automatically percent encode the url
+        bridgeUrl.searchParams.append(CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM, url);
         return bridgeUrl.toString();
     };
     const initBridge = (w) => {


### PR DESCRIPTION
Following up #7523. 

This suggestion addresses the issue of non-encoded URLs in patched fetch and XHR requests. By encoding the full original URL and appending it as a parameter to the bridge/proxy URL, this solution should be more robust when passed to the native code. Also, there is no longer a need to distinguish between HTTP and HTTPS URLs separately, as this information is already embedded in the encoded URL parameter.

Working test implementation can be found here (including an example with non 80 port): https://github.com/michaelwolz/capacitor-tests/tree/fix/url-encoding