### PR TITLE
chore(ci): Update simulator version on tests

### DIFF
--- a/ios/package.json
+++ b/ios/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "verify": "npm run xc:build:Capacitor && npm run xc:build:CapacitorCordova",
-    "xc:build:Capacitor": "cd Capacitor && xcodebuild clean test -workspace Capacitor.xcworkspace -scheme Capacitor -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' && cd ..",
+    "xc:build:Capacitor": "cd Capacitor && xcodebuild clean test -workspace Capacitor.xcworkspace -scheme Capacitor -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0.1' && cd ..",
     "xc:build:CapacitorCordova": "cd CapacitorCordova && xcodebuild && cd .."
   },
   "peerDependencies": {


### PR DESCRIPTION
tests on https://github.com/ionic-team/capacitor/pull/8195 are failing because of macos-15 removing iOS 26.0 and adding 26.0.1, so replace the version on the tests