### PR TITLE
refactor!: Remove redundant PluginCall methods success() and error()

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -50,25 +50,6 @@ public class PluginCall {
         this.msgHandler.sendResponseMessage(this, successResult, null);
     }
 
-    /**
-     * @deprecated
-     * Use {@link #resolve(JSObject data)}
-     */
-    @Deprecated
-    public void success(JSObject data) {
-        PluginResult result = new PluginResult(data);
-        this.msgHandler.sendResponseMessage(this, result, null);
-    }
-
-    /**
-     * @deprecated
-     * Use {@link #resolve()}
-     */
-    @Deprecated
-    public void success() {
-        this.resolve(new JSObject());
-    }
-
     public void resolve(JSObject data) {
         PluginResult result = new PluginResult(data);
         this.msgHandler.sendResponseMessage(this, result, null);
@@ -88,33 +69,6 @@ public class PluginCall {
         }
 
         this.msgHandler.sendResponseMessage(this, null, errorResult);
-    }
-
-    /**
-     * @deprecated
-     * Use {@link #reject(String msg, Exception ex)}
-     */
-    @Deprecated
-    public void error(String msg, Exception ex) {
-        reject(msg, ex);
-    }
-
-    /**
-     * @deprecated
-     * Use {@link #reject(String msg, String code, Exception ex)}
-     */
-    @Deprecated
-    public void error(String msg, String code, Exception ex) {
-        reject(msg, code, ex);
-    }
-
-    /**
-     * @deprecated
-     * Use {@link #reject(String msg)}
-     */
-    @Deprecated
-    public void error(String msg) {
-        reject(msg);
     }
 
     public void reject(String msg, String code, Exception ex, JSObject data) {

--- a/ios/Capacitor/Capacitor/CAPPluginCall.swift
+++ b/ios/Capacitor/Capacitor/CAPPluginCall.swift
@@ -34,27 +34,12 @@ extension CAPPluginCall: JSValueContainer {
         return !(value is NSNull)
     }
 
-    @available(*, deprecated, renamed: "resolve()")
-    func success() {
-        successHandler(CAPPluginCallResult([:]), self)
-    }
-
-    @available(*, deprecated, renamed: "resolve")
-    func success(_ data: PluginCallResultData = [:]) {
-        successHandler(CAPPluginCallResult(data), self)
-    }
-
     func resolve() {
         successHandler(CAPPluginCallResult(nil), self)
     }
 
     func resolve(_ data: PluginCallResultData = [:]) {
         successHandler(CAPPluginCallResult(data), self)
-    }
-
-    @available(*, deprecated, renamed: "reject")
-    func error(_ message: String, _ error: Error? = nil, _ data: PluginCallResultData = [:]) {
-        errorHandler(CAPPluginCallError(message: message, code: nil, error: error, data: data))
     }
 
     func reject(_ message: String, _ code: String? = nil, _ error: Error? = nil, _ data: PluginCallResultData? = nil) {


### PR DESCRIPTION
The plugin call methods `success()` and `error()` have been marked deprecated in favor of `resolve()` and `reject()` since August 2020. This pull request removes these methods entirely from the code base. 