### PR TITLE
fix(http): Properly URL-encode key and values during `x-www-form-urlencoded` POSTs

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/util/CapacitorHttpUrlConnection.java
@@ -248,7 +248,7 @@ public class CapacitorHttpUrlConnection implements ICapacitorHttpUrlConnection {
             while (keys.hasNext()) {
                 String key = keys.next();
                 Object d = object.get(key);
-                os.writeBytes(key);
+                os.writeBytes(URLEncoder.encode(key, "UTF-8"));
                 os.writeBytes("=");
                 os.writeBytes(URLEncoder.encode(d.toString(), "UTF-8"));
 

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -44,7 +44,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
 
         obj.keys.forEach { (key: String) in
             let value = obj[key] as? String ?? ""
-            components.queryItems?.append(URLQueryItem(name: key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key, value: value.addingPercentEncoding(withAllowedCharacters: allowed)))
+            components.queryItems?.append(URLQueryItem(name: key.addingPercentEncoding(withAllowedCharacters: allowed)?.replacingOccurrences(of: "%20", with: "+") ?? key, value: value.addingPercentEncoding(withAllowedCharacters: allowed)?.replacingOccurrences(of: "%20", with: "+")))
         }
 
         if components.query != nil {

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -44,7 +44,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
 
         obj.keys.forEach { (key: String) in
             let value = obj[key] as? String ?? ""
-            components.queryItems?.append(URLQueryItem(name: key.addingPercentEncoding(withAllowedCharacters: allowed), value: value.addingPercentEncoding(withAllowedCharacters: allowed)))
+            components.queryItems?.append(URLQueryItem(name: key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key, value: value.addingPercentEncoding(withAllowedCharacters: allowed)))
         }
 
         if components.query != nil {

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -40,7 +40,7 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ multipart/form-data ] may only be a plain javascript object")
         }
 
-        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+        let allowed = CharacterSet(charactersIn: "-._*").union(.alphanumerics)
 
         obj.keys.forEach { (key: String) in
             let value = obj[key] as? String ?? ""

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -39,8 +39,8 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
             // Throw, other data types explicitly not supported
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ multipart/form-data ] may only be a plain javascript object")
         }
-        
-        let allowed = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
 
         obj.keys.forEach { (key: String) in
             let value = obj[key] as? String ?? ""

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -39,9 +39,12 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
             // Throw, other data types explicitly not supported
             throw CapacitorUrlRequestError.serializationError("[ data ] argument for request with content-type [ multipart/form-data ] may only be a plain javascript object")
         }
+        
+        let allowed = CharacterSet(charactersIn:"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
 
         obj.keys.forEach { (key: String) in
-            components.queryItems?.append(URLQueryItem(name: key, value: "\(obj[key] ?? "")"))
+            let value = obj[key] as? String ?? ""
+            components.queryItems?.append(URLQueryItem(name: key.addingPercentEncoding(withAllowedCharacters: allowed), value: value.addingPercentEncoding(withAllowedCharacters: allowed)))
         }
 
         if components.query != nil {


### PR DESCRIPTION
This PR fixes keys and values that were not url-encoded in CapacitorHttp on iOS during `application/x-www-form-urlencoded` HTTP POST requests.

closes: https://github.com/ionic-team/capacitor/issues/7840