### PR TITLE
fix(ios): respect shouldEncodeUrlParams value

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -76,7 +76,7 @@ open class HttpRequestHandler {
             return self
         }
 
-        public func setUrlParams(_ params: [String: Any]) -> CapacitorHttpRequestBuilder {
+        public func setUrlParams(_ params: [String: Any], _ shouldEncodeUrlParams: Bool = true) -> CapacitorHttpRequestBuilder {
             if params.count != 0 {
                 // swiftlint:disable force_cast
                 var cmps = URLComponents(url: url!, resolvingAgainstBaseURL: true)
@@ -84,18 +84,27 @@ open class HttpRequestHandler {
                     cmps?.queryItems = []
                 }
 
-                var urlSafeParams: [URLQueryItem] = []
-                for (key, value) in params {
-                    if let arr = value as? [String] {
-                        arr.forEach { str in
-                            urlSafeParams.append(URLQueryItem(name: key, value: str))
+                if shouldEncodeUrlParams {
+                    var urlSafeParams: [URLQueryItem] = []
+                    for (key, value) in params {
+                        if let arr = value as? [String] {
+                            arr.forEach { str in
+                                urlSafeParams.append(URLQueryItem(name: key, value: str))
+                            }
+                        } else {
+                            urlSafeParams.append(URLQueryItem(name: key, value: (value as! String)))
                         }
-                    } else {
-                        urlSafeParams.append(URLQueryItem(name: key, value: (value as! String)))
                     }
+                    cmps!.queryItems?.append(contentsOf: urlSafeParams)
+                } else {
+                    cmps?.query = params.flatMap { key, value -> [String] in
+                        if let arrayValue = value as? [String] {
+                            return arrayValue.map { "\(key)=\($0)" }
+                        } else {
+                            return ["\(key)=\(value)"]
+                        }
+                    }.joined(separator: "&")
                 }
-
-                cmps!.queryItems?.append(contentsOf: urlSafeParams)
                 url = cmps!.url!
             }
             return self
@@ -169,6 +178,7 @@ open class HttpRequestHandler {
         let params = (call.getObject("params") ?? [:]) as [String: Any]
         let responseType = call.getString("responseType") ?? "text"
         let connectTimeout = call.getDouble("connectTimeout")
+        let shouldEncodeUrlParams = call.getBool("shouldEncodeUrlParams", true)
         let readTimeout = call.getDouble("readTimeout")
         let dataType = call.getString("dataType") ?? "any"
 
@@ -180,7 +190,7 @@ open class HttpRequestHandler {
         let request = try CapacitorHttpRequestBuilder()
             .setUrl(urlString)
             .setMethod(method)
-            .setUrlParams(params)
+            .setUrlParams(params, shouldEncodeUrlParams)
             .openConnection()
             .build()
 


### PR DESCRIPTION
iOS is always encoding url params, this PR reads the `shouldEncodeUrlParams` and not encode them if false.

closes https://github.com/ionic-team/capacitor/issues/7911