### PR TITLE
chore(android)!: Bump default minSdkVersion to 23

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -44,7 +44,7 @@ android {
     namespace "com.getcapacitor.android"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34
         versionCode 1
         versionName "1.0"

--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -104,8 +104,6 @@ public class BridgeWebChromeClient extends WebChromeClient {
 
     @Override
     public void onPermissionRequest(final PermissionRequest request) {
-        boolean isRequestPermissionRequired = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M;
-
         List<String> permissionList = new ArrayList<>();
         if (Arrays.asList(request.getResources()).contains("android.webkit.resource.VIDEO_CAPTURE")) {
             permissionList.add(Manifest.permission.CAMERA);
@@ -114,7 +112,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
             permissionList.add(Manifest.permission.MODIFY_AUDIO_SETTINGS);
             permissionList.add(Manifest.permission.RECORD_AUDIO);
         }
-        if (!permissionList.isEmpty() && isRequestPermissionRequired) {
+        if (!permissionList.isEmpty()) {
             String[] permissions = permissionList.toArray(new String[0]);
             permissionListener =
                 isGranted -> {


### PR DESCRIPTION
And remove code that becomes irrelevant after the change since on android 23+ you always have to request the permissions.