### PR TITLE
fix(android): Remove calculated bottom inset if keyboard is visible

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -165,8 +165,8 @@ public class SystemBars extends Plugin {
                     boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
 
                     if (keyboardVisible) {
-                        safeAreaInsets = Insets.of(safeAreaInsets.left,safeAreaInsets.top, safeAreaInsets.right, 0);
-                        
+                        safeAreaInsets = Insets.of(safeAreaInsets.left, safeAreaInsets.top, safeAreaInsets.right, 0);
+
                         Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
                         setViewMargins(v, Insets.of(0, 0, 0, imeInsets.bottom));
                     } else {


### PR DESCRIPTION
fixes: https://github.com/ionic-team/capacitor/issues/8277