### PR TITLE
chore(ci): upgrade GitHub Actions to v5/v6 and Node.js to 22

### DIFF
--- a/.github/workflows/capacitor-bot.yml
+++ b/.github/workflows/capacitor-bot.yml
@@ -15,7 +15,7 @@ jobs:
     name: ${{ github.event_name }}/${{ github.event.action }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ionic-team/bot@main
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Get Latest
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:
@@ -34,10 +34,10 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:
@@ -53,10 +53,10 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:
@@ -74,10 +74,10 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:
@@ -100,10 +100,10 @@ jobs:
           - /Applications/Xcode_26.0.app
     steps:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:
@@ -121,15 +121,15 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'zulu'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,13 +27,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: 'main'
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - name: set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'zulu'

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
-      - uses: actions/checkout@v4
+          node-version: 22.x
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: 'main'

--- a/.github/workflows/publish-npm-alpha.yml
+++ b/.github/workflows/publish-npm-alpha.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-beta.yml
+++ b/.github/workflows/publish-npm-beta.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-dev.yml
+++ b/.github/workflows/publish-npm-dev.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-latest-from-pre.yml
+++ b/.github/workflows/publish-npm-latest-from-pre.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-rc.yml
+++ b/.github/workflows/publish-npm-rc.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'


### PR DESCRIPTION
- Upgrade `actions/checkout` v4 → v5 (https://github.com/actions/checkout/releases/tag/v5.0.0)
- Upgrade `actions/setup-node` v4 → v6 (https://github.com/actions/setup-node/releases/tag/v6.0.0)
- Upgrade `actions/setup-java` v4 → v5 (https://github.com/actions/setup-java/releases/tag/v5.0.0
- Keep `actions/cache` on v4 (latest available)
- Upgrade `Node` from 20 to 22 across all workflows