### PR TITLE
fix(ios): fix retain cycle caused by CDVPluginManager

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPluginManager.h
@@ -15,8 +15,8 @@
 @property (nonatomic, strong) NSMutableDictionary * pluginsMap;
 @property (nonatomic, strong) NSMutableDictionary * pluginObjects;
 @property (nonatomic, strong) NSMutableDictionary * settings;
-@property (nonatomic, strong) UIViewController * viewController;
-@property (nonatomic, strong) WKWebView * webView;
+@property (nonatomic, weak) UIViewController * viewController;
+@property (nonatomic, weak) WKWebView * webView;
 @property (nonatomic, strong) id <CDVCommandDelegate> commandDelegate;
 
 - (id)initWithParser:(CDVConfigParser*)parser viewController:(UIViewController*)viewController webView:(WKWebView *)webview;


### PR DESCRIPTION
This strong reference to the `UIViewController` and `WKWebView` owned by Capacitor causes a retain cycle that does not allow for anything to be released from memory when using Cordova plugins. This issue isn't present in typical Capacitor applications, but any scenario where a `CAPBridgeViewController` that uses Cordova plugins is presented will stay in memory even when the view controller is dismissed.