### PR TITLE
fix(cli): ensures the execution order of CLI hooks

### DIFF
--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -151,9 +151,8 @@ export async function runHooks(config: Config, platformName: string, dir: string
   await runPlatformHook(config, platformName, dir, hook);
 
   const allPlugins = await getPlugins(config, platformName);
-  allPlugins.forEach(async (p) => {
-    await runPlatformHook(config, platformName, p.rootPath, hook);
-  });
+  const promises = allPlugins.map( p => runPlatformHook(config, platformName, p.rootPath, hook));
+  await Promise.all(promises);
 }
 
 export async function runPlatformHook(

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -151,8 +151,10 @@ export async function runHooks(config: Config, platformName: string, dir: string
   await runPlatformHook(config, platformName, dir, hook);
 
   const allPlugins = await getPlugins(config, platformName);
-  const promises = allPlugins.map( p => runPlatformHook(config, platformName, p.rootPath, hook));
-  await Promise.all(promises);
+
+  for (const p of allPlugins) {
+    await runPlatformHook(config, platformName, p.rootPath, hook);
+  }
 }
 
 export async function runPlatformHook(


### PR DESCRIPTION
This PR fixes the execution order of CLI Hooks.

The `forEach()` method of Array instances expects synchronous functions and it does not wait for promises.