### PR TITLE
fix(cli): enable cleartext for live reload

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -760,6 +760,7 @@ export async function writeCordovaAndroidManifest(
   cordovaPlugins: Plugin[],
   config: Config,
   platform: string,
+  cleartext?: boolean,
 ): Promise<void> {
   const manifestPath = join(
     config.android.cordovaPluginsDirAbs,
@@ -1078,15 +1079,15 @@ export async function writeCordovaAndroidManifest(
     });
   });
   const cleartextString = 'android:usesCleartextTraffic="true"';
-  const cleartext =
-    config.app.extConfig.server?.cleartext &&
+  const cleartextValue =
+    (cleartext || config.app.extConfig.server?.cleartext) &&
     !applicationXMLAttributes.includes(cleartextString)
       ? cleartextString
       : '';
   let content = `<?xml version='1.0' encoding='utf-8'?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:amazon="http://schemas.amazon.com/apk/res/android">
-<application ${applicationXMLAttributes.join('\n')} ${cleartext}>
+<application ${applicationXMLAttributes.join('\n')} ${cleartextValue}>
 ${applicationXMLEntries.join('\n')}
 </application>
 ${rootXMLEntries.join('\n')}

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -95,36 +95,34 @@ export async function runCommand(
       if (options.sync) {
         await sync(config, platformName, false, true);
       }
+      const cordovaPlugins = await getCordovaPlugins(config, platformName);
       if (options.liveReload) {
         await CapLiveReloadHelper.editCapConfigForLiveReload(
           config,
           platformName,
           options,
         );
-      }
-      const cordovaPlugins = await getCordovaPlugins(config, platformName);
-      if (platformName === config.android.name) {
-        await await writeCordovaAndroidManifest(
-          cordovaPlugins,
-          config,
-          platformName,
-          true,
-        );
+        if (platformName === config.android.name) {
+          await await writeCordovaAndroidManifest(
+            cordovaPlugins,
+            config,
+            platformName,
+            true,
+          );
+        }
       }
       await run(config, platformName, options);
       if (options.liveReload) {
         new Promise(resolve => process.on('SIGINT', resolve))
           .then(async () => {
-            if (options.liveReload) {
-              await CapLiveReloadHelper.revertCapConfigForLiveReload();
-              if (platformName === config.android.name) {
-                await writeCordovaAndroidManifest(
-                  cordovaPlugins,
-                  config,
-                  platformName,
-                  false,
-                );
-              }
+            await CapLiveReloadHelper.revertCapConfigForLiveReload();
+            if (platformName === config.android.name) {
+              await writeCordovaAndroidManifest(
+                cordovaPlugins,
+                config,
+                platformName,
+                false,
+              );
             }
           })
           .then(() => process.exit());

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -11,7 +11,8 @@ import {
   promptForPlatform,
   getPlatformTargetName,
 } from '../common';
-import type { AppConfig, Config } from '../definitions';
+import { getCordovaPlugins, writeCordovaAndroidManifest } from '../cordova';
+import type { Config } from '../definitions';
 import { fatal, isFatal } from '../errors';
 import { runIOS } from '../ios/run';
 import { logger, output } from '../log';
@@ -92,44 +93,43 @@ export async function runCommand(
 
     try {
       if (options.sync) {
-        if (options.liveReload) {
-          const newExtConfig =
-            await CapLiveReloadHelper.editExtConfigForLiveReload(
-              config,
-              platformName,
-              options,
-            );
-          const cfg: {
-            -readonly [K in keyof Config]: Config[K];
-          } = config;
-          const cfgapp: {
-            -readonly [K in keyof AppConfig]: AppConfig[K];
-          } = config.app;
-          cfgapp.extConfig = newExtConfig;
-          cfg.app = cfgapp;
-          await sync(cfg, platformName, false, true);
-        } else {
-          await sync(config, platformName, false, true);
-        }
-      } else {
-        if (options.liveReload) {
-          await CapLiveReloadHelper.editCapConfigForLiveReload(
-            config,
-            platformName,
-            options,
-          );
-        }
+        await sync(config, platformName, false, true);
+      }
+      if (options.liveReload) {
+        await CapLiveReloadHelper.editCapConfigForLiveReload(
+          config,
+          platformName,
+          options,
+        );
+      }
+      const cordovaPlugins = await getCordovaPlugins(config, platformName);
+      if (platformName === config.android.name) {
+        await await writeCordovaAndroidManifest(
+          cordovaPlugins,
+          config,
+          platformName,
+          true,
+        );
       }
       await run(config, platformName, options);
       if (options.liveReload) {
-        process.on('SIGINT', async () => {
-          if (options.liveReload) {
-            await CapLiveReloadHelper.revertCapConfigForLiveReload();
-          }
-          process.exit();
-        });
-        console.log(
-          `\nApp running with live reload listing for: http://${options.host}:${options.port}. Press Ctrl+C to quit.`,
+        new Promise(resolve => process.on('SIGINT', resolve))
+          .then(async () => {
+            if (options.liveReload) {
+              await CapLiveReloadHelper.revertCapConfigForLiveReload();
+              if (platformName === config.android.name) {
+                await writeCordovaAndroidManifest(
+                  cordovaPlugins,
+                  config,
+                  platformName,
+                  false,
+                );
+              }
+            }
+          })
+          .then(() => process.exit());
+        logger.info(
+          `App running with live reload listing for: http://${options.host}:${options.port}. Press Ctrl+C to quit.`,
         );
         await sleepForever();
       }

--- a/cli/src/util/livereload.ts
+++ b/cli/src/util/livereload.ts
@@ -120,6 +120,7 @@ class CapLiveReload {
     return !all.length ? loopback(family) : all[0];
   }
 
+  // TODO remove on next major as it's unused
   async editExtConfigForLiveReload(
     config: Config,
     platformName: string,
@@ -147,6 +148,7 @@ class CapLiveReload {
     return configJson;
   }
 
+  // TODO remove rootConfigChange param on next major as it's unused
   async editCapConfigForLiveReload(
     config: Config,
     platformName: string,


### PR DESCRIPTION
This PR enables cleartext when using live reload by directly writing into the `capacitor-cordova-android-plugins`'s `AndroidManifest.xml`, and removes it once the command is stopped.

It no longer overrides the original `extConfig` object but instead modifies the  platform's `capacitor.config.json` after sync.

Added a TODO to remove `editExtConfigForLiveReload` since it's no longer being used.
Added a TODO to remove the last param of `editCapConfigForLiveReload` as it's not being used.
Didn't remove any of them at the moment as people could be using the `CapLiveReloadHelper` directly, so removing them is breaking.

I've put the `process.on('SIGINT'` inside a promise to prevent multiple calls, it was being called three times.

There is an [alternate PR](https://github.com/ionic-team/capacitor/pull/7528), but it requires users to declare the `cleartext` themselves and doesn't work if using the `--no-sync` option.


closes https://github.com/ionic-team/capacitor/issues/7323
closes https://github.com/ionic-team/capacitor/pull/7528