### PR TITLE
[ios] Add explicit Native -> JS message acknowledgement and message replay

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -887,6 +887,13 @@ var nativeBridge = (function (exports) {
              */
             cap.fromNative = (result) => {
                 returnResult(result);
+                acknowledgeMessage(result.messageId);
+            };
+            const acknowledgeMessage = (messageId) => {
+                postToNative({
+                    type: 'acknowledgeMessage',
+                    messageId,
+                });
             };
             const returnResult = (result) => {
                 var _a, _b;
@@ -967,6 +974,9 @@ var nativeBridge = (function (exports) {
             initLegacyHandlers(win, cap);
             initVendor(win, cap);
             win.Capacitor = cap;
+            postToNative({
+                type: 'startupHandshake',
+            });
         }
         initNativeBridge(w);
     };

--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -890,6 +890,12 @@ var nativeBridge = (function (exports) {
                 acknowledgeMessage(result.messageId);
             };
             const acknowledgeMessage = (messageId) => {
+                if (messageId === undefined) {
+                    return;
+                }
+                if (typeof postToNative !== 'function') {
+                    return;
+                }
                 postToNative({
                     type: 'acknowledgeMessage',
                     messageId,
@@ -974,9 +980,11 @@ var nativeBridge = (function (exports) {
             initLegacyHandlers(win, cap);
             initVendor(win, cap);
             win.Capacitor = cap;
-            postToNative({
-                type: 'startupHandshake',
-            });
+            if (typeof postToNative === 'function') {
+                postToNative({
+                    type: 'startupHandshake',
+                });
+            }
         }
         initNativeBridge(w);
     };

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -874,7 +874,7 @@ const initBridge = (w: any): void => {
     // an existing callback id from an old session
     let callbackIdCount = Math.floor(Math.random() * 134217728);
 
-    let postToNative: (data: CallData) => void | null = null;
+    let postToNative: ((data: CallData) => void) | null = null;
 
     const isNativePlatform = () => true;
     const getPlatform = () => getPlatformId(win);
@@ -994,7 +994,13 @@ const initBridge = (w: any): void => {
       acknowledgeMessage(result.messageId);
     };
 
-    const acknowledgeMessage = (messageId: number) => {
+    const acknowledgeMessage = (messageId?: number) => {
+      if (messageId === undefined) {
+        return;
+      }
+      if (typeof postToNative !== 'function') {
+        return;
+      }
       postToNative({
         type: 'acknowledgeMessage',
         messageId,
@@ -1009,7 +1015,6 @@ const initBridge = (w: any): void => {
       // get the stored call, if it exists
       try {
         const storedCall = callbacks.get(result.callbackId);
-
         if (storedCall) {
           // looks like we've got a stored call
 
@@ -1090,9 +1095,11 @@ const initBridge = (w: any): void => {
 
     win.Capacitor = cap;
 
-    postToNative({
-      type: 'startupHandshake',
-    });
+    if (typeof postToNative === 'function') {
+      postToNative({
+        type: 'startupHandshake',
+      });
+    }
   }
 
   initNativeBridge(w);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -991,8 +991,14 @@ const initBridge = (w: any): void => {
      */
     cap.fromNative = (result) => {
       returnResult(result);
-      
-      // TODO: XXX acknowledge the message
+      acknowledgeMessage(result.messageId);
+    };
+
+    const acknowledgeMessage = (messageId: number) => {
+      postToNative({
+        type: 'acknowledgeMessage',
+        messageId,
+      });
     };
 
     const returnResult = (result: any) => {
@@ -1084,7 +1090,9 @@ const initBridge = (w: any): void => {
 
     win.Capacitor = cap;
 
-    // TODO: XXX postToNative message that we should start flowing messages
+    postToNative({
+      type: 'startupHandshake',
+    });
   }
 
   initNativeBridge(w);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -991,6 +991,8 @@ const initBridge = (w: any): void => {
      */
     cap.fromNative = (result) => {
       returnResult(result);
+      
+      // TODO: XXX acknowledge the message
     };
 
     const returnResult = (result: any) => {
@@ -1081,6 +1083,8 @@ const initBridge = (w: any): void => {
     initVendor(win, cap);
 
     win.Capacitor = cap;
+
+    // TODO: XXX postToNative message that we should start flowing messages
   }
 
   initNativeBridge(w);

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -110,12 +110,22 @@ export interface ErrorCallData {
   };
 }
 
-export type CallData = MessageCallData | ErrorCallData;
+export interface StartupHandshakeCallData {
+  type?: 'startupHandshake';
+}
+
+export interface AcknowledgeMessageCallData {
+  type?: 'acknowledgeMessage';
+  messageId: number;
+}
+
+export type CallData = StartupHandshakeCallData | MessageCallData | AcknowledgeMessageCallData | ErrorCallData;
 
 /**
  * A resulting call back from the native layer.
  */
 export interface PluginResult {
+  messageId: number;
   callbackId?: string;
   methodName?: string;
   data: PluginResultData;

--- a/core/src/definitions-internal.ts
+++ b/core/src/definitions-internal.ts
@@ -125,7 +125,7 @@ export type CallData = StartupHandshakeCallData | MessageCallData | AcknowledgeM
  * A resulting call back from the native layer.
  */
 export interface PluginResult {
-  messageId: number;
+  messageId?: number;
   callbackId?: string;
   methodName?: string;
   data: PluginResultData;

--- a/core/src/tests/bridge.spec.ts
+++ b/core/src/tests/bridge.spec.ts
@@ -119,6 +119,9 @@ describe('bridge', () => {
     win.androidBridge = {
       postMessage: (m) => {
         const d = JSON.parse(m);
+        if (d.type === 'startupHandshake') {
+          return;
+        }
         Promise.resolve().then(() => {
           pluginResult.callbackId = d.callbackId;
           pluginResult.methodName = d.methodName;
@@ -133,6 +136,9 @@ describe('bridge', () => {
       messageHandlers: {
         bridge: {
           postMessage: (m) => {
+            if (m.type === 'startupHandshake') {
+              return;
+            }
             Promise.resolve().then(() => {
               pluginResult.callbackId = m.callbackId;
               pluginResult.methodName = m.methodName;

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -117,7 +117,7 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
     // Calls we are storing to resolve later
     var storedCalls = ConcurrentDictionary<CAPPluginCall>()
     // Messages sent to JS that have not yet been acknowledged
-    private var unacknowledgedMessages = MyQueue()
+    private var unacknowledgedMessages = JSMessageQueue()
     // Whether to inject the Cordova files
     private var injectCordovaFiles = false
     private var cordovaParser: CDVConfigParser?
@@ -806,7 +806,7 @@ struct JSMessagePayloadWithId {
     let payload: JSMessagePayload
 }
 
-class MyQueue: NSObject {
+class JSMessageQueue: NSObject {
     private var queue: [JSMessagePayloadWithId] = []
     private var nextId: Int = 0
 

--- a/ios/Capacitor/Capacitor/CapacitorBridge.swift
+++ b/ios/Capacitor/Capacitor/CapacitorBridge.swift
@@ -116,15 +116,13 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
     var cordovaPluginManager: CDVPluginManager?
     // Calls we are storing to resolve later
     var storedCalls = ConcurrentDictionary<CAPPluginCall>()
-    // Messages sent to JS that have not yet been acknowledged.
+    // Messages sent to JS that have not yet been acknowledged
     private var unacknowledgedMessages = MyQueue()
     // Whether to inject the Cordova files
     private var injectCordovaFiles = false
     private var cordovaParser: CDVConfigParser?
     private var injectMiscFiles: [String] = []
     private var canInjectJS: Bool = true
-    // A FIFO queue used to store unacknowledged messages sent to JS
-    private var 
 
     // Background dispatch queue for plugin calls
     open private(set) var dispatchQueue = DispatchQueue(label: "bridge")
@@ -571,9 +569,9 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
         for message in messages {
             switch message.payload {
             case .result(let result, let save):
-                toJsDispatch(result, save, message.id)
+                toJsDispatch(result: result, save: save, messageId: message.id)
             case .error(let error):
-                toJsErrorDispatch(error: error, message.id)
+                toJsErrorDispatch(error: error, messageId: message.id)
             }
         }
     }
@@ -584,7 +582,7 @@ open class CapacitorBridge: NSObject, CAPBridgeProtocol {
 
     func toJs(result: JSResultProtocol, save: Bool) {
       let messageId = self.unacknowledgedMessages.add(.result(result: result, save: save))
-      toJsDispatch(result, save, messageId)
+      toJsDispatch(result: result, save: save, messageId: messageId)
     }
 
 
@@ -809,12 +807,12 @@ struct JSMessagePayloadWithId {
 }
 
 class MyQueue: NSObject {
-    private var queue: [MessagePayloadWithId] = []
+    private var queue: [JSMessagePayloadWithId] = []
     private var nextId: Int = 0
 
     func add(_ payload: JSMessagePayload) -> Int {
         let id = nextId
-        self.queue.append(MessagePayloadWithId(id, payload))
+        self.queue.append(JSMessagePayloadWithId(id: id, payload: payload))
         nextId += 1
         return id
     }

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -188,6 +188,8 @@ open class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegat
                 }
 
                 bridge.handleJSCall(call: JSCall(options: options, pluginId: pluginId, method: method, callbackId: callbackId))
+                // TODO: XXX add a new type for acknowledgement of receipt
+                // TODO: XXX add a new type for initial handshake
             } else if type == "cordova" {
                 let pluginId = dict["service"] as? String ?? ""
                 let method = dict["action"] as? String ?? ""

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -193,7 +193,7 @@ open class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegat
             } else if type == "acknowledgeMessage" {
                 let messageId = dict["messageId"] as? Int
                 if messageId != nil {
-                    bridge.acknowledgeMessage(messageId: messageId!)
+                    bridge.acknowledgeMessageIdFromJs(messageId!)
                 }
             } else if type == "cordova" {
                 let pluginId = dict["service"] as? String ?? ""

--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -176,6 +176,8 @@ open class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegat
                 if let error = dict["error"] as? [String: Any] {
                     logJSError(error)
                 }
+            } else if type == "startupHandshake" {
+                bridge.sendPendingJsMessages()
             } else if type == "message" {
                 let pluginId = dict["pluginId"] as? String ?? ""
                 let method = dict["methodName"] as? String ?? ""
@@ -188,8 +190,11 @@ open class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegat
                 }
 
                 bridge.handleJSCall(call: JSCall(options: options, pluginId: pluginId, method: method, callbackId: callbackId))
-                // TODO: XXX add a new type for acknowledgement of receipt
-                // TODO: XXX add a new type for initial handshake
+            } else if type == "acknowledgeMessage" {
+                let messageId = dict["messageId"] as? Int
+                if messageId != nil {
+                    bridge.acknowledgeMessage(messageId: messageId!)
+                }
             } else if type == "cordova" {
                 let pluginId = dict["service"] as? String ?? ""
                 let method = dict["action"] as? String ?? ""

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -887,6 +887,13 @@ var nativeBridge = (function (exports) {
              */
             cap.fromNative = (result) => {
                 returnResult(result);
+                acknowledgeMessage(result.messageId);
+            };
+            const acknowledgeMessage = (messageId) => {
+                postToNative({
+                    type: 'acknowledgeMessage',
+                    messageId,
+                });
             };
             const returnResult = (result) => {
                 var _a, _b;
@@ -967,6 +974,9 @@ var nativeBridge = (function (exports) {
             initLegacyHandlers(win, cap);
             initVendor(win, cap);
             win.Capacitor = cap;
+            postToNative({
+                type: 'startupHandshake',
+            });
         }
         initNativeBridge(w);
     };

--- a/ios/Frameworks/Capacitor.xcframework/ios-arm64/Capacitor.framework/native-bridge.js
+++ b/ios/Frameworks/Capacitor.xcframework/ios-arm64/Capacitor.framework/native-bridge.js
@@ -890,12 +890,6 @@ var nativeBridge = (function (exports) {
                 acknowledgeMessage(result.messageId);
             };
             const acknowledgeMessage = (messageId) => {
-                if (messageId === undefined) {
-                    return;
-                }
-                if (typeof postToNative !== 'function') {
-                    return;
-                }
                 postToNative({
                     type: 'acknowledgeMessage',
                     messageId,
@@ -980,11 +974,9 @@ var nativeBridge = (function (exports) {
             initLegacyHandlers(win, cap);
             initVendor(win, cap);
             win.Capacitor = cap;
-            if (typeof postToNative === 'function') {
-                postToNative({
-                    type: 'startupHandshake',
-                });
-            }
+            postToNative({
+                type: 'startupHandshake',
+            });
         }
         initNativeBridge(w);
     };


### PR DESCRIPTION
Fixes #7810 

Teaches `CapacitorBridge` for iOS to store all messages sent from Native -> JS in a local FIFO, the entries of which persist until an `"acknolwedgeMessage"` message is received from JS to indicate the message was processed by the JS code.

Pre-review task list:

- [ ] Test using minimal reproduction app linked from #7810
- [ ] Smoke-test on Android to show nothing there is newly broken
- [ ] Add doc comments to new code (include link to original bug report for relevant context)