### PR TITLE
fix(livereload): Don't overwrite the whole config.server section in `editCapConfigForLiveReload` function

### DIFF
--- a/cli/src/util/livereload.ts
+++ b/cli/src/util/livereload.ts
@@ -142,6 +142,7 @@ class CapLiveReload {
     this.configJsonToRevertTo.platformPath = capConfigPath;
     const url = `http://${options.host}:${options.port}`;
     configJson.server = {
+      ...configJson.server,
       url,
     };
     return configJson;


### PR DESCRIPTION
Live reload now works with cleartext: true