### PR TITLE
fix(ios): Remove Cordova UIView extension

### DIFF
--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.h
@@ -24,12 +24,6 @@
 #import "CDVAvailability.h"
 #import <WebKit/WebKit.h>
 
-@interface UIView (org_apache_cordova_UIView_Extension)
-
-@property (nonatomic, weak) UIScrollView* scrollView;
-
-@end
-
 extern NSString* const CDVPageDidLoadNotification;
 extern NSString* const CDVPluginHandleOpenURLNotification;
 extern NSString* const CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification;
@@ -54,7 +48,7 @@ extern NSString* const CDVViewWillTransitionToSizeNotification;
 @interface CDVPlugin : NSObject {}
 
 - (instancetype)initWithWebViewEngine:(WKWebView *)theWebViewEngine;
-@property (nonatomic, weak) UIView* webView;
+@property (nonatomic, weak) WKWebView* webView;
 @property (nonatomic, weak) WKWebView * webViewEngine;
 @property (nonatomic, strong) NSString * className;
 

--- a/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.m
+++ b/ios/CapacitorCordova/CapacitorCordova/Classes/Public/CDVPlugin.m
@@ -18,24 +18,6 @@
  */
 
 #import "CDVPlugin.h"
-#include <objc/message.h>
-
-@implementation UIView (org_apache_cordova_UIView_Extension)
-
-@dynamic scrollView;
-
-- (UIScrollView*)scrollView
-{
-    SEL scrollViewSelector = NSSelectorFromString(@"scrollView");
-
-    if ([self respondsToSelector:scrollViewSelector]) {
-        return ((id (*)(id, SEL))objc_msgSend)(self, scrollViewSelector);
-    }
-
-    return nil;
-}
-
-@end
 
 NSString* const CDVPageDidLoadNotification = @"CDVPageDidLoadNotification";
 NSString* const CDVPluginHandleOpenURLNotification = @"CDVPluginHandleOpenURLNotification";


### PR DESCRIPTION
Cordova has deprecated the `scrollView` extension for Objective-C and removed it for Swift on the Cordova's `webView`, which is a `UIView`.
But instead of doing that in our compat code, I've removed the extension entirely and turned the `UIView` into a `WKWebView`, which already has a `scrollView`.
In Cordova they don't plan to do such thing since there might be other kind of WebView in the future since the European Union now allows to use other engines, but for Capacitor compat is always going to be a `WKWebView`, so we can safely remove the class.

This approach is non breaking for plugins unlike the Cordova's approach which requires some Swift plugin to change some code and some Objective-C plugins in the future too.

closes https://github.com/ionic-team/capacitor/issues/8022