### PR TITLE
Fix `update` failing because of "Could not delete [...]/ios/App/build" xcodebuild error

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -149,7 +149,10 @@ async function updatePodfile(config: Config, plugins: Plugin[], deployment: bool
 
   const isXcodebuildAvailable = await isInstalled('xcodebuild');
   if (isXcodebuildAvailable) {
-    await runCommand('xcodebuild', ['-project', basename(`${config.ios.nativeXcodeProjDirAbs}`), 'clean'], {
+    await runCommand('xcodebuild', ['-project', basename(`${config.ios.nativeXcodeProjDirAbs}`), 
+      ...(config.ios.scheme ? ['-scheme', config.ios.scheme] : []), 
+      'clean'
+    ], {
       cwd: config.ios.nativeProjectDirAbs,
     });
   } else {


### PR DESCRIPTION
This PR fixes xcodebuild failing with `Could not delete [...]/ios/App/build because it was not created by the build system.`.

To solve this we append the scheme to the clean command.