### PR TITLE
refactor(core): reference window.Capacitor

### DIFF
--- a/core/cordova.js
+++ b/core/cordova.js
@@ -203,7 +203,7 @@
        * bNoDetach is required for events which cause an exception which needs to be caught in native code
        */
       fireDocumentEvent: function (type, data, bNoDetach) {
-        var evt = Capacitor.createEvent(type, data);
+        var evt = window.Capacitor.createEvent(type, data);
         if (typeof documentEventHandlers[type] !== 'undefined') {
           if (bNoDetach) {
             documentEventHandlers[type].fire(evt);
@@ -221,7 +221,7 @@
         }
       },
       fireWindowEvent: function (type, data) {
-        var evt = Capacitor.createEvent(type, data);
+        var evt = window.Capacitor.createEvent(type, data);
         if (typeof windowEventHandlers[type] !== 'undefined') {
           setTimeout(function () {
             windowEventHandlers[type].fire(evt);
@@ -1320,7 +1320,7 @@
 
   define('cordova/platform', function (require, exports, module) {
     module.exports = {
-      id: Capacitor.getPlatform(),
+      id: window.Capacitor.getPlatform(),
       bootstrap: function () {
         require('cordova/channel').onNativeReady.fire();
       },


### PR DESCRIPTION
Since the addition of the ability to inject misc JS modules into the WebView on https://github.com/ionic-team/capacitor/pull/7864 there's a possibility that some user provided JS module defines a "top-level" `const Capacitor` variable which ends up conflicting with the variable being referenced by cordova.js.

This change makes it so that cordova.js usage of global Capacitor object follows the other usages found throughout the framework where `window.` is prefixed. 