### PR TITLE
chore: set skipLibCheck to true in tsconfig.json

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -12,6 +12,7 @@
     "noEmitHelpers": true,
     "outDir": "dist",
     "pretty": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "es2019"
   },

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -12,6 +12,7 @@
     "noUnusedParameters": true,
     "outDir": "build",
     "declarationDir": "types",
+    "skipLibCheck": true,
     "sourceMap": true,
     "target": "es2017"
   },


### PR DESCRIPTION
To prevent build failures when there are type problems on `node_modules`.