### PR TITLE
Inject Capacitor JS for error fallbacks.

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -258,9 +258,12 @@ public class Bridge {
         // Start the local web server
         JSInjector injector = getJSInjector();
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
-            String allowedOrigin = Uri.parse(appUrl).buildUpon().path(null).fragment(null).clearQuery().build().toString();
+            Set<String> allowedOrigins = new HashSet<>(Arrays.asList(
+                 Uri.parse(appUrl).buildUpon().path(null).fragment(null).clearQuery().build().toString(),
+                 "https://localhost"
+             ));
             try {
-                WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
+                WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), allowedOrigins);
                 injector = null;
             } catch (IllegalArgumentException ex) {
                 Logger.warn("Invalid url, using fallback");


### PR DESCRIPTION
When using a local `server.errorPath` in conjunction with a remote `server.url`, and the device is offline, Capacitor does not inject its JS because `allowedOrigin` will be set to the remote `server.url` hostname, while the error is loaded from the local server. This means that plugins and other Capacitor/Cordova functionality are unavailable in this situation.

This PR adds `https://localhost` as an `allowedOrigin`, ensuring that all the Capacitor JS is being included in the error case.

There is a related PR for the case when the document start script feature is not supported: https://github.com/ionic-team/capacitor/pull/6247