### PR TITLE
fix(cli): make Cordova plugins use same default kotlin version as Capacitor

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -226,7 +226,7 @@ if (hasProperty('postBuildExtras')) {
 export async function handleCordovaPluginsGradle(config: Config, cordovaPlugins: Plugin[]): Promise<void> {
   const pluginsGradlePath = join(config.android.cordovaPluginsDirAbs, 'build.gradle');
   const kotlinNeeded = await kotlinNeededCheck(config, cordovaPlugins);
-  const kotlinVersionString = config.app.extConfig.cordova?.preferences?.GradlePluginKotlinVersion ?? '1.8.20';
+  const kotlinVersionString = config.app.extConfig.cordova?.preferences?.GradlePluginKotlinVersion ?? '1.9.10';
   const frameworksArray: any[] = [];
   let prefsArray: any[] = [];
   const applyArray: any[] = [];


### PR DESCRIPTION
We updated the default Capacitor kotlin version to 1.9.10 but Cordova plugins will still use 1.8.20 as default.
Sync the versions.