### PR TITLE
fix: support dependencies with ".swift" at the end of name

### DIFF
--- a/cli/src/util/iosplugin.ts
+++ b/cli/src/util/iosplugin.ts
@@ -17,7 +17,10 @@ export async function getPluginFiles(plugins: Plugin[]): Promise<string[]> {
 
   const options: ReaddirPOptions = {
     filter: item => {
-      if (item.stats.isFile() && (item.path.endsWith('.swift') || item.path.endsWith('.m'))) {
+      if (
+        item.stats.isFile() &&
+        (item.path.endsWith('.swift') || item.path.endsWith('.m'))
+      ) {
         return true;
       } else {
         return false;

--- a/cli/src/util/iosplugin.ts
+++ b/cli/src/util/iosplugin.ts
@@ -17,7 +17,7 @@ export async function getPluginFiles(plugins: Plugin[]): Promise<string[]> {
 
   const options: ReaddirPOptions = {
     filter: item => {
-      if (item.path.endsWith('.swift') || item.path.endsWith('.m')) {
+      if (item.stats.isFile() && (item.path.endsWith('.swift') || item.path.endsWith('.m'))) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
support dependencies with ".swift" at the end of name
closes #7582 