### PR TITLE
fix: use Capacitor 7 for SPM dependency

### DIFF
--- a/ios-spm-template/App/CapApp-SPM/Package.swift
+++ b/ios-spm-template/App/CapApp-SPM/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
We did this for Capacitor 6 when we started publishing Capacitor 7 into SPM to make Capacitor 6 use only the 6 version and make it match with the npm installed one
But we also need this for Capacitor 7 in case we publish a Capacitor 6 version to main branch (that will happen when a 6.x release is made after a Capacitor 7 release)