### PR TITLE
chore: Remove social_media_url from podspecs

### DIFF
--- a/capacitor-cordova-ios-plugins/CordovaPluginsResources.podspec
+++ b/capacitor-cordova-ios-plugins/CordovaPluginsResources.podspec
@@ -2,7 +2,6 @@ Pod::Spec.new do |s|
   s.name = 'CordovaPluginsResources'
   s.version = '0.0.105'
   s.summary = 'Resources for Cordova plugins'
-  s.social_media_url = 'https://twitter.com/capacitorjs'
   s.license = 'MIT'
   s.homepage = 'https://capacitorjs.com/'
   s.authors = { 'Ionic Team' => 'hi@ionicframework.com' }

--- a/ios/Capacitor.podspec
+++ b/ios/Capacitor.podspec
@@ -10,7 +10,6 @@ Pod::Spec.new do |s|
   s.name = 'Capacitor'
   s.version = package['version']
   s.summary = 'Capacitor for iOS'
-  s.social_media_url = 'https://twitter.com/capacitorjs'
   s.license = 'MIT'
   s.homepage = 'https://capacitorjs.com/'
   s.ios.deployment_target = '14.0'


### PR DESCRIPTION
This was used by CocoaPods to post updates on `CocoaPodsFeed` on twitter, but last post is from 2019 and the sites are down too, so doesn't seem like it's used anymore and also causes a warning on publish about the url not being reachable, so removed it.
