### PR TITLE
feat: Enable copying native resource files from Capacitor plugins to …

### DIFF
--- a/cli/src/android/update.ts
+++ b/cli/src/android/update.ts
@@ -41,6 +41,7 @@ export async function updateAndroid(config: Config): Promise<void> {
   if (cordovaPlugins.length > 0) {
     await copyPluginsNativeFiles(config, cordovaPlugins);
   }
+  await copyPluginsNativeFiles(config, capacitorPlugins);
   if (!(await pathExists(config.android.webDirAbs))) {
     await copyTask(config, platform);
   }
@@ -139,7 +140,7 @@ export async function installGradlePlugins(
   if (!capacitorAndroidPackagePath) {
     fatal(
       `Unable to find ${c.strong('node_modules/@capacitor/android')}.\n` +
-        `Are you sure ${c.strong('@capacitor/android')} is installed?`,
+      `Are you sure ${c.strong('@capacitor/android')} is installed?`,
     );
   }
 
@@ -152,19 +153,19 @@ export async function installGradlePlugins(
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('${relativeCapcitorAndroidPath}')
 ${capacitorPlugins
-  .map((p) => {
-    if (!p.android) {
-      return '';
-    }
+      .map((p) => {
+        if (!p.android) {
+          return '';
+        }
 
-    const relativePluginPath = convertToUnixPath(relative(settingsPath, p.rootPath));
+        const relativePluginPath = convertToUnixPath(relative(settingsPath, p.rootPath));
 
-    return `
+        return `
 include ':${getGradlePackageName(p.id)}'
 project(':${getGradlePackageName(p.id)}').projectDir = new File('${relativePluginPath}/${p.android.path}')
 `;
-  })
-  .join('')}`;
+      })
+      .join('')}`;
 
   const applyArray: any[] = [];
   const frameworksArray: any[] = [];
@@ -204,10 +205,10 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
 ${capacitorPlugins
-  .map((p) => {
-    return `    implementation project(':${getGradlePackageName(p.id)}')`;
-  })
-  .join('\n')}
+      .map((p) => {
+        return `    implementation project(':${getGradlePackageName(p.id)}')`;
+      })
+      .join('\n')}
 ${frameworkString}
 }
 ${applyArray.join('\n')}

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -72,6 +72,9 @@ export async function resolvePlugin(config: Config, name: string): Promise<Plugi
     if (!meta) {
       return null;
     }
+    const pluginXMLPath = join(rootPath, 'plugin.xml');
+    const xmlMeta = await readXML(pluginXMLPath);
+
     if (meta.capacitor) {
       return {
         id: name,
@@ -80,10 +83,9 @@ export async function resolvePlugin(config: Config, name: string): Promise<Plugi
         rootPath,
         repository: meta.repository,
         manifest: meta.capacitor,
+        xml: xmlMeta ? xmlMeta.plugin : undefined,
       };
     }
-    const pluginXMLPath = join(rootPath, 'plugin.xml');
-    const xmlMeta = await readXML(pluginXMLPath);
     return {
       id: name,
       name: fixName(name),

--- a/cli/test/update.android.resources.spec.ts
+++ b/cli/test/update.android.resources.spec.ts
@@ -1,0 +1,102 @@
+import { APP_ID, APP_NAME, MappedFS, makeAppDir, run, installPlatform } from './util';
+import { join } from 'path';
+import { mkdirp, writeFile } from 'fs-extra';
+import { runCommand } from '../src/util/subprocess';
+
+const CAPACITOR_PLUGIN_ID = 'capacitor-resource-plugin';
+const CAPACITOR_PLUGIN_JS = `
+module.exports = {
+  echo: function(options) {
+    return Promise.resolve(options);
+  }
+};
+`;
+
+const CAPACITOR_PLUGIN_XML = `
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    id="${CAPACITOR_PLUGIN_ID}"
+    version="1.0.0">
+    <name>Capacitor Resource Plugin</name>
+    <platform name="android">
+        <resource-file src="android/src/main/res/xml/automotive_app_desc.xml" target="res/xml/automotive_app_desc.xml" />
+    </platform>
+</plugin>
+`;
+
+const CAPACITOR_PLUGIN_PACKAGE = `
+{
+  "name": "${CAPACITOR_PLUGIN_ID}",
+  "version": "1.0.0",
+  "description": "Capacitor Resource Plugin",
+  "capacitor": {
+    "android": {
+      "src": "android"
+    }
+  },
+  "main": "plugin.js"
+}
+`;
+
+const AUTOMOTIVE_APP_DESC = `
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>
+`;
+
+async function makeCapacitorPlugin(pluginPath: string) {
+    const androidPath = join(pluginPath, 'android/src/main');
+    const resPath = join(androidPath, 'res/xml');
+    await mkdirp(resPath);
+    await writeFile(join(pluginPath, 'plugin.js'), CAPACITOR_PLUGIN_JS);
+    await writeFile(join(pluginPath, 'plugin.xml'), CAPACITOR_PLUGIN_XML);
+    await writeFile(join(pluginPath, 'package.json'), CAPACITOR_PLUGIN_PACKAGE);
+    await writeFile(join(resPath, 'automotive_app_desc.xml'), AUTOMOTIVE_APP_DESC);
+
+    // Create dummy android project structure for the plugin so it looks valid
+    await writeFile(join(androidPath, 'AndroidManifest.xml'), '<manifest></manifest>');
+}
+
+describe('Update: Android Resources', () => {
+    let appDirObj: any;
+    let appDir: string;
+    let FS: MappedFS;
+
+    beforeAll(async () => {
+        jest.setTimeout(150000);
+        appDirObj = await makeAppDir();
+        appDir = appDirObj.appDir;
+
+        // Create and install custom capacitor plugin
+        const pluginPath = join(appDirObj.path, CAPACITOR_PLUGIN_ID);
+        await makeCapacitorPlugin(pluginPath);
+
+        await runCommand('npm', ['install', '--save', pluginPath], {
+            cwd: appDir,
+        });
+
+        await run(appDir, `init "${APP_NAME}" "${APP_ID}"`);
+        await installPlatform(appDir, 'android');
+        await run(appDir, `add android`);
+        FS = new MappedFS(appDir);
+    });
+
+    afterAll(() => {
+        //appDirObj.cleanupCallback();
+    });
+
+    it('Should copy resource-file from Capacitor plugin', async () => {
+        // Run update to trigger the copy
+        await run(appDir, `update android`);
+
+        const resourcePath = 'android/capacitor-cordova-android-plugins/src/main/res/xml/automotive_app_desc.xml';
+        const exists = await FS.exists(resourcePath);
+        expect(exists).toBe(true);
+
+        if (exists) {
+            const content = await FS.read(resourcePath);
+            expect(content).toContain('<uses name="media"/>');
+        }
+    });
+});


### PR DESCRIPTION
closes #8273 
Description

This PR adds support for the` <resource-file>` tag in `plugin.xml `for Capacitor Core plugins, bringing parity with Cordova plugin handling.

Changes

Updated resolvePlugin to parse` plugin.xml `for Capacitor Core plugins.

Updated updateAndroid to copy resource files defined under` <resource-file>` into the Android project during cap sync/update.

Verification

Added integration test: `test/update.android.resources.spec.ts`

Confirmed that resource files are correctly copied into `android/capacitor-cordova-android-plugins/src/main/res/xml/.`

Related

Fixes missing resource merging for Android Auto–related plugins.