### PR TITLE
chore(cli): bump default minSdkVersion to 23

### DIFF
--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -19,7 +19,7 @@ android {
     namespace "capacitor.cordova.android.plugins"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
         targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34
         versionCode 1
         versionName "1.0"

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -270,7 +270,7 @@ async function loadAndroidConfig(
 
   return {
     name,
-    minVersion: '22',
+    minVersion: '23',
     studioPath,
     platformDir,
     platformDirAbs,


### PR DESCRIPTION
In the CLI config and capacitor-cordova-android-plugins module since it's shipped with the CLI