### PR TITLE
fix(android): Add missing null checks in BridgeActivity

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeActivity.java
@@ -66,9 +66,9 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-		if (bridge != null) {
-			bridge.saveInstanceState(outState);
-		}
+        if (bridge != null) {
+            bridge.saveInstanceState(outState);
+        }
     }
 
     @Override
@@ -84,10 +84,10 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onRestart() {
         super.onRestart();
-		if (this.bridge != null) {
-			this.bridge.onRestart();
-			Logger.debug("App restarted");
-		}
+        if (this.bridge != null) {
+            this.bridge.onRestart();
+            Logger.debug("App restarted");
+        }
     }
 
     @Override
@@ -135,9 +135,9 @@ public class BridgeActivity extends AppCompatActivity {
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-		if (this.bridge != null) {
-			this.bridge.onDetachedFromWindow();
-		}
+        if (this.bridge != null) {
+            this.bridge.onDetachedFromWindow();
+        }
     }
 
     /**


### PR DESCRIPTION
Adds missing null checks for 3 methods in `BridgeActivity`. We have seen rare NPEs in two of these in Crashlytics.

Resolves https://github.com/ionic-team/capacitor/issues/8182