### PR TITLE
fix(android): rename bridge layout to avoid collision

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -25,7 +25,7 @@ public class BridgeActivity extends AppCompatActivity {
         getApplication().setTheme(R.style.AppTheme_NoActionBar);
         setTheme(R.style.AppTheme_NoActionBar);
         try {
-            setContentView(R.layout.bridge_layout_main);
+            setContentView(R.layout.capacitor_bridge_layout_main);
         } catch (Exception ex) {
             setContentView(R.layout.no_webview);
             return;

--- a/android/capacitor/src/main/res/layout/capacitor_bridge_layout_main.xml
+++ b/android/capacitor/src/main/res/layout/capacitor_bridge_layout_main.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.getcapacitor.BridgeActivity"
+    >
+
+    <com.getcapacitor.CapacitorWebView
+        android:id="@+id/webview"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
kept the old one in case somebody was using it somewhere else, should be removed in Capacitor 8.