### PR TITLE
fix(Android): range requests

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -129,7 +129,7 @@ public class WebViewLocalServer {
         }
 
         public Map<String, String> getResponseHeaders() {
-            return responseHeaders;
+            return new HashMap<>(responseHeaders);
         }
     }
 


### PR DESCRIPTION
The responseHeaders map is shared between threads, causing simultaneous requests to return the same Content-Length to the browser in case of range requests. See the illustration in https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/453 (the same issue is present Capacitor).

This PR proposes to return a copy of the map on each invocation. Based on https://github.com/ionic-team/capacitor/pull/5956 