### PR TITLE
docs(cli): use proper version for ios buildOptions

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -494,27 +494,27 @@ export interface CapacitorConfig {
       /**
        * The signing style to use when building the app for distribution.
        *
-       * @since 7.0.0
+       * @since 7.1.0
        * @default 'automatic'
        */
       signingStyle?: 'automatic' | 'manual';
       /**
        * The method used by xcodebuild to export the archive
        *
-       * @since 7.0.0
+       * @since 7.1.0
        * @default 'app-store-connect'
        */
       exportMethod?: string;
       /**
        * A certificate name, SHA-1 hash, or automatic selector to use for signing for iOS builds.
        *
-       * @since 7.0.0
+       * @since 7.1.0
        */
       signingCertificate?: string;
       /**
        * A provisioning profile name or UUID for iOS builds.
        *
-       * @since 7.0.0
+       * @since 7.1.0
        */
       provisioningProfile?: string;
     };


### PR DESCRIPTION
iOS `buildOptions` were added in Capacitor 7.1.0, not 7.0.0.