### PR TITLE
fix(cli): correct rimraf import

### DIFF
--- a/cli/src/ios/build.ts
+++ b/cli/src/ios/build.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, unlinkSync } from 'fs-extra';
 import { basename, join } from 'path';
-import rimraf from 'rimraf';
+import { rimraf } from 'rimraf';
 
 import { runTask } from '../common';
 import type { Config } from '../definitions';

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, readFileSync, existsSync } from 'fs-extra';
 import { join } from 'path';
-import rimraf from 'rimraf';
+import { rimraf } from 'rimraf';
 import { coerce, gte, lt } from 'semver';
 
 import { getAndroidPlugins } from '../android/common';


### PR DESCRIPTION
I updated rimraf to version 6 and the import needs to be updated, otherwise it fails to delete on migrate and build commands.