### PR TITLE
chore(ci): increase iOS tests timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./core
   test-ios:
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - setup
       - lint


### PR DESCRIPTION
tests are failing a lot lately since we started using Xcode 26 because of timeouts, so I'm increasing the timeout from 30 minutes to 60 hoping it will finish in that time