### PR TITLE
chore(ci): Use Xcode 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - /Applications/Xcode_16.app
+          - /Applications/Xcode_26.0.app
     steps:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - run: sudo xcode-select --switch /Applications/Xcode_16.app
+      - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/ios/package.json
+++ b/ios/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova",
-    "xc:build:Capacitor": "cd Capacitor && xcodebuild clean test -workspace Capacitor.xcworkspace -scheme Capacitor -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' && cd ..",
+    "xc:build:Capacitor": "cd Capacitor && xcodebuild clean test -workspace Capacitor.xcworkspace -scheme Capacitor -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' && cd ..",
     "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd .."
   },
   "peerDependencies": {


### PR DESCRIPTION
While it's still on beta, it has a symlink to `Xcode_26` so we don't need to update it once it gets updated to the final version