### PR TITLE
fix(android): better cleaning of allowedOrigin url

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -259,17 +259,13 @@ public class Bridge {
         // Start the local web server
         JSInjector injector = getJSInjector();
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
-            String allowedOrigin = appUrl;
-            Uri appUri = Uri.parse(appUrl).buildUpon().clearQuery().build();
-            if (appUri.getPath() != null) {
-                if (appUri.getPath().equals("/")) {
-                    allowedOrigin = appUrl.substring(0, appUrl.length() - 1);
-                } else {
-                    allowedOrigin = appUri.toString().replace(appUri.getPath(), "");
-                }
+            String allowedOrigin = Uri.parse(appUrl).buildUpon().path(null).fragment(null).clearQuery().build().toString();
+            try {
+                WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
+                injector = null;
+            } catch (IllegalArgumentException ex) {
+                Logger.warn("Invalid url, using fallback");
             }
-            WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
-            injector = null;
         }
         localServer = new WebViewLocalServer(context, this, injector, authorities, html5mode);
         localServer.hostAssets(DEFAULT_WEB_ASSET_DIR);


### PR DESCRIPTION
clean the path and fragment before passing the `allowedOrigin` to `addDocumentStartJavaScript`

Also catch `IllegalArgumentException` in case the url is still not allowed by `addDocumentStartJavaScript` so it uses the old injector instead of crashing the app.

closes https://github.com/ionic-team/capacitor/pull/7597
closes https://github.com/ionic-team/capacitor/issues/7596
closes https://github.com/ionic-team/capacitor/issues/7327