### PR TITLE
feat(http):  Apply overrideUserAgent to requests

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/HttpRequestHandler.java
@@ -398,6 +398,11 @@ public class HttpRequestHandler {
 
         boolean isHttpMutate = method.equals("DELETE") || method.equals("PATCH") || method.equals("POST") || method.equals("PUT");
 
+        String overriddenUserAgent = bridge.getConfig().getOverriddenUserAgentString();
+        if (overriddenUserAgent != null) {
+            headers.put("User-Agent", overriddenUserAgent);
+        }
+
         URL url = new URL(urlString);
         HttpURLConnectionBuilder connectionBuilder = new HttpURLConnectionBuilder()
             .setUrl(url)

--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -165,7 +165,7 @@ open class HttpRequestHandler {
         guard var urlString = call.getString("url") else { throw URLError(.badURL) }
         let method = httpMethod ?? call.getString("method", "GET")
 
-        let headers = (call.getObject("headers") ?? [:]) as [String: Any]
+        var headers = (call.getObject("headers") ?? [:]) as [String: Any]
         let params = (call.getObject("params") ?? [:]) as [String: Any]
         let responseType = call.getString("responseType") ?? "text"
         let connectTimeout = call.getDouble("connectTimeout")
@@ -183,6 +183,10 @@ open class HttpRequestHandler {
             .setUrlParams(params)
             .openConnection()
             .build()
+        
+        if let userAgentString = config?.overridenUserAgentString {
+            headers["User-Agent"] = userAgentString
+        }
 
         request.setRequestHeaders(headers)
 


### PR DESCRIPTION
Take the Cap Config values of `overrideUserAgent` (or `ios.overrideUserAgent` | `android.overrideUserAgent`) and apply them to CapacitorHttp requests.