### PR TITLE
feat: expose `appStartPath` on cap config server configuration

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -251,6 +251,7 @@ public class CapConfig {
         serverUrl = JSONUtils.getString(configJSON, "server.url", null);
         hostname = JSONUtils.getString(configJSON, "server.hostname", hostname);
         errorPath = JSONUtils.getString(configJSON, "server.errorPath", null);
+        startPath = JSONUtils.getString(configJSON, "server.appStartPath", null);
 
         String configSchema = JSONUtils.getString(configJSON, "server.androidScheme", androidScheme);
         if (this.validateScheme(configSchema)) {

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -616,6 +616,7 @@ export interface CapacitorConfig {
      * Only affects iOS.
      *
      * @since 7.3.0
+     * @default null
      */
     appStartPath?: string;
   };

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -614,6 +614,7 @@ export interface CapacitorConfig {
     /**
      * Append a path to the app URL.
      *
+     * Allows loading from other paths than the default `/index.html`.
      * @since 7.3.0
      * @default null
      */

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -613,7 +613,6 @@ export interface CapacitorConfig {
 
     /**
      * Append a path to the app URL.
-     * Only affects iOS.
      *
      * @since 7.3.0
      * @default null

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -610,6 +610,14 @@ export interface CapacitorConfig {
      * @default null
      */
     errorPath?: string;
+
+    /**
+     * Append a path to the app URL.
+     * Only affects iOS.
+     *
+     * @since 7.3.0
+     */
+    appStartPath?: string;
   };
 
   cordova?: {

--- a/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
+++ b/ios/Capacitor/Capacitor/CAPInstanceDescriptor.swift
@@ -149,6 +149,9 @@ internal extension InstanceDescriptor {
             if let initialFocus = (config[keyPath: "ios.initialFocus"] as? Bool) ?? (config[keyPath: "initialFocus"] as? Bool) {
                 hasInitialFocus = initialFocus
             }
+            if let startPath = (config[keyPath: "server.appStartPath"] as? String) {
+                appStartPath = startPath
+            }
         }
     }
     // swiftlint:enable cyclomatic_complexity


### PR DESCRIPTION
Fixes [7972](https://github.com/ionic-team/capacitor/issues/7972).
closes [3912](https://github.com/ionic-team/capacitor/issues/3912)

These changes introduce a new `capacitor.config` flag, `appStartPath`.

On iOS and Android, the logic already existed, but there was no way to configure this value.  This PR simply exposes that configuration.