### PR TITLE
Introducing Capacitor Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/dw/@capacitor/core?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/v/@capacitor/core?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/l/@capacitor/core?style=flat-square" /></a>
+  <a href="https://gurubase.io/g/capacitor"><img src="https://img.shields.io/badge/Gurubase-Ask%20Capacitor%20Guru-006BFF?style=flat-square" /></a>
 </p>
 <p align="center">
   <a href="https://capacitorjs.com/docs"><img src="https://img.shields.io/static/v1?label=docs&message=capacitorjs.com&color=blue&style=flat-square" /></a>

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/dw/@capacitor/core?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/v/@capacitor/core?style=flat-square" /></a>
   <a href="https://www.npmjs.com/package/@capacitor/core"><img src="https://img.shields.io/npm/l/@capacitor/core?style=flat-square" /></a>
-  <a href="https://gurubase.io/g/capacitor"><img src="https://img.shields.io/badge/Gurubase-Ask%20Capacitor%20Guru-006BFF?style=flat-square" /></a>
 </p>
 <p align="center">
   <a href="https://capacitorjs.com/docs"><img src="https://img.shields.io/static/v1?label=docs&message=capacitorjs.com&color=blue&style=flat-square" /></a>
   <a href="https://twitter.com/capacitorjs"><img src="https://img.shields.io/twitter/follow/capacitorjs" /></a>
+  <a href="https://gurubase.io/g/capacitor"><img src="https://img.shields.io/badge/Gurubase-Ask%20Capacitor%20Guru-006BFF?style=flat-square" /></a>
 </p>
 
 ---


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Capacitor Guru](https://gurubase.io/g/capacitor) to Gurubase. Capacitor Guru uses the data from this repo and data from the [docs](https://capacitorjs.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Capacitor Guru", which highlights that Capacitor now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Capacitor Guru in Gurubase, just let me know that's totally fine.
