### PR TITLE
fix(http): boundary not added for Request objects

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -468,6 +468,15 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
+                        const headers = new Headers(options === null || options === void 0 ? void 0 : options.headers);
+                        const contentType = headers.get('Content-Type') || headers.get('content-type');
+                        if ((options === null || options === void 0 ? void 0 : options.body) instanceof FormData &&
+                            (contentType === null || contentType === void 0 ? void 0 : contentType.includes('multipart/form-data')) &&
+                            !contentType.includes('boundary')) {
+                            headers.delete('Content-Type');
+                            headers.delete('content-type');
+                            options.headers = headers;
+                        }
                         const request = new Request(resource, options);
                         if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
                             return win.CapacitorWebFetch(resource, options);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -491,6 +491,17 @@ const initBridge = (w: any): void => {
       if (doPatchHttp) {
         // fetch patch
         window.fetch = async (resource: RequestInfo | URL, options?: RequestInit) => {
+          const headers = new Headers(options?.headers);
+          const contentType = headers.get('Content-Type') || headers.get('content-type');
+          if (
+            options?.body instanceof FormData &&
+            contentType?.includes('multipart/form-data') &&
+            !contentType.includes('boundary')
+          ) {
+            headers.delete('Content-Type');
+            headers.delete('content-type');
+            options.headers = headers;
+          }
           const request = new Request(resource, options);
           if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
             return win.CapacitorWebFetch(resource, options);

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -468,6 +468,15 @@ var nativeBridge = (function (exports) {
                 if (doPatchHttp) {
                     // fetch patch
                     window.fetch = async (resource, options) => {
+                        const headers = new Headers(options === null || options === void 0 ? void 0 : options.headers);
+                        const contentType = headers.get('Content-Type') || headers.get('content-type');
+                        if ((options === null || options === void 0 ? void 0 : options.body) instanceof FormData &&
+                            (contentType === null || contentType === void 0 ? void 0 : contentType.includes('multipart/form-data')) &&
+                            !contentType.includes('boundary')) {
+                            headers.delete('Content-Type');
+                            headers.delete('content-type');
+                            options.headers = headers;
+                        }
                         const request = new Request(resource, options);
                         if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
                             return win.CapacitorWebFetch(resource, options);


### PR DESCRIPTION
If the user provides the `multipart/form-data` content-type without boundary, the call to `const request = new Request(resource, options);` is not able to generate a browser boundary. 
So remove the content-type from the headers when they are set to `multipart/form-data` and if they don't have a boundary.
Also do it only for `FormData` bodies as other types or bodies are handled differently and I'm not sure if the issue is also present there.

closes https://github.com/ionic-team/capacitor/issues/7589