### PR TITLE
fix(ios): don't check isMediaExtension on range requests

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -58,8 +58,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             }
 
             if let rangeString = urlSchemeTask.request.value(forHTTPHeaderField: "Range"),
-               let totalSize = try fileUrl.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-               isMediaExtension(pathExtension: url.pathExtension) {
+               let totalSize = try fileUrl.resourceValues(forKeys: [.fileSizeKey]).fileSize {
                 let fileHandle = try FileHandle(forReadingFrom: fileUrl)
                 let parts = rangeString.components(separatedBy: "=")
                 let streamParts = parts[1].components(separatedBy: "-")


### PR DESCRIPTION
There are multiple file extensions that support range requests, not only media extensions, we shouldn't be checking `isMediaExtension` for the requested resource if the request has `Range` header, if the header has `Range`, then it should return `206` and the appropriate range headers.

closes https://github.com/ionic-team/capacitor/issues/7789