### PR TITLE
chore(android-template): update minSdkVersion to 23

### DIFF
--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 23
     compileSdkVersion = 34
     targetSdkVersion = 34
     androidxActivityVersion = '1.8.0'


### PR DESCRIPTION
Bump the `minSdkVersion` of Capacitor-generated Android projects to API level 23.