### PR TITLE
feat: allow spm platforms to select os without being overwritten

### DIFF
--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -125,13 +125,14 @@ export function getMajorMinoriOSVersion(config: Config): string {
   // Extract until semicolon or newline (typical end of value in pbxproj)
   const endIndex = pbx.indexOf(';', valueStart);
   const newlineIndex = pbx.indexOf('\n', valueStart);
-  const actualEnd = endIndex !== -1 && newlineIndex !== -1 
-    ? Math.min(endIndex, newlineIndex)
-    : endIndex !== -1 
-      ? endIndex 
-      : newlineIndex !== -1 
-        ? newlineIndex 
-        : pbx.length;
+  const actualEnd =
+    endIndex !== -1 && newlineIndex !== -1
+      ? Math.min(endIndex, newlineIndex)
+      : endIndex !== -1
+        ? endIndex
+        : newlineIndex !== -1
+          ? newlineIndex
+          : pbx.length;
   let iosVersion = pbx.substring(valueStart, actualEnd).trim();
   // Remove trailing .0 if present
   if (iosVersion.endsWith('.0')) {

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -113,3 +113,29 @@ export function getMajoriOSVersion(config: Config): string {
   );
   return iosVersion;
 }
+
+export function getMajorMinoriOSVersion(config: Config): string {
+  const pbx = readFileSync(join(config.ios.nativeXcodeProjDirAbs, 'project.pbxproj'), 'utf-8');
+  const searchString = 'IPHONEOS_DEPLOYMENT_TARGET = ';
+  const startIndex = pbx.indexOf(searchString);
+  if (startIndex === -1) {
+    return '';
+  }
+  const valueStart = startIndex + searchString.length;
+  // Extract until semicolon or newline (typical end of value in pbxproj)
+  const endIndex = pbx.indexOf(';', valueStart);
+  const newlineIndex = pbx.indexOf('\n', valueStart);
+  const actualEnd = endIndex !== -1 && newlineIndex !== -1 
+    ? Math.min(endIndex, newlineIndex)
+    : endIndex !== -1 
+      ? endIndex 
+      : newlineIndex !== -1 
+        ? newlineIndex 
+        : pbx.length;
+  let iosVersion = pbx.substring(valueStart, actualEnd).trim();
+  // Remove trailing .0 if present
+  if (iosVersion.endsWith('.0')) {
+    iosVersion = iosVersion.slice(0, -2);
+  }
+  return iosVersion;
+}

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -8,7 +8,7 @@ import { extract } from 'tar';
 import { getCapacitorPackageVersion } from '../common';
 import type { Config } from '../definitions';
 import { fatal } from '../errors';
-import { getMajoriOSVersion } from '../ios/common';
+import { getMajorMinoriOSVersion } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
 import { getPluginType, PluginType } from '../plugin';
@@ -92,7 +92,7 @@ export async function removeCocoapodsFiles(config: Config): Promise<void> {
 
 export async function generatePackageText(config: Config, plugins: Plugin[]): Promise<string> {
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
-  const iosVersion = getMajoriOSVersion(config);
+  const iosVersion = getMajorMinoriOSVersion(config);
 
   let packageSwiftText = `// swift-tools-version: 5.9
 import PackageDescription

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -100,7 +100,7 @@ import PackageDescription
 // DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
 let package = Package(
     name: "CapApp-SPM",
-    platforms: [.iOS(.v${iosVersion})],
+    platforms: [.iOS(${iosVersion.includes('.') ? `"${iosVersion}"` : `.v${iosVersion}`})],
     products: [
         .library(
             name: "CapApp-SPM",


### PR DESCRIPTION
## Problem

When using Swift Package Manager (SPM), the Capacitor CLI currently defaults to iOS 15.0 as the minimum deployment target, regardless of what is configured in Xcode build settings. This causes issues when plugins require a higher minimum iOS version, particularly for security reasons.

### Related Work

[PR #7556](https://github.com/ionic-team/capacitor/pull/7556) attempted to address this issue by reading the iOS deployment target from the Xcode project configuration. However, it did not fully solve the problem because:

1. **It only reads the major version** - The implementation reads only 2 characters from the deployment target, which means it cannot handle minor versions like `15.5` (it would only read `15`)
2. **It uses the wrong format** - It generates `.iOS(.v15)` format, which doesn't support dot versions. According to Apple's documentation, versions with minor numbers (like 15.5) must use the `.iOS("15.5")` string format instead

This PR builds upon that work by properly reading the full version (including minor versions) and using the correct Swift Package Manager format.

### Security Impact

This is particularly critical for plugins that depend on libraries with security requirements. For example, [ZipArchive requires iOS 15.5+](https://github.com/ZipArchive/ZipArchive?tab=readme-ov-file#version-250-updates-minimum-os-versions) due to a security vulnerability (CVE-2018-25032) in zlib versions before 1.2.12. zlib 1.2.12 is only included in iOS 15.5+ and later versions.

When Capacitor CLI generates a `Package.swift` file with `.iOS(.v15)` instead of `.iOS("15.5")`, it prevents proper enforcement of the security requirement, potentially exposing apps to known vulnerabilities. Furthermore, the project will simply not build if the minimum iOS version is not met.

## Solution

This PR fixes the SPM platform version generation to:

1. **Read the full iOS deployment target** (including minor versions like 15.5) from the Xcode project configuration
2. **Use the correct Swift Package Manager format** based on Apple's documentation:
   - `.iOS("15.5")` when a dot version is detected (required for versions like 15.5)
   - `.iOS(.v15)` when no dot version is detected (for major versions only)

This ensures that the generated `Package.swift` accurately reflects the iOS deployment target configured in Xcode, allowing plugins with security requirements (like ZipArchive) to properly enforce their minimum iOS version requirements.

## Changes

- Added `getMajorMinoriOSVersion()` function to read the full iOS deployment target (including minor versions) from `project.pbxproj`
- Updated SPM `Package.swift` generation to use the correct platform version format based on whether a dot version is present
- Fixed iOS enum usage in platform version formatting

## Documentation

- [Apple's PackageDescription documentation](https://developer.apple.com/documentation/packagedescription/supportedplatform/ios(_:)-83bbf) - explains the `.iOS("15.5")` format requirement
- [ZipArchive security requirements](https://github.com/ZipArchive/ZipArchive?tab=readme-ov-file#version-250-updates-minimum-os-versions) - explains why iOS 15.5+ is required for security

## Availability

This fix is already available in our fork [Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus) and can be installed via npm:

```bash
npm install @capacitor-plus/cli
```

## Testing

Tested manually with a Capacitor app configured for iOS 15.5 deployment target. The generated `Package.swift` now correctly uses `.iOS("15.5")` format.
