### PR TITLE
fix(ios): also call bridge.reset() on webViewWebContentProcessDidTerminate

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewDelegationHandler.swift
@@ -159,6 +159,7 @@ open class WebViewDelegationHandler: NSObject, WKNavigationDelegate, WKUIDelegat
 
     open func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         CAPLog.print("⚡️  WebView process terminated")
+        bridge?.reset()
         webView.reload()
     }
 


### PR DESCRIPTION
webViewWebContentProcessDidTerminate won't be called when the app is in the background but when you put it back in the foreground, so when it reloads the app and the didStartProvisionalNavigation gets called might be too late for some events

closes https://github.com/ionic-team/capacitor/issues/8101