### PR TITLE
fix(android): add command not changing namespace

### DIFF
--- a/cli/src/android/common.ts
+++ b/cli/src/android/common.ts
@@ -92,7 +92,7 @@ export async function editProjectSettingsAndroid(config: Config): Promise<void> 
   let gradleContent = await readFile(buildGradlePath, { encoding: 'utf-8' });
   gradleContent = gradleContent.replace(/applicationId "[^"]+"/, `applicationId "${appId}"`);
   // Update the namespace in build.gradle
-  gradleContent = gradleContent.replace(/namespace "[^"]+"/, `namespace "${appId}"`);
+  gradleContent = gradleContent.replace(/namespace = "[^"]+"/, `namespace = "${appId}"`);
 
   await writeFile(buildGradlePath, gradleContent, { encoding: 'utf-8' });
 


### PR DESCRIPTION
`npx cap add android` is not able to set the configured appId value (`namespace` value in `build.gradle`) because of it having a `=` now.
Fixed the regex to include the `=`.

