### PR TITLE
feat(iOS): add open func instanceCapacitorBridge

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -45,16 +45,20 @@ import Cordova
         prepareWebView(with: configuration, assetHandler: assetHandler, delegationHandler: delegationHandler)
         view = webView
         // create the bridge
-        capacitorBridge = CapacitorBridge(with: configuration,
-                                          delegate: self,
-                                          cordovaConfiguration: configDescriptor.cordovaConfiguration,
-                                          assetHandler: assetHandler,
-                                          delegationHandler: delegationHandler)
+        capacitorBridge = instanceCapacitorBridge(configDescriptor, configuration, assetHandler, delegationHandler)
         capacitorDidLoad()
 
         if configDescriptor.instanceType == .fixed {
             updateBinaryVersion()
         }
+    }
+    
+    open func instanceCapacitorBridge(_ configDescriptor: InstanceDescriptor, _ configuration: InstanceConfiguration, _ assetHandler: WebViewAssetHandler, _ delegationHandler: WebViewDelegationHandler) -> CapacitorBridge {
+        return CapacitorBridge(with: configuration,
+                                              delegate: self,
+                                              cordovaConfiguration: configDescriptor.cordovaConfiguration,
+                                              assetHandler: assetHandler,
+                                              delegationHandler: delegationHandler)
     }
 
     override open func viewDidLoad() {


### PR DESCRIPTION
When I want to register plugins manually, `registerPluginType` on `CapacitorBridge` is blocked by `autoRegisterPlugins` that by default set to true.
So, we need some open function that return CapacitorBridge instance on `CAPBridgeViewController`:
`
open func instanceCapacitorBridge(_ configDescriptor: InstanceDescriptor, _ configuration: InstanceConfiguration, _ assetHandler: WebViewAssetHandler, _ delegationHandler: WebViewDelegationHandler) -> CapacitorBridge {
        return CapacitorBridge(with: configuration,
                                              delegate: self,
                                              cordovaConfiguration: configDescriptor.cordovaConfiguration,
                                              assetHandler: assetHandler,
                                              delegationHandler: delegationHandler)
    }
`