### PR TITLE
feat(ios): Enable Fullscreen API on WebView

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -130,6 +130,9 @@ import Cordova
         webViewConfiguration.allowsAirPlayForMediaPlayback = true
         webViewConfiguration.mediaTypesRequiringUserActionForPlayback = []
         webViewConfiguration.limitsNavigationsToAppBoundDomains = instanceConfiguration.limitsNavigationsToAppBoundDomains
+        if #available(iOS 15.4, *) {
+            webViewConfiguration.preferences.isElementFullscreenEnabled = true
+        }
         if let appendUserAgent = instanceConfiguration.appendedUserAgentString {
             if let appName = webViewConfiguration.applicationNameForUserAgent {
                 webViewConfiguration.applicationNameForUserAgent = "\(appName)  \(appendUserAgent)"


### PR DESCRIPTION
Marking it as a feat, but could also be a fix since Fullscreen API has been available on Android for a while (or always).

closes https://github.com/ionic-team/capacitor/issues/7701