### PR TITLE
fix(android): sanitize portable file name

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -219,7 +219,8 @@ public class FileUtils {
         int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
         cursor.moveToFirst();
         String name = (cursor.getString(nameIndex));
-        File file = new File(context.getFilesDir(), name);
+        String fileName = sanitizeFilename(name);
+        File file = new File(context.getFilesDir(), fileName);
         try {
             InputStream inputStream = context.getContentResolver().openInputStream(uri);
             FileOutputStream outputStream = new FileOutputStream(file);
@@ -288,5 +289,15 @@ public class FileUtils {
             }
         }
         return null;
+    }
+
+    private String sanitizeFilename(String displayName) {
+        String[] badCharacters = new String[] { "..", "/" };
+        String[] segments = displayName.split("/");
+        String fileName = segments[segments.length - 1];
+        for (String suspString : badCharacters) {
+            fileName = fileName.replace(suspString, "_");
+        }
+        return fileName;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -291,7 +291,7 @@ public class FileUtils {
         return null;
     }
 
-    private String sanitizeFilename(String displayName) {
+    private static String sanitizeFilename(String displayName) {
         String[] badCharacters = new String[] { "..", "/" };
         String[] segments = displayName.split("/");
         String fileName = segments[segments.length - 1];


### PR DESCRIPTION
Fix linting error for Android. When building a plugin I get the following error:
```
Execution failed for task ':capacitor-android:lintDebug'.

/node_modules/@capacitor/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java:222: Error: Using name is unsafe as it is a filename obtained directly from a ContentProvider. You should sanitize it before using it for creating a File. [UnsanitizedFilenameFromContentProvider]
          File file = new File(context.getFilesDir(), name);
```

I've applied the fix recommended here https://developer.android.com/privacy-and-security/risks/untrustworthy-contentprovider-provided-filename.

closes https://github.com/ionic-team/capacitor/issues/7880
closes https://outsystemsrd.atlassian.net/browse/RDMR-556