### PR TITLE
fix(cli): replace app-store deprecated method on build

### DIFF
--- a/cli/src/ios/build.ts
+++ b/cli/src/ios/build.ts
@@ -53,7 +53,7 @@ export async function buildiOS(
 <plist version="1.0">
 <dict>
 <key>method</key>
-<string>app-store</string>
+<string>app-store-connect</string>
 </dict>
 </plist>`;
 


### PR DESCRIPTION
`app-store` is deprecated and was replaced with `app-store-connect` in Xcode 14.3.
It doesn't cause build failures yet, but better replace it now before it causes issues or breaks builds in the future.

It won't be cherry picked into 5.x branch since Capacitor 5 supports Xcode 14 and would require additional logic to use one value or the other based on the Xcode version.

closes https://github.com/ionic-team/capacitor/issues/7632