### PR TITLE
feat(android-template)!: added density to configChanges to prevent reloading of the WebView

### DIFF
--- a/android-template/app/src/main/AndroidManifest.xml
+++ b/android-template/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -624,14 +624,9 @@ async function updateAndroidManifest(filename: string) {
   if (txt.includes('navigation')) {
     return; // Probably already updated
   }
-  let replaced = txt.replace(
+  const replaced = txt.replace(
     'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"',
-    'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"',
-  );
-
-  replaced = txt.replace(
     'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"',
-    'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"',
   );
 
   writeFileSync(filename, replaced, 'utf-8');

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -624,9 +624,14 @@ async function updateAndroidManifest(filename: string) {
   if (txt.includes('navigation')) {
     return; // Probably already updated
   }
-  const replaced = txt.replace(
+  let replaced = txt.replace(
     'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"',
+    'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"',
+  );
+
+  replaced = txt.replace(
     'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"',
+    'android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"',
   );
 
   writeFileSync(filename, replaced, 'utf-8');


### PR DESCRIPTION
Adding density to the default `android:configChanges` values prevents the webView from being reloaded on resize. Currently, there is a known issue with android that causes the repainting of the webView to fail on occasion. A bug has been created and can be tracked [here](https://issuetracker.google.com/issues/433671013). 

Alternative solutions:
- Disable hardware acceleration and resizing will work, but app functionality will be degraded.
- Tweak `android:configChanges` if you are okay with losing the state of your webView during resize events.



Example of behavior with the changes in this PR: 
https://github.com/user-attachments/assets/6cafbb1b-9ae9-4082-98ce-0bff36fd327b

