### PR TITLE
fix(android): respect all allowed origins on modern WebViewCompat JS injection

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -263,7 +263,12 @@ public class Bridge {
                     allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
                 }
             }
-            WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
+            final String finalAllowedOrigin = allowedOrigin;
+            Set<String> allowedOrigins = new HashSet<String>() {{
+                add(finalAllowedOrigin);
+                addAll(allowedOriginRules);
+            }};
+            WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), allowedOrigins);
             injector = null;
         }
         localServer = new WebViewLocalServer(context, this, injector, authorities, html5mode);


### PR DESCRIPTION
Fixes #7454

I applied the fix from @rfe-css at https://github.com/ionic-team/capacitor/issues/7454, but I figured my device would skip this, so please someone can verify this before merge.