### PR TITLE
chore(ios): Update TODO note in WebViewAssetHandler.swift

### DIFF
--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -111,7 +111,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
                     return mimetype as String
                 }
             }
-            // TODO: Remove in the future if Apple fixes the issue
+            // TODO: Remove when deployment target is set to iOS 17
             if let mimeType = mimeTypes[pathExtension] {
                 return mimeType
             }


### PR DESCRIPTION
Since I was looking into replacing the `UTType` related deprecations, I've been testing in different iOS versions and Apple fixed this issue on iOS 17, so updated the TODO to note when we can remove the code since it's fixed now, but only for iOS 17+.
Couldn't run on iOS 15 simulators on Xcode 16, but the problem was still reproducible on iOS 16 rosetta simulator.