### PR TITLE
chore: run dispatch-release.yaml in 6.x branch

### DIFF
--- a/.github/workflows/publish-spm-release.yaml
+++ b/.github/workflows/publish-spm-release.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Assign Tag Number to RELEASE_VERSION environment variable
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Dispatch Release Workflow on ionic-team/capacitor-swift-pm
-        run: gh workflow run dispatch-release.yaml -f release-version=${{ env.RELEASE_VERSION }} --repo ionic-team/capacitor-swift-pm
+        run: gh workflow run dispatch-release.yaml -f release-version=${{ env.RELEASE_VERSION }} --repo ionic-team/capacitor-swift-pm -r 6.x
         env:
           GITHUB_TOKEN: ${{ secrets.CAPICTOR_PUBLISH_XCFRAMEWORK }}


### PR DESCRIPTION
I've created a 6.x branch in ionic-team/capacitor-swift-pm for Capacitor 6, make the 6.x Capacitor branch run the workflow in 6.x branch too