### PR TITLE
Fix for Capacitor issue 7596, remove fragment from allowedOrigin

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -255,10 +255,11 @@ public class Bridge {
         JSInjector injector = getJSInjector();
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
             String allowedOrigin = appUrl;
-            Uri appUri = Uri.parse(appUrl).buildUpon().clearQuery().build();
+            Uri appUri = Uri.parse(appUrl).buildUpon().clearQuery().fragment(null).build();
             if (appUri.getPath() != null) {
                 if (appUri.getPath().equals("/")) {
-                    allowedOrigin = appUrl.substring(0, appUrl.length() - 1);
+                    String allowedOriginWithSlashPath = appUri.toString();
+                    allowedOrigin = allowedOriginWithSlashPath.substring(0, allowedOriginWithSlashPath.length() - 1);
                 } else {
                     allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
                 }


### PR DESCRIPTION
If the `server.url` contains a fragment, then the `allowedOrigin` rule is not valid and the WebView will not inject plugin javascript. This manifests as the javascript runtime in the WebView reporting that `Capacitor.platform` is `web` instead of `android` and plugin calls within the `WebView` failing.