### PR TITLE
fix(ios): fix URL resolution when external frameworks are loaded

### DIFF
--- a/ios/Capacitor/Capacitor/Router.swift
+++ b/ios/Capacitor/Capacitor/Router.swift
@@ -17,7 +17,7 @@ public struct CapacitorRouter: Router {
     public init() {}
     public var basePath: String = ""
     public func route(for path: String) -> String {
-        let pathUrl = URL(fileURLWithPath: path)
+        let pathUrl = URL(fileURLWithPath: basePath + path)
 
         // If there's no path extension it also means the path is empty or a SPA route
         if pathUrl.pathExtension.isEmpty {


### PR DESCRIPTION
I'm not 100% sure if this fixes the issue I was encountering in all cases but here's the lowdown:

I'm loading an [xcframework compiled by gomobile](https://github.com/Jigsaw-Code/outline-sdk/tree/main/x/mobileproxy#add-the-mobileproxy-dependency) into the xcode project that Capacitor creates. There was this mysterious behavior where as soon as I called any function exposed by that library, my app wouldn't load and I'd get the following error:

```
[pageProxyID=16, webPageID=17, PID=50534] WebPageProxy::didFailProvisionalLoadForFrame: 
frameID=1, isMainFrame=1, domain=NSCocoaErrorDomain, code=256, isMainFrame=1, 
willInternallyHandleFailure=0
```

I traced the source of the error to this `Router.swift` file and discovered that when I didn't call any gomobile-compiled function, the result of `pathUrl` was different. According to the Swift Foundation source, `URL(fileURLWithPath:)`

```
    /// Initializes a newly created URL using the contents of the given data, 
relative to a base URL.
```

So it seems that somehow (I don't fully understand it), accessing the `.xcframework` in the running code changes the base URL that `URL(fileURLWithPath:)` starts from. By adding the `basePath` in here, I think we're now enforcing a consistent URL base, and my app appears to work now whether I call a method from my library or not.

Here is a photo of it working with the fix:

<img width="1035" alt="Screenshot 2025-01-16 at 4 26 34 PM" src="https://github.com/user-attachments/assets/7eea5042-3006-4d1f-a038-88b3a167671a" />




