### PR TITLE
fix(iOS): change hardcoded config path when using custom config file for auto register plugins

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -54,6 +54,7 @@ public class CapConfig {
     private String errorPath;
     private boolean zoomableWebView = false;
     private boolean resolveServiceWorkerRequests = true;
+    private String adjustMarginsForEdgeToEdge = "auto";
 
     // Embedded
     private String startPath;
@@ -286,6 +287,7 @@ public class CapConfig {
         webContentsDebuggingEnabled = JSONUtils.getBoolean(configJSON, "android.webContentsDebuggingEnabled", isDebug);
         zoomableWebView = JSONUtils.getBoolean(configJSON, "android.zoomEnabled", JSONUtils.getBoolean(configJSON, "zoomEnabled", false));
         resolveServiceWorkerRequests = JSONUtils.getBoolean(configJSON, "android.resolveServiceWorkerRequests", true);
+        adjustMarginsForEdgeToEdge = JSONUtils.getString(configJSON, "android.adjustMarginsForEdgeToEdge", "auto");
 
         String logBehavior = JSONUtils.getString(
             configJSON,
@@ -582,6 +584,7 @@ public class CapConfig {
         private int minHuaweiWebViewVersion = DEFAULT_HUAWEI_WEBVIEW_VERSION;
         private boolean zoomableWebView = false;
         private boolean resolveServiceWorkerRequests = true;
+        private String adjustMarginsForEdgeToEdge = "auto";
 
         // Embedded
         private String startPath = null;

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -707,17 +707,11 @@ export interface PluginsConfig {
    */
   SystemBars?: {
     /**
-     * Specifies how to handle problematic insets on Android.
+     * Disables the injection of device css insets into the web view.
      *
-     * This option is only supported on Android.
-     *
-     * `css` = Injects CSS variables (`--safe-area-inset-*`) containing correct safe area inset values into the webview.
-     *
-     * `disable` = Disable all inset handling.
-     *
-     * @default "css"
+     * @default false
      */
-    insetsHandling?: 'css' | 'disable';
+    disableInsets?: boolean;
     /**
      * The style of the text and icons of the system bars.
      *

--- a/core/package.json
+++ b/core/package.json
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run docgen && npm run transpile && npm run rollup",
     "build:nativebridge": "tsc native-bridge.ts --target es2017 --moduleResolution node --outDir build && rollup --config rollup.bridge.config.js",
     "clean": "rimraf dist",
-    "docgen": "docgen --api CapacitorCookiesPlugin --output-readme cookies.md && docgen --api CapacitorHttpPlugin --output-readme http.md && docgen --api SystemBarsPlugin --output-readme system-bars.md",
+    "docgen": "docgen --api CapacitorCookiesPlugin --output-readme cookies.md && docgen --api CapacitorHttpPlugin --output-readme http.md && docgen --api SystemBarsPlugin --output-readme systembars.md",
     "prepublishOnly": "npm run build",
     "rollup": "rollup --config rollup.config.js",
     "transpile": "tsc",

--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -617,14 +617,14 @@ export interface SystemBarsPlugin {
    *
    * @since 8.0.0
    */
-  show(options?: SystemBarsVisibilityOptions): Promise<void>;
+  show(options: SystemBarsVisibilityOptions): Promise<void>;
 
   /**
    * Hide the system bars.
    *
    * @since 8.0.0
    */
-  hide(options?: SystemBarsVisibilityOptions): Promise<void>;
+  hide(options: SystemBarsVisibilityOptions): Promise<void>;
 
   /**
    * Set the animation to use when showing / hiding the status bar.

--- a/core/systembars.md
+++ b/core/systembars.md
@@ -1,0 +1,259 @@
+# SystemBars
+
+The SystemBars API provides methods for configuring the style and visibility of the device System Bars / Status Bar.  This API differs from the [Status Bar](https://capacitorjs.com/docs/apis/status-bar) plugin in that it is only intended to support modern edge to edge use cases moving forward.  For legacy functionality, use the [Status Bar](https://capacitorjs.com/docs/apis/status-bar) plugin.
+
+| Feature | System Bars | Status Bar |
+| ------- | ----------- | ---------- |
+| `setOverlaysWebView()` | Unsupported | Supported on iOS and Android <= 14 (or 15 if edge to edge opt-out is enabled) |
+| `setBackgroundColor()` | Unsupported | Supported |
+| `setStyle()` | Supported | Supported - top Status Bar only |
+| `hide()/show()` | Supported | Supported - top Status Bar only |
+
+## iOS Note
+
+This plugin requires "View controller-based status bar appearance"
+(`UIViewControllerBasedStatusBarAppearance`) set to `YES` in `Info.plist`. Read
+about [Configuring iOS](https://capacitorjs.com/docs/ios/configuration) for
+help.
+
+The status bar visibility defaults to visible and the style defaults to
+`Style.Default`. You can change these defaults by adding
+`UIStatusBarHidden` and/or `UIStatusBarStyle` in `Info.plist`.
+
+## Android Note
+
+Due to a [bug](https://issues.chromium.org/issues/40699457) in some older versions of Android WebView (< 140), correct safe area values are not available via the `safe-area-inset-x` CSS `env` variables.  This plugin will inject the correct inset values into a new CSS variable(s) named `--safe-area-inset-x` that you can use as a fallback in your frontend styles:
+
+```css
+html {
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  padding-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+  padding-left: var(--safe-area-inset-left, env(safe-area-inset-left, 0px));
+  padding-right: var(--safe-area-inset-right, env(safe-area-inset-right, 0px));
+}
+```
+
+To disable the inset variable injections, set the configuration setting `disableInsets` to `true`.
+
+## Example
+
+```typescript
+import { SystemBars, SystemBarsStyle } from '@capacitor/core';
+
+const setSystemBarStyleDark = async () => {
+  await SystemBars.setStyle({ style: SystemBarsStyle.Dark });
+};
+
+const setSystemBarStyleLight = async () => {
+  await SystemBars.setStyle({ style: SystemBarsStyle.Light });
+};
+
+const hideSystemBars = async () => {
+  await SystemBars.hide();
+};
+
+const showSystemBars = async () => {
+  await SystemBars.show();
+};
+
+const hideNavigationBar = async () => {
+  await SystemBars.hide({
+    bar: SystemBarType.NavigationBar
+  })
+}
+
+// Set the Status Bar animation, only on iOS
+const setStatusBarAnimation = async () => {
+  await SystemBars.setAnimation({ animation: "NONE" });
+}
+
+````
+
+## Configuration
+| Prop          | Type                 | Description                                                               | Default            |
+| ------------- | -------------------- | ------------------------------------------------------------------------- | ------------------ |
+| **`disableInsets`** | <code>boolean</code> | Disables the injection of device css insets into the webview.  This option is only supported on Android. | <code>false</code> |
+| **`style`** | <code>string</code> | The style of the text and icons of the system bars. | <code>DEFAULT</code> |
+| **`hidden`** | <code>boolean</code> | Hide the system bars on start. | <code>false</code> |
+| **`animation`** | <code>string</code> | The type of status bar animation used when showing or hiding.  This option is only supported on iOS. | <code>FADE</code> |
+
+
+### Example Configuration
+
+In `capacitor.config.json`:
+
+```json
+{
+  "plugins": {
+    "SystemBars": {
+      "disableInsets": true,
+      "style": "DARK",
+      "hidden": false,
+      "animation": "NONE"
+    }
+  }
+}
+```
+
+In `capacitor.config.ts`:
+
+```ts
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  plugins: {
+    SystemBars: {
+      disableInsets: true,
+      style: "DARK",
+      hidden: false,
+      animation: "NONE"
+    },
+  },
+};
+
+export default config;
+```
+
+## API
+
+<docgen-index>
+
+* [`setStyle(...)`](#setstyle)
+* [`show(...)`](#show)
+* [`hide(...)`](#hide)
+* [`setAnimation(...)`](#setanimation)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
+* [Enums](#enums)
+
+</docgen-index>
+
+<docgen-api>
+<!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
+
+### setStyle(...)
+
+```typescript
+setStyle(options: SystemBarsStyleOptions) => Promise<void>
+```
+
+Set the current style of the system bars.
+
+| Param         | Type                                                                      |
+| ------------- | ------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#systembarsstyleoptions">SystemBarsStyleOptions</a></code> |
+
+**Since:** 8.0.0
+
+--------------------
+
+
+### show(...)
+
+```typescript
+show(options: SystemBarsVisibilityOptions) => Promise<void>
+```
+
+Show the system bars.
+
+| Param         | Type                                                                                |
+| ------------- | ----------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#systembarsvisibilityoptions">SystemBarsVisibilityOptions</a></code> |
+
+**Since:** 8.0.0
+
+--------------------
+
+
+### hide(...)
+
+```typescript
+hide(options: SystemBarsVisibilityOptions) => Promise<void>
+```
+
+Hide the system bars.
+
+| Param         | Type                                                                                |
+| ------------- | ----------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#systembarsvisibilityoptions">SystemBarsVisibilityOptions</a></code> |
+
+**Since:** 8.0.0
+
+--------------------
+
+
+### setAnimation(...)
+
+```typescript
+setAnimation(options: SystemBarsAnimationOptions) => Promise<void>
+```
+
+Set the animation to use when showing / hiding the status bar.
+
+Only available on iOS.
+
+| Param         | Type                                                                              |
+| ------------- | --------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#systembarsanimationoptions">SystemBarsAnimationOptions</a></code> |
+
+**Since:** 8.0.0
+
+--------------------
+
+
+### Interfaces
+
+
+#### SystemBarsStyleOptions
+
+| Prop        | Type                                                        | Description                                     | Default                | Since |
+| ----------- | ----------------------------------------------------------- | ----------------------------------------------- | ---------------------- | ----- |
+| **`style`** | <code><a href="#systembarsstyle">SystemBarsStyle</a></code> | Style of the text and icons of the system bars. | <code>'DEFAULT'</code> | 8.0.0 |
+| **`bar`**   | <code><a href="#systembartype">SystemBarType</a></code>     | The system bar to which to apply the style.     | <code>null</code>      | 8.0.0 |
+
+
+#### SystemBarsVisibilityOptions
+
+| Prop            | Type                                                                | Description                                                                                         | Default             | Since |
+| --------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- | ----- |
+| **`bar`**       | <code><a href="#systembartype">SystemBarType</a></code>             | The system bar to hide or show.                                                                     | <code>null</code>   | 8.0.0 |
+| **`animation`** | <code><a href="#systembarsanimation">SystemBarsAnimation</a></code> | The type of status bar animation used when showing or hiding. This option is only supported on iOS. | <code>'FADE'</code> | 8.0.0 |
+
+
+#### SystemBarsAnimationOptions
+
+| Prop            | Type                                                                | Description                                                                                         | Default             | Since |
+| --------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------- | ----- |
+| **`animation`** | <code><a href="#systembarsanimation">SystemBarsAnimation</a></code> | The type of status bar animation used when showing or hiding. This option is only supported on iOS. | <code>'FADE'</code> | 8.0.0 |
+
+
+### Type Aliases
+
+
+#### SystemBarsAnimation
+
+Available status bar animations.  iOS only.
+
+<code>'FADE' | 'NONE'</code>
+
+
+### Enums
+
+
+#### SystemBarsStyle
+
+| Members       | Value                  | Description                                                                                                                                                                                                              | Since |
+| ------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`Dark`**    | <code>'DARK'</code>    | Light system bar content on a dark background.                                                                                                                                                                           | 8.0.0 |
+| **`Light`**   | <code>'LIGHT'</code>   | For dark system bar content on a light background.                                                                                                                                                                       | 8.0.0 |
+| **`Default`** | <code>'DEFAULT'</code> | The style is based on the device appearance or the underlying content. If the device is using Dark mode, the system bars content will be light. If the device is using Light mode, the system bars content will be dark. | 8.0.0 |
+
+
+#### SystemBarType
+
+| Members             | Value                        | Description                                                         | Since |
+| ------------------- | ---------------------------- | ------------------------------------------------------------------- | ----- |
+| **`StatusBar`**     | <code>'StatusBar'</code>     | The top status bar on both Android and iOS.                         | 8.0.0 |
+| **`NavigationBar`** | <code>'NavigationBar'</code> | The navigation bar (or gesture bar on iOS) on both Android and iOS. | 8.0.0 |
+
+</docgen-api>

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.h
@@ -13,6 +13,7 @@ NS_SWIFT_NAME(InstanceConfiguration)
 @property (nonatomic, readonly, nonnull) NSArray<NSString*> *allowedNavigationHostnames;
 @property (nonatomic, readonly, nonnull) NSURL *localURL;
 @property (nonatomic, readonly, nonnull) NSURL *serverURL;
+@property (nonatomic, readonly, nullable) NSURL *configURL;
 @property (nonatomic, readonly, nullable) NSString *errorPath;
 @property (nonatomic, readonly, nonnull) NSDictionary *pluginConfigurations;
 @property (nonatomic, readonly) BOOL loggingEnabled;

--- a/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
+++ b/ios/Capacitor/Capacitor/CAPInstanceConfiguration.m
@@ -49,6 +49,13 @@
         else {
             _serverURL = _localURL;
         }
+        
+        if (descriptor.configUrl != nil) {
+            _configURL = descriptor.configUrl;
+        }
+        else {
+            _configURL = [[NSURL alloc] initWithString:(@"capacitor.config.json")];
+        }
         _errorPath = descriptor.errorPath;
         // extract the one value we care about from the cordova configuration
         _cordovaDeployDisabled = [descriptor cordovaDeployDisabled];

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.h
@@ -69,6 +69,11 @@ NS_SWIFT_NAME(InstanceDescriptor)
  */
 @property (nonatomic, copy, nullable) NSString *serverURL;
 /**
+ @brief The file URL from which Capacitor will load configuration
+ @discussion Defaults to @c capacitor.config.json located at the root of the application bundle.
+ */
+@property (nonatomic, copy, nullable) NSURL *configUrl;
+/**
  @brief The JSON dictionary that contains the plugin-specific configuration information.
  @discussion Set by @c plugins in the configuration file.
  */

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -30,6 +30,8 @@ internal extension InstanceDescriptor {
     // swiftlint:disable function_body_length
     // swiftlint:disable:next identifier_name
     @objc func _parseConfiguration(at capacitorURL: URL?, cordovaConfiguration cordovaURL: URL?) {
+        configUrl = capacitorURL
+        
         // sanity check that the app directory is valid
         var isDirectory: ObjCBool = ObjCBool(false)
         if warnings.contains(.missingAppDir) == false,

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -305,9 +305,9 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
     func registerPlugins() {
         var pluginList: [AnyClass] = [CAPHttpPlugin.self, CAPConsolePlugin.self, CAPWebViewPlugin.self, CAPCookiesPlugin.self, CAPSystemBarsPlugin.self]
 
-        if autoRegisterPlugins {
+        if autoRegisterPlugins && config.configURL != nil {
             do {
-                if let pluginJSON = Bundle.main.url(forResource: "capacitor.config", withExtension: "json") {
+                if let pluginJSON = Bundle.main.url(forResource: (config.configURL!.path as NSString).deletingPathExtension, withExtension: "json") {
                     let pluginData = try Data(contentsOf: pluginJSON)
                     let registrationList = try JSONDecoder().decode(RegistrationList.self, from: pluginData)
 

--- a/ios/Capacitor/Capacitor/Plugins/SystemBars.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SystemBars.swift
@@ -5,10 +5,10 @@ public class CAPSystemBarsPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "CAPSystemBarsPlugin"
     public let jsName = "SystemBars"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "setStyle", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "setAnimation", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "setStyle", returnType: CAPPluginReturnNone),
+        CAPPluginMethod(name: "setAnimation", returnType: CAPPluginReturnNone),
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnNone),
+        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnNone)
     ]
 
     public private(set) var hideHomeIndicator: Bool = false


### PR DESCRIPTION
When I use `InstanceDescriptor` with custom config path, the `CapacitorBridge` initialization on the `CAPBridgeViewController` is by default autoRegisterPlugins set to true.
But as we can see on CapacitorBridge class function registerPlugins config path is hardcoded
`
if autoRegisterPlugins {
            do {
                if let pluginJSON = Bundle.main.url(forResource: "capacitor.config", withExtension: "json") {
                //..
`
So, I've created new property configUrl that will be given when parsing configuration at InstanceDescriptor initialization.