### PR TITLE
Update WebColor.java to don't crash on empty string on colorString var

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/util/WebColor.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/util/WebColor.java
@@ -11,7 +11,7 @@ public class WebColor {
      */
     public static int parseColor(String colorString) {
         String formattedColor = colorString;
-        if (colorString.charAt(0) != '#') {
+        if (!colorString.isEmpty() && colorString.charAt(0) != '#') {
             formattedColor = "#" + formattedColor;
         }
 


### PR DESCRIPTION
Detected a crash if colorString equals a "". By fixing this the app don't crash anymore and the user can successfully open the application.