### PR TITLE
chore: include proper template folders for swiftlint

### DIFF
--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -492,13 +492,13 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
             let pluginCall = CAPPluginCall(callbackId: call.callbackId,
                                            options: JSTypes.coerceDictionaryToJSObject(call.options,
                                                                                        formattingDatesAsStrings: plugin.shouldStringifyDatesInCalls) ?? [:],
-                                           success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) -> Void in
+                                           success: {(result: CAPPluginCallResult?, pluginCall: CAPPluginCall?) in
                                             if let result = result {
                                                 self?.toJs(result: JSResult(call: call, callResult: result), save: pluginCall?.keepAlive ?? false)
                                             } else {
                                                 self?.toJs(result: JSResult(call: call, result: .dictionary([:])), save: pluginCall?.keepAlive ?? false)
                                             }
-                                           }, error: {(error: CAPPluginCallError?) -> Void in
+                                           }, error: {(error: CAPPluginCallError?) in
                                             if let error = error {
                                                 self?.toJsError(error: JSResultError(call: call, callError: error))
                                             } else {

--- a/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
@@ -130,7 +130,7 @@ extension _JSValueDecoder: Decoder {
     // force casting is fine becasue we've already determined that T is the type in the case
     // the swift standard library also force casts in their similar functions
     // https://github.com/swiftlang/swift-foundation/blob/da80d51fa3e77f3e7ed57c4300a870689e755713/Sources/FoundationEssentials/JSON/JSONEncoder.swift#L1140
-    //swiftlint:disable force_cast
+    // swiftlint:disable force_cast
     fileprivate func decodeData<T>(as type: T.Type) throws -> T where T: Decodable {
         switch type {
         case is Date.Type:
@@ -143,7 +143,7 @@ extension _JSValueDecoder: Decoder {
             return try T(from: self)
         }
     }
-    //swiftlint:enable force_cast
+    // swiftlint:enable force_cast
 
     private func decodeDate() throws -> Date {
         switch options.dateStrategy {
@@ -162,8 +162,8 @@ extension _JSValueDecoder: Decoder {
             return date
         case .formatted(let formatter):
             guard let value = data as? String else { throw DecodingError.dataCorrupted(data, target: String.self, codingPath: codingPath) }
-              guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
-              return date
+            guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
+            return date
         case .custom(let decode):
             return try decode(self)
         @unknown default:
@@ -173,7 +173,7 @@ extension _JSValueDecoder: Decoder {
 
     private func decodeUrl() throws -> URL {
         guard let str = data as? String,
-            let url = URL(string: str)
+              let url = URL(string: str)
         else { throw DecodingError.dataCorrupted(data, target: URL.self, codingPath: codingPath) }
 
         return url
@@ -371,7 +371,7 @@ extension SingleValueContainer: SingleValueDecodingContainer {
 
     private func castFloat<N>(to type: N.Type) throws -> N where N: FloatingPoint {
         if let data = data as? String,
-            case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
+           case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
             switch data {
             case pos:
                 return N.infinity

--- a/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
@@ -146,8 +146,8 @@ extension _JSValueDecoder: Decoder {
                 return date as! T
             case .formatted(let formatter):
                 guard let value = data as? String else { throw DecodingError.dataCorrupted(data, target: String.self, codingPath: codingPath) }
-                  guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
-                  return date as! T
+                guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
+                return date as! T
             case .custom(let decode):
                 return try decode(self) as! T
             @unknown default:
@@ -155,7 +155,7 @@ extension _JSValueDecoder: Decoder {
             }
         case is URL.Type:
             guard let str = data as? String,
-                let url = URL(string: str)
+                  let url = URL(string: str)
             else { throw DecodingError.dataCorrupted(data, target: URL.self, codingPath: codingPath) }
 
             return url as! T
@@ -354,7 +354,7 @@ extension SingleValueContainer: SingleValueDecodingContainer {
 
     private func castFloat<N>(to type: N.Type) throws -> N where N: FloatingPoint {
         if let data = data as? String,
-            case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
+           case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
             switch data {
             case pos:
                 return N.infinity

--- a/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueDecoder.swift
@@ -146,8 +146,8 @@ extension _JSValueDecoder: Decoder {
                 return date as! T
             case .formatted(let formatter):
                 guard let value = data as? String else { throw DecodingError.dataCorrupted(data, target: String.self, codingPath: codingPath) }
-                guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
-                return date as! T
+                  guard let date = formatter.date(from: value) else { throw DecodingError.dataCorrupted(value, target: Date.self, codingPath: codingPath) }
+                  return date as! T
             case .custom(let decode):
                 return try decode(self) as! T
             @unknown default:
@@ -155,7 +155,7 @@ extension _JSValueDecoder: Decoder {
             }
         case is URL.Type:
             guard let str = data as? String,
-                  let url = URL(string: str)
+                let url = URL(string: str)
             else { throw DecodingError.dataCorrupted(data, target: URL.self, codingPath: codingPath) }
 
             return url as! T
@@ -354,7 +354,7 @@ extension SingleValueContainer: SingleValueDecodingContainer {
 
     private func castFloat<N>(to type: N.Type) throws -> N where N: FloatingPoint {
         if let data = data as? String,
-           case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
+            case let .convertFromString(positiveInfinity: pos, negativeInfinity: neg, nan: nan) = options.nonConformingStrategy {
             switch data {
             case pos:
                 return N.infinity

--- a/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
@@ -595,7 +595,7 @@ extension SingleValueContainer: SingleValueEncodingContainer {
         try encodeFloat(value)
     }
 
-    //swiftlint:disable force_cast
+    // swiftlint:disable force_cast
     private func encodeFloat<N>(_ value: N) throws where N: FloatingPoint {
         if value.isFinite {
             data = value as! NSNumber
@@ -615,7 +615,7 @@ extension SingleValueContainer: SingleValueEncodingContainer {
             }
         }
     }
-    //swiftlint:enable force_cast
+    // swiftlint:enable force_cast
 
     func encode(_ value: Float) throws {
         try encodeFloat(value)

--- a/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
+++ b/ios/Capacitor/Capacitor/Codable/JSValueEncoder.swift
@@ -82,7 +82,6 @@ public final class JSValueEncoder: TopLevelEncoder {
         self.options = .init(optionalStrategy: optionalEncodingStrategy, dateStrategy: dateEncodingStrategy, dataStrategy: dataEncodingStrategy, nonConformingFloatStrategy: nonConformingFloatEncodingStategy)
     }
 
-
     /// Encodes an `Encodable` value to a ``JSValue``
     /// - Parameter value: The value to encode to ``JSValue``
     /// - Returns: The encoded ``JSValue``

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -133,7 +133,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
     func handleCapacitorHttpRequest(_ urlSchemeTask: WKURLSchemeTask, _ localUrl: URL, _ isHttpsRequest: Bool) {
         var urlRequest = urlSchemeTask.request
         guard let url = urlRequest.url else { return }
-        
+
         let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
         if let targetUrl = urlComponents?.queryItems?.first(where: { $0.name == CapacitorBridge.httpInterceptorUrlParam })?.value,
            !targetUrl.isEmpty {

--- a/ios/Capacitor/CodableTests/DataCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DataCodableTests.swift
@@ -132,7 +132,6 @@ class JSValueEncoderDataTests: XCTestCase {
         try unkeyedContainer.encode(contentsOf: byteArray)
     }
 
-
     func testEncode_data__custom_root() throws {
         let encoder = JSValueEncoder(dataEncodingStrategy: customStrategy)
         let rawResult = try encoder.encode(jsonData)

--- a/ios/Capacitor/CodableTests/DateCodableTests.swift
+++ b/ios/Capacitor/CodableTests/DateCodableTests.swift
@@ -23,12 +23,11 @@ private let formatter: DateFormatter = {
     formatter.timeZone = .init(abbreviation: "CDT")
     return formatter
 }()
-private let formatted = "Sep 5, 2024 at 5:36:20 PM CDT" 
+private let formatted = "Sep 5, 2024 at 5:36:20 PM CDT"
 
 private struct Foo: Codable, Equatable {
     var date: Date
 }
-
 
 final class JSValueDecoderDateTests: XCTestCase {
     func testDecode_date__default() throws {

--- a/ios/Capacitor/CodableTests/NonconformingFloatCodableTests.swift
+++ b/ios/Capacitor/CodableTests/NonconformingFloatCodableTests.swift
@@ -29,7 +29,6 @@ class JSValueEncoderNonConformingFloatTests: XCTestCase {
         XCTAssertTrue(result[2].isNaN)
     }
 
-
     func testEncode_float__default_struct() throws {
         let encoder = JSValueEncoder()
         let rawResult = try encoder.encode(Foo.init(number: .infinity))
@@ -168,7 +167,7 @@ class JSValueDecoderNonConformingFloatTests: XCTestCase {
         XCTAssertEqual(result, .init(number: .infinity))
         result = try decoder.decode(Foo.self, from: ["number": "neg"])
         XCTAssertEqual(result, .init(number: -.infinity))
-        result = try decoder.decode(Foo.self, from: ["number":"nan"])
+        result = try decoder.decode(Foo.self, from: ["number": "nan"])
         XCTAssertTrue(result.number.isNaN)
     }
 }

--- a/swiftlint.config.js
+++ b/swiftlint.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   ...require('@ionic/swiftlint-config'),
-  included: ['${PWD}/ios', '${PWD}/ios-template'],
+  included: [
+    '${PWD}/ios',
+    '${PWD}/ios-pods-template',
+    '${PWD}/ios-spm-template',
+  ],
   excluded: [
     '${PWD}/ios/Capacitor/CapacitorTests',
     '${PWD}/ios/Capacitor/TestsHostApp',


### PR DESCRIPTION
The ios template was renamed last year but the path in `swiftlint.config.js` was not adjusted and also the SPM template was not added, so corrected the path and added the SPM path too.

Then ran `npm run fmt` with swiftlint 0.57.0 and it made those changes.

We have some tests folders in the excluded lists, not sure why, but not the `CodableTests` folders, not sure if we want to exclude that too, or remove the exclusion of the other tests folders.