### PR TITLE
feat(ios): JSValueEncoder/Decoder feature parity with JSONEncoder/Decoder

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		A71289EB27F380FD00DADDF3 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71289EA27F380FD00DADDF3 /* RouterTests.swift */; };
 		A7187FD22BD1CB7D00093C45 /* CAPPluginMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */; };
 		A76739792B98E09700795F7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */; };
+		A771ADEE2C8B845000AF234D /* DateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A771ADED2C8B845000AF234D /* DateCodableTests.swift */; };
+		A771ADF12C8B909100AF234D /* URLCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A771ADF02C8B909100AF234D /* URLCodableTests.swift */; };
 		A7BE62CC2B486A5400165ACB /* KeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */; };
 		A7D8B3522B238A840003FAD6 /* JSValueEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */; };
 		A7D8B3632B263B8D0003FAD6 /* NestedCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D8B3622B263B8D0003FAD6 /* NestedCodableTests.swift */; };
@@ -244,6 +246,8 @@
 		A71289EA27F380FD00DADDF3 /* RouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
 		A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAPPluginMethod.swift; sourceTree = "<group>"; };
 		A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		A771ADED2C8B845000AF234D /* DateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCodableTests.swift; sourceTree = "<group>"; };
+		A771ADF02C8B909100AF234D /* URLCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCodableTests.swift; sourceTree = "<group>"; };
 		A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStore.swift; sourceTree = "<group>"; };
 		A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueEncoder.swift; sourceTree = "<group>"; };
 		A7D8B3562B23B2110003FAD6 /* CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTests.swift; sourceTree = "<group>"; };
@@ -475,6 +479,8 @@
 				A7D8B3622B263B8D0003FAD6 /* NestedCodableTests.swift */,
 				A7D8B3562B23B2110003FAD6 /* CodableTests.swift */,
 				A7D8B36D2B2692300003FAD6 /* SuperCodableTests.swift */,
+				A771ADED2C8B845000AF234D /* DateCodableTests.swift */,
+				A771ADF02C8B909100AF234D /* URLCodableTests.swift */,
 			);
 			path = CodableTests;
 			sourceTree = "<group>";
@@ -779,9 +785,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A771ADEE2C8B845000AF234D /* DateCodableTests.swift in Sources */,
 				A7D8B3632B263B8D0003FAD6 /* NestedCodableTests.swift in Sources */,
 				A7D8B36A2B263B990003FAD6 /* CodableTests.swift in Sources */,
 				A7D8B36E2B2692300003FAD6 /* SuperCodableTests.swift in Sources */,
+				A771ADF12C8B909100AF234D /* URLCodableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		A771ADEE2C8B845000AF234D /* DateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A771ADED2C8B845000AF234D /* DateCodableTests.swift */; };
 		A771ADF12C8B909100AF234D /* URLCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A771ADF02C8B909100AF234D /* URLCodableTests.swift */; };
 		A7BE62CC2B486A5400165ACB /* KeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */; };
+		A7D474D52C8BA8E8005620A8 /* DataCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D474D42C8BA8E8005620A8 /* DataCodableTests.swift */; };
+		A7D474D82C8BA8FD005620A8 /* NonconformingFloatCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D474D72C8BA8FD005620A8 /* NonconformingFloatCodableTests.swift */; };
 		A7D8B3522B238A840003FAD6 /* JSValueEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */; };
 		A7D8B3632B263B8D0003FAD6 /* NestedCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D8B3622B263B8D0003FAD6 /* NestedCodableTests.swift */; };
 		A7D8B3642B263B8D0003FAD6 /* Capacitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50503EDF1FC08594003606DC /* Capacitor.framework */; };
@@ -249,6 +251,8 @@
 		A771ADED2C8B845000AF234D /* DateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCodableTests.swift; sourceTree = "<group>"; };
 		A771ADF02C8B909100AF234D /* URLCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCodableTests.swift; sourceTree = "<group>"; };
 		A7BE62CB2B486A5400165ACB /* KeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStore.swift; sourceTree = "<group>"; };
+		A7D474D42C8BA8E8005620A8 /* DataCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCodableTests.swift; sourceTree = "<group>"; };
+		A7D474D72C8BA8FD005620A8 /* NonconformingFloatCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonconformingFloatCodableTests.swift; sourceTree = "<group>"; };
 		A7D8B3512B238A840003FAD6 /* JSValueEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueEncoder.swift; sourceTree = "<group>"; };
 		A7D8B3562B23B2110003FAD6 /* CodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTests.swift; sourceTree = "<group>"; };
 		A7D8B3602B263B8D0003FAD6 /* CodableTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CodableTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -481,6 +485,8 @@
 				A7D8B36D2B2692300003FAD6 /* SuperCodableTests.swift */,
 				A771ADED2C8B845000AF234D /* DateCodableTests.swift */,
 				A771ADF02C8B909100AF234D /* URLCodableTests.swift */,
+				A7D474D42C8BA8E8005620A8 /* DataCodableTests.swift */,
+				A7D474D72C8BA8FD005620A8 /* NonconformingFloatCodableTests.swift */,
 			);
 			path = CodableTests;
 			sourceTree = "<group>";
@@ -787,8 +793,10 @@
 			files = (
 				A771ADEE2C8B845000AF234D /* DateCodableTests.swift in Sources */,
 				A7D8B3632B263B8D0003FAD6 /* NestedCodableTests.swift in Sources */,
+				A7D474D52C8BA8E8005620A8 /* DataCodableTests.swift in Sources */,
 				A7D8B36A2B263B990003FAD6 /* CodableTests.swift in Sources */,
 				A7D8B36E2B2692300003FAD6 /* SuperCodableTests.swift in Sources */,
+				A7D474D82C8BA8FD005620A8 /* NonconformingFloatCodableTests.swift in Sources */,
 				A771ADF12C8B909100AF234D /* URLCodableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
@@ -11,12 +11,18 @@ import Combine
 
 /// A decoder that can decode ``JSValue`` objects into `Decodable` types.
 public final class JSValueDecoder: TopLevelDecoder {
+    /// The strategies available for formatting dates when decoding from a ``JSValue``
     public typealias DateDecodingStrategy = JSONDecoder.DateDecodingStrategy
+    /// The strategies available for decoding raw data.
     public typealias DataDecodingStrategy = JSONDecoder.DataDecodingStrategy
 
+    /// The strategies availble for decoding NaN, Infinity, and -Infinity
     public enum NonConformingFloatDecodingStrategy {
+        /// Decodes directly into the floating point type as .infinity, -.infinity, or .nan
         case deferred
+        /// Throw an error when a non-conforming float is encountered
         case `throw`
+        /// Converts from the provided strings into .infinity, -.infinity, or .nan
         case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
     }
 
@@ -28,6 +34,11 @@ public final class JSValueDecoder: TopLevelDecoder {
 
     private var options: Options
 
+    /// Creates a new JSValueDecoder with the provided decoding and formatting strategies
+    /// - Parameters:
+    ///   - dateDecodingStrategy: Defaults to `DateDecodingStrategy.deferredToDate`
+    ///   - dataDecodingStrategy: Defaults to `DataDecodingStrategy.deferredToData`
+    ///   - nonConformingFloatDecodingStrategy: Defaults to ``NonConformingFloatDecodingStrategy/deferred``
     public init(
         dateDecodingStrategy: DateDecodingStrategy = .deferredToDate,
         dataDecodingStrategy: DataDecodingStrategy = .deferredToData,
@@ -40,9 +51,22 @@ public final class JSValueDecoder: TopLevelDecoder {
         self.options = options
     }
 
+    /// The strategy to use when decoding dates from a ``JSValue``
     public var dateDecodingStrategy: DateDecodingStrategy {
         get { options.dateStrategy }
         set { options.dateStrategy = newValue }
+    }
+
+    /// The strategy to use when decoding raw data from a ``JSValue``
+    public var dataDecodingStrategy: DataDecodingStrategy {
+        get { options.dataStrategy }
+        set { options.dataStrategy = newValue }
+    }
+
+    /// The strategy used by a decoder when it encounters exceptional floating-point values
+    public var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy {
+        get { options.nonConformingStrategy }
+        set { options.nonConformingStrategy = newValue }
     }
 
     /// Decodes a ``JSValue`` into the provided `Decodable` type

--- a/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
@@ -19,9 +19,13 @@ public final class JSValueEncoder: TopLevelEncoder {
         case undefined
     }
 
+    /// The strategies available for encoding .nan, .infinity, and -.infinity
     public enum NonConformingFloatEncodingStrategy: Equatable {
+        /// Throws an error when encountering an exceptional floating-point value
         case `throw`
+        /// Converts to the provided strings
         case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
+        /// Encodes directly into an NSNumber
         case deferred
     }
 
@@ -46,20 +50,29 @@ public final class JSValueEncoder: TopLevelEncoder {
         set { options.optionalStrategy = newValue }
     }
 
-    /// The strategy to use when encoding dates.
+    /// The strategy to use when encoding dates
     public var dateEncodingStrategy: DateEncodingStrategy {
         get { options.dateStrategy }
         set { options.dateStrategy = newValue }
     }
 
+    /// The encoding strategy to use when encoding raw data
     public var dataEncodingStrategy: DataEncodingStrategy {
         get { options.dataStrategy }
         set { options.dataStrategy = newValue }
     }
 
+    /// The encoding strategy to use when the encoder encounters exceptional floating-point values
+    public var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy {
+        get { options.nonConformingFloatStrategy }
+        set { options.nonConformingFloatStrategy = newValue }
+    }
+
     /// Creates a new `JSValueEncoder`
-    /// - Parameter optionalEncodingStrategy: The strategy to use when encoding `nil` values
-    /// - Parameter dateEncodingStrategy: The date encoding strategy.
+    /// - Parameter optionalEncodingStrategy: The strategy to use when encoding `nil` values. Defaults to ``OptionalEncodingStrategy-swift.enum/undefined``
+    /// - Parameter dateEncodingStrategy: Defaults to `DateEncodingStrategy.deferredToDate`
+    /// - Parameter dataEncodingStrategy: Defaults to `DataEncodingStrategy.deferredToData`
+    /// - Parameter nonConformingFloatEncodingStategy: Defaults to ``NonConformingFloatEncodingStrategy-swift.enum/deferred``
     public init(
         optionalEncodingStrategy: OptionalEncodingStrategy = .undefined,
         dateEncodingStrategy: DateEncodingStrategy = .deferredToDate,

--- a/ios/Capacitor/CodableTests/DataCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DataCodableTests.swift
@@ -1,0 +1,156 @@
+//
+//  DataCodableTests.swift
+//  CodableTests
+//
+//  Created by Steven Sherry on 9/6/24.
+//  Copyright © 2024 Drifty Co. All rights reserved.
+//
+
+import XCTest
+import Capacitor
+
+private struct Foo: Codable, Equatable {
+    var data: Data
+}
+
+private let jsonString = #"{ "key": "value" }"#
+private let jsonData = jsonString.data(using: .utf8)!
+private let jsonByteArray: [NSNumber] = [123, 32, 34, 107, 101, 121, 34, 58, 32, 34, 118, 97, 108, 117, 101, 34, 32, 125]
+private let jsonBase64 = "eyAia2V5IjogInZhbHVlIiB9"
+
+class JSValueDecoderDataTests: XCTestCase {
+    func testDecode_data__default_root() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode(Data.self, from: jsonByteArray)
+        XCTAssertEqual(result, jsonData)
+    }
+
+    func testDecode_data__default_array() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode([Data].self, from: [jsonByteArray, jsonByteArray])
+        XCTAssertEqual(result, [jsonData, jsonData])
+    }
+
+    func testDecode_data__default_struct() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode(Foo.self, from: ["data": jsonByteArray])
+        XCTAssertEqual(result, .init(data: jsonData))
+    }
+
+    func testDecode_data__base64_root() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: .base64)
+        let result = try decoder.decode(Data.self, from: jsonBase64)
+        XCTAssertEqual(result, jsonData)
+    }
+
+    func testDecode_data__base64_array() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: .base64)
+        let result = try decoder.decode([Data].self, from: [jsonBase64, jsonBase64])
+        XCTAssertEqual(result, [jsonData, jsonData])
+    }
+
+    func testDecode_data__base64_struct() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: .base64)
+        let result = try decoder.decode(Foo.self, from: ["data": jsonBase64])
+        XCTAssertEqual(result, .init(data: jsonData))
+    }
+
+    let customStrategy = JSValueDecoder.DataDecodingStrategy.custom { decoder in
+        var container = try decoder.unkeyedContainer()
+        var byteArray: [UInt8] = []
+        while !container.isAtEnd {
+            byteArray.append(try container.decode(UInt8.self))
+        }
+        return Data(byteArray)
+    }
+
+    func testDecode_data__custom_root() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: customStrategy)
+        let result = try decoder.decode(Data.self, from: jsonByteArray)
+        XCTAssertEqual(result, jsonData)
+    }
+
+    func testDecode_data__custom_array() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: customStrategy)
+        let result = try decoder.decode([Data].self, from: [jsonByteArray, jsonByteArray])
+        XCTAssertEqual(result, [jsonData, jsonData])
+    }
+
+    func testDecode_data__custom_struct() throws {
+        let decoder = JSValueDecoder(dataDecodingStrategy: customStrategy)
+        let result = try decoder.decode(Foo.self, from: ["data": jsonByteArray])
+        XCTAssertEqual(result, .init(data: jsonData))
+    }
+}
+
+class JSValueEncoderDataTests: XCTestCase {
+    func testEncode_data__default_root() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode(jsonData)
+        let result = try XCTUnwrap(rawResult as? [NSNumber])
+        XCTAssertEqual(result, jsonByteArray)
+    }
+
+    func testEncode_data__default_array() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode([jsonData, jsonData])
+        let result = try XCTUnwrap(rawResult as? [[NSNumber]])
+        XCTAssertEqual(result, [jsonByteArray, jsonByteArray])
+    }
+
+    func testEncode_data__default_struct() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode(Foo(data: jsonData))
+        let result = try XCTUnwrap(rawResult as? [String: [NSNumber]])
+        XCTAssertEqual(result, ["data": jsonByteArray])
+    }
+
+    func testEncode_data__base64_root() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: .base64)
+        let rawResult = try encoder.encode(jsonData)
+        let result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, jsonBase64)
+    }
+
+    func testEncode_data__base64_array() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: .base64)
+        let rawResult = try encoder.encode([jsonData, jsonData])
+        let result = try XCTUnwrap(rawResult as? [String])
+        XCTAssertEqual(result, [jsonBase64, jsonBase64])
+    }
+
+    func testEncode_data__base64_struct() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: .base64)
+        let rawResult = try encoder.encode(Foo(data: jsonData))
+        let result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["data": jsonBase64])
+    }
+
+    let customStrategy = JSValueEncoder.DataEncodingStrategy.custom { data, encoder in
+        let byteArray = data.map { $0 }
+        var unkeyedContainer = encoder.unkeyedContainer()
+        try unkeyedContainer.encode(contentsOf: byteArray)
+    }
+
+
+    func testEncode_data__custom_root() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: customStrategy)
+        let rawResult = try encoder.encode(jsonData)
+        let result = try XCTUnwrap(rawResult as? [NSNumber])
+        XCTAssertEqual(result, jsonByteArray)
+    }
+
+    func testEncode_data__custom_array() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: customStrategy)
+        let rawResult = try encoder.encode([jsonData, jsonData])
+        let result = try XCTUnwrap(rawResult as? [[NSNumber]])
+        XCTAssertEqual(result, [jsonByteArray, jsonByteArray])
+    }
+
+    func testEncode_data__custom_struct() throws {
+        let encoder = JSValueEncoder(dataEncodingStrategy: customStrategy)
+        let rawResult = try encoder.encode(Foo(data: jsonData))
+        let result = try XCTUnwrap(rawResult as? [String: [NSNumber]])
+        XCTAssertEqual(result, ["data": jsonByteArray])
+    }
+}

--- a/ios/Capacitor/CodableTests/DateCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DateCodableTests.swift
@@ -1,0 +1,158 @@
+//
+//  DateCodableTests.swift
+//  CodableTests
+//
+//  Created by Steven Sherry on 9/6/24.
+//  Copyright © 2024 Drifty Co. All rights reserved.
+//
+
+import XCTest
+import Capacitor
+
+// Fixture data that all refers to the same Date and Time
+private let timeIntervalSinceReferenceDate: TimeInterval = 747268580
+private let referenceDate = Date(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDate)
+private let secondsSince1970 = 1725575780 as Double
+private let millisecondsSince1970 = 1725575780000 as Double
+private let iso8601 = "2024-09-05T22:36:20Z"
+
+private let formatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .long
+    formatter.timeZone = .init(abbreviation: "CDT")
+    return formatter
+}()
+private let formatted = "Sep 5, 2024 at 5:36:20 PM CDT" 
+
+private struct Foo: Codable, Equatable {
+    var date: Date
+}
+
+
+final class JSValueDecoderDateTests: XCTestCase {
+    func testDecode_date__default() throws {
+        let reference = timeIntervalSinceReferenceDate
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode(Date.self, from: reference)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__secondsSince1970() throws {
+        let decoder = JSValueDecoder(dateDecodingStrategy: .secondsSince1970)
+        let result = try decoder.decode(Date.self, from: secondsSince1970)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__millisecondsSince1970() throws {
+        let decoder = JSValueDecoder(dateDecodingStrategy: .millisecondsSince1970)
+        let result = try decoder.decode(Date.self, from: millisecondsSince1970)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__iso8601() throws {
+        let decoder = JSValueDecoder(dateDecodingStrategy: .iso8601)
+        let result = try decoder.decode(Date.self, from: iso8601)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__formatted() throws {
+        let decoder = JSValueDecoder(dateDecodingStrategy: .formatted(formatter))
+        let result = try decoder.decode(Date.self, from: formatted)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__custom() throws {
+        let strategy = JSValueDecoder.DateDecodingStrategy.custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let referenceDateString = try container.decode(String.self)
+            guard let referenceDateSeconds = Double(referenceDateString) else {
+                throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Unable to decode Double from String"))
+            }
+            return Date(timeIntervalSinceReferenceDate: referenceDateSeconds)
+        }
+
+        let referenceString = "\(timeIntervalSinceReferenceDate)"
+        let decoder = JSValueDecoder(dateDecodingStrategy: strategy)
+        let result = try decoder.decode(Date.self, from: referenceString)
+        XCTAssertEqual(result, referenceDate)
+    }
+
+    func testDecode_date__array() throws {
+        let dateArray = [iso8601, iso8601]
+        let decoder = JSValueDecoder(dateDecodingStrategy: .iso8601)
+        let result = try decoder.decode([Date].self, from: dateArray)
+        XCTAssertEqual(result, [referenceDate, referenceDate])
+    }
+
+    func testDecode_date__struct() throws {
+        let value = ["date": iso8601] as JSObject
+        let decoder = JSValueDecoder(dateDecodingStrategy: .iso8601)
+        let result = try decoder.decode(Foo.self, from: value)
+        XCTAssertEqual(result, Foo(date: referenceDate))
+    }
+}
+
+final class JSValueEncoderDateTests: XCTestCase {
+    func testEncode_date__default() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? Double)
+        XCTAssertEqual(result, timeIntervalSinceReferenceDate)
+    }
+
+    func testEncode_date__secondsSince1970() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .secondsSince1970)
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? Double)
+        XCTAssertEqual(result, secondsSince1970)
+    }
+
+    func testEncode_date__millisecondsSince1970() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .millisecondsSince1970)
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? Double)
+        XCTAssertEqual(result, millisecondsSince1970)
+    }
+
+    func testEncode_date__iso8601() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .iso8601)
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, iso8601)
+    }
+
+    func testEncode_date__formatted() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .formatted(formatter))
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, formatted)
+    }
+
+    func testEncode_date__custom() throws {
+        let strategy = JSValueEncoder.DateEncodingStrategy.custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode("\(date.timeIntervalSinceReferenceDate)")
+        }
+
+        let encoder = JSValueEncoder(dateEncodingStrategy: strategy)
+        let rawResult = try encoder.encode(referenceDate)
+        let result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, "\(timeIntervalSinceReferenceDate)")
+    }
+
+    func testEncode_date__array() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .iso8601)
+        let array = [referenceDate, referenceDate]
+        let rawResult = try encoder.encode(array)
+        let result = try XCTUnwrap(rawResult as? [String])
+        XCTAssertEqual(result, [iso8601, iso8601])
+    }
+
+    func testEncode_date__struct() throws {
+        let encoder = JSValueEncoder(dateEncodingStrategy: .iso8601)
+        let rawResult = try encoder.encode(Foo(date: referenceDate))
+        let result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["date": iso8601])
+    }
+}

--- a/ios/Capacitor/CodableTests/DateCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DateCodableTests.swift
@@ -154,5 +154,9 @@ final class JSValueEncoderDateTests: XCTestCase {
         let rawResult = try encoder.encode(Foo(date: referenceDate))
         let result = try XCTUnwrap(rawResult as? [String: String])
         XCTAssertEqual(result, ["date": iso8601])
+
+        let json = #"{ "key": "value" }"#.data(using: .utf8)!
+        let rawJsonData = try encoder.encode(json)
+        print(rawJsonData)
     }
 }

--- a/ios/Capacitor/CodableTests/DateCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DateCodableTests.swift
@@ -154,9 +154,5 @@ final class JSValueEncoderDateTests: XCTestCase {
         let rawResult = try encoder.encode(Foo(date: referenceDate))
         let result = try XCTUnwrap(rawResult as? [String: String])
         XCTAssertEqual(result, ["date": iso8601])
-
-        let json = #"{ "key": "value" }"#.data(using: .utf8)!
-        let rawJsonData = try encoder.encode(json)
-        print(rawJsonData)
     }
 }

--- a/ios/Capacitor/CodableTests/NonconformingFloatCodableTests.swift
+++ b/ios/Capacitor/CodableTests/NonconformingFloatCodableTests.swift
@@ -1,0 +1,174 @@
+//
+//  NonconformingFloatCodableTests.swift
+//  CodableTests
+//
+//  Created by Steven Sherry on 9/6/24.
+//  Copyright © 2024 Drifty Co. All rights reserved.
+//
+
+import XCTest
+import Capacitor
+
+private struct Foo: Codable, Equatable {
+    var number: Double
+}
+
+class JSValueEncoderNonConformingFloatTests: XCTestCase {
+    func testEncode_float__default_root() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode(Double.infinity)
+        let result = try XCTUnwrap(rawResult as? Double)
+        XCTAssertEqual(result, .infinity)
+    }
+
+    func testEncode_float__default_array() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode([Double.infinity, -.infinity, .nan])
+        let result = try XCTUnwrap(rawResult as? [Double])
+        XCTAssertEqual(result[0...1], [.infinity, -.infinity])
+        XCTAssertTrue(result[2].isNaN)
+    }
+
+
+    func testEncode_float__default_struct() throws {
+        let encoder = JSValueEncoder()
+        let rawResult = try encoder.encode(Foo.init(number: .infinity))
+        let result = try XCTUnwrap(rawResult as? [String: Double])
+        XCTAssertEqual(result, ["number": .infinity])
+    }
+
+    func testEncode_float__convertToString_root() throws {
+        let encoder = JSValueEncoder(
+            nonConformingFloatEncodingStategy: .convertToString(
+                positiveInfinity: "pos",
+                negativeInfinity: "neg",
+                nan: "nan"
+            )
+        )
+
+        var rawResult = try encoder.encode(Double.infinity)
+        var result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, "pos")
+
+        rawResult = try encoder.encode(-Double.infinity)
+        result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, "neg")
+
+        rawResult = try encoder.encode(Double.nan)
+        result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, "nan")
+    }
+
+    func testEncode_float__convertToString_array() throws {
+        let encoder = JSValueEncoder(
+            nonConformingFloatEncodingStategy: .convertToString(
+                positiveInfinity: "pos",
+                negativeInfinity: "neg",
+                nan: "nan"
+            )
+        )
+
+        let rawResult = try encoder.encode([Double.infinity, -.infinity, .nan])
+        let result = try XCTUnwrap(rawResult as? [String])
+        XCTAssertEqual(result, ["pos", "neg", "nan"])
+    }
+
+    func testEncode_float__convertToString_struct() throws {
+        let encoder = JSValueEncoder(
+            nonConformingFloatEncodingStategy: .convertToString(
+                positiveInfinity: "pos",
+                negativeInfinity: "neg",
+                nan: "nan"
+            )
+        )
+
+        var rawResult = try encoder.encode(Foo(number: .infinity))
+        var result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["number": "pos"])
+
+        rawResult = try encoder.encode(Foo(number: -.infinity))
+        result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["number": "neg"])
+
+        rawResult = try encoder.encode(Foo(number: .nan))
+        result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["number": "nan"])
+    }
+
+    func testEncode_float__throw_root() throws {
+        let encoder = JSValueEncoder(nonConformingFloatEncodingStategy: .throw)
+        XCTAssertThrowsError(try encoder.encode(Double.infinity))
+    }
+
+    func testEncode_float__throw_array() throws {
+        let encoder = JSValueEncoder(nonConformingFloatEncodingStategy: .throw)
+        XCTAssertThrowsError(try encoder.encode([Double.infinity, -.infinity, .nan]))
+    }
+
+    func testEncode_float__throw_struct() throws {
+        let encoder = JSValueEncoder(nonConformingFloatEncodingStategy: .throw)
+        XCTAssertThrowsError(try encoder.encode(Foo(number: .infinity)))
+    }
+}
+
+class JSValueDecoderNonConformingFloatTests: XCTestCase {
+    func testDecode_float__default_root() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode(Double.self, from: Double.infinity)
+        XCTAssertEqual(result, .infinity)
+    }
+
+    func testDecode_float__default_array() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode([Double].self, from: [Double.infinity, Double.infinity])
+        XCTAssertEqual(result, [.infinity, .infinity])
+    }
+
+    func testDecode_float__default_struct() throws {
+        let decoder = JSValueDecoder()
+        let result = try decoder.decode(Foo.self, from: ["number": Double.infinity])
+        XCTAssertEqual(result, .init(number: .infinity))
+    }
+
+    func testDecode_float__throw_root() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .throw)
+        XCTAssertThrowsError(try decoder.decode(Double.self, from: Double.infinity))
+    }
+
+    func testDecode_float__throw_array() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .throw)
+        XCTAssertThrowsError(try decoder.decode([Double].self, from: [Double.infinity, Double.infinity]))
+    }
+
+    func testDecode_float__throw_struct() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .throw)
+        XCTAssertThrowsError(try decoder.decode(Foo.self, from: ["number": Double.infinity]))
+    }
+
+    func testDecode_float__convertFromString_root() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .convertFromString(positiveInfinity: "pos", negativeInfinity: "neg", nan: "nan"))
+        var result = try decoder.decode(Double.self, from: "pos")
+        XCTAssertEqual(result, .infinity)
+        result = try decoder.decode(Double.self, from: "neg")
+        XCTAssertEqual(result, -.infinity)
+        result = try decoder.decode(Double.self, from: "nan")
+        XCTAssertTrue(result.isNaN)
+    }
+
+    func testDecode_float__convertFromString_array() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .convertFromString(positiveInfinity: "pos", negativeInfinity: "neg", nan: "nan"))
+        let result = try decoder.decode([Double].self, from: ["pos", "neg", "nan"])
+        XCTAssertEqual(result[0...1], [.infinity, -.infinity])
+        XCTAssertTrue(result[2].isNaN)
+    }
+
+    func testDecode_float__convertFromString_struct() throws {
+        let decoder = JSValueDecoder(nonConformingFloatDecodingStrategy: .convertFromString(positiveInfinity: "pos", negativeInfinity: "neg", nan: "nan"))
+        var result = try decoder.decode(Foo.self, from: ["number": "pos"])
+        XCTAssertEqual(result, .init(number: .infinity))
+        result = try decoder.decode(Foo.self, from: ["number": "neg"])
+        XCTAssertEqual(result, .init(number: -.infinity))
+        result = try decoder.decode(Foo.self, from: ["number":"nan"])
+        XCTAssertTrue(result.number.isNaN)
+    }
+}

--- a/ios/Capacitor/CodableTests/URLCodableTests.swift
+++ b/ios/Capacitor/CodableTests/URLCodableTests.swift
@@ -1,0 +1,62 @@
+//
+//  URLCodableTests.swift
+//  CodableTests
+//
+//  Created by Steven Sherry on 9/6/24.
+//  Copyright © 2024 Drifty Co. All rights reserved.
+//
+
+import XCTest
+import Capacitor
+
+private let urlString = "https://capacitorjs.com"
+private let url = URL(string: urlString)!
+
+private struct Website: Codable, Equatable {
+    var url: URL
+}
+
+class JSValueDecoderURLTests: XCTestCase {
+    let decoder = JSValueDecoder()
+
+    func testDecode_url__root() throws {
+        let result = try decoder.decode(URL.self, from: urlString)
+        XCTAssertEqual(result, url)
+    }
+
+    func testDecode_url__array() throws {
+        let result = try decoder.decode([URL].self, from: [urlString, urlString])
+        XCTAssertEqual(result, [url, url])
+    }
+
+    func testDecode_url__struct() throws {
+        let result = try decoder.decode(Website.self, from: ["url": urlString])
+        XCTAssertEqual(result, .init(url: url))
+    }
+
+    func testDecode_url__fails_when_invalid_url_string_is_provided() {
+        XCTAssertThrowsError(try decoder.decode(URL.self, from: "🐞://🐞.com/🐞"))
+    }
+}
+
+class JSValueEncoderURLTests: XCTestCase {
+    let encoder = JSValueEncoder()
+
+    func testEncode_url__root() throws {
+        let rawResult = try encoder.encode(url)
+        let result = try XCTUnwrap(rawResult as? String)
+        XCTAssertEqual(result, urlString)
+    }
+
+    func testEncode_url__array() throws {
+        let rawResult = try encoder.encode([url, url])
+        let result = try XCTUnwrap(rawResult as? [String])
+        XCTAssertEqual(result, [urlString, urlString])
+    }
+
+    func testEncode_url__struct() throws {
+        let rawResult = try encoder.encode(Website(url: url))
+        let result = try XCTUnwrap(rawResult as? [String: String])
+        XCTAssertEqual(result, ["url": urlString])
+    }
+}


### PR DESCRIPTION
The default implementation of URL encodes to/decodes from a dictionary, while Date by default encodes to/decodes from seconds since January 1, 2001.

This implementation is similar to the method for handling dates and urls in [Foundation](https://github.com/apple/swift-foundation/blob/da80d51fa3e77f3e7ed57c4300a870689e755713/Sources/FoundationEssentials/JSON/JSONEncoder.swift#L1140).