### PR TITLE
feat(ios): return secure cookies on local scheme 

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorCookieManager.swift
@@ -21,7 +21,16 @@ public class CapacitorCookieManager {
     }
 
     public func getServerUrl() -> URL? {
-        return self.config?.serverURL ?? self.config?.localURL
+        guard let serverURL = self.config?.serverURL ?? self.config?.localURL else { return nil }
+        let assetHandlerScheme = self.config?.localURL.scheme ?? InstanceDescriptorDefaults.scheme
+        // If we're serving assets bundled with the app, then we need to change the scheme of the URL to
+        // https so that cookies marked secure are returned from HTTPCookieStorage.
+        if serverURL.scheme == assetHandlerScheme {
+            var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)
+            components?.scheme = "https"
+            return components?.url
+        }
+        return serverURL
     }
 
     private func isUrlSanitized(_ urlString: String) -> Bool {


### PR DESCRIPTION
This PR reworks the `CapacitorCookieManager.getServerUrl` method to modify the URL if it uses the scheme for serving local assets. By swapping the scheme to `https`, this allows calls to `HTTPCookieStorage` to return secure cookies when asking for cookies with the result of `getServerUrl`.

Happy to have a discussion here on this change. This is more or less a reference implementation to hopefully better convey what I'm expressing in https://github.com/ionic-team/capacitor/discussions/7690.