### PR TITLE
chore: unify discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://forum.ionicframework.com/
     about: Ask questions and discuss with other community members
   - name: Chat on our Discord
-    url: https://discord.gg/UPYYRhtyzp
+    url: https://ionic.link/discord
     about: Ask questions and chat with other community members

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -33,7 +33,7 @@ closeAndLock:
     - label: "support request"
       message: >
         Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
-        bug reports and feature requests. Please use our [forum](https://forum.ionicframework.com) or our community [Discord](https://discord.gg/PvAF4Kv86P) for questions about Capacitor.
+        bug reports and feature requests. Please use our [forum](https://forum.ionicframework.com) or our community [Discord](https://ionic.link/discord) for questions about Capacitor.
 
 
         Thank you for using Capacitor!


### PR DESCRIPTION
We have different discord invite links, use the official `https://ionic.link/discord` in both places instead