### PR TITLE
chore(cli): Deprecate cordova.staticPlugins

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -679,6 +679,7 @@ export function needsStaticPod(plugin: Plugin, config: Config): boolean {
     'onesignal-cordova-plugin',
   ];
   if (config.app.extConfig?.cordova?.staticPlugins) {
+    logger.warn('cordova.staticPlugins is deprecated, make sure you are using latest version of the plugin')
     pluginList = pluginList.concat(
       config.app.extConfig?.cordova?.staticPlugins,
     );

--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -679,7 +679,9 @@ export function needsStaticPod(plugin: Plugin, config: Config): boolean {
     'onesignal-cordova-plugin',
   ];
   if (config.app.extConfig?.cordova?.staticPlugins) {
-    logger.warn('cordova.staticPlugins is deprecated, make sure you are using latest version of the plugin')
+    logger.warn(
+      'cordova.staticPlugins is deprecated, make sure you are using latest version of the plugin',
+    );
     pluginList = pluginList.concat(
       config.app.extConfig?.cordova?.staticPlugins,
     );

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -580,7 +580,10 @@ export interface CapacitorConfig {
      * List of Cordova plugins that need to be static but are not
      * already in the static plugin list.
      *
+     * It's deprecated and will be removed in Capacitor 7
+     *
      * @since 3.3.0
+     * @deprecated 6.1.1
      */
     staticPlugins?: string[];
   };


### PR DESCRIPTION
`cordova.staticPlugins` is used to put some plugins into a separate CocoaPods project that has `static_framework = true`.

This is used in some plugins that use `framework` tag for CocoaPods, which didn't allow to specify if they need to be static.
But using `framework` tag for CocoaPods dependencies is not supported on latest cordova-ios (version 7.x that was released a year ago).
So if Cordova doesn't support that, we shouldn't have this special case for plugins that are out of date. 
If they are up to date, using `podspec` tag instead of `framework` tag, then they can specify if the plugin needs to be static or not and Capacitor already handles that.

Also note that we have a list of plugins that we knew that needed to be static so users didn't have to add them with this configuration and we haven't updated the list for 3 years, so probably nobody is needing it anymore.