### PR TITLE
fix(ios): Match CapApp-SPM iOS version with project version

### DIFF
--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -1,5 +1,5 @@
-import { existsSync, writeFileSync } from '@ionic/utils-fs';
-import { relative, resolve } from 'path';
+import { existsSync, readFileSync, writeFileSync } from '@ionic/utils-fs';
+import { join, relative, resolve } from 'path';
 
 import type { Config } from '../definitions';
 import { logger } from '../log';
@@ -46,13 +46,23 @@ export async function generatePackageFile(
 }
 
 function generatePackageText(config: Config, plugins: Plugin[]): string {
+  const pbx = readFileSync(
+    join(config.ios.nativeXcodeProjDirAbs, 'project.pbxproj'),
+    'utf-8',
+  );
+  const searchString = 'IPHONEOS_DEPLOYMENT_TARGET = ';
+  const iosVersion = pbx.substring(
+    pbx.indexOf(searchString) + searchString.length,
+    pbx.indexOf(searchString) + searchString.length + 2,
+  );
+
   let packageSwiftText = `// swift-tools-version: 5.9
 import PackageDescription
 
 // DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
 let package = Package(
     name: "CapApp-SPM",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v${iosVersion})],
     products: [
         .library(
             name: "CapApp-SPM",


### PR DESCRIPTION
Make the CapApp-SPM project use the configured iOS version (`IPHONEOS_DEPLOYMENT_TARGET`) on the App project instead of the hardcoded version 13.

closes https://github.com/ionic-team/capacitor/issues/7544