### PR TITLE
fix(cli): change SPM incompatible plugin message

### DIFF
--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -54,7 +54,7 @@ export async function checkPluginsForPackageSwift(config: Config, plugins: Plugi
     logger.debug(`Found ${plugins.length} iOS plugins, ${packageSwiftPluginList.length} have a Package.swift file`);
     logger.info('All plugins have a Package.swift file and will be included in Package.swift');
   } else {
-    logger.warn('Some installed packages my not be compatable with SPM');
+    logger.warn('Some installed packages are not compatable with SPM');
   }
 
   return packageSwiftPluginList;


### PR DESCRIPTION
I was going to fix the `my` typo, but ended changing the message, because if there is no `Package.swift` then the plugin is definitely not compatible, so changed the message to say so.