### PR TITLE
fix(cli): Android apk name multi flavor dimensions parsing

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -590,6 +590,9 @@ export async function checkJDKMajorVersion(): Promise<number> {
 }
 
 export function parseApkNameFromFlavor(flavor: string): string {
-  const convertedName = flavor.replace(/([A-Z])/g, '$1').toLowerCase();
+  let convertedName = flavor.replace(/([A-Z])/g, '-$1').toLowerCase();
+
+  if(convertedName.startsWith('-')) convertedName = convertedName.replace('-', '');
+
   return `app-${convertedName ? `${convertedName}-` : ''}debug.apk`;
 }


### PR DESCRIPTION
Hi @theproducer

Support for multi-dimensional flavors was added with pull request #6704, but it caused an error that added a dash at the beginning of the flavor name when it started with an uppercase letter. This was attempted to be corrected with #7382, but it affected the multi-flavor dimensions parsing.

I propose this solution: revert your commit, but remove the dash if it exists at the beginning of the flavor name.