### PR TITLE
feat(ios) (issue #7664) Add PMTiles to mediaExtensions

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -123,7 +123,8 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
 
     open func isMediaExtension(pathExtension: String) -> Bool {
         let mediaExtensions = ["m4v", "mov", "mp4",
-                               "aac", "ac3", "aiff", "au", "flac", "m4a", "mp3", "wav"]
+                               "aac", "ac3", "aiff", "au", "flac", "m4a", "mp3", "wav",
+                               "pmtiles"]
         if mediaExtensions.contains(pathExtension.lowercased()) {
             return true
         }


### PR DESCRIPTION
PMTiles relies on byte range requests to serve vector tiles. See https://github.com/protomaps/PMTiles/blob/6f54794/js/index.ts#L380 for example of client request.