### PR TITLE
fix(cli): use latest native-run

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "env-paths": "^2.2.0",
     "fs-extra": "^11.2.0",
     "kleur": "^4.1.5",
-    "native-run": "^2.0.1",
+    "native-run": "^2.0.2",
     "open": "^8.4.0",
     "plist": "^3.1.0",
     "prompts": "^2.4.2",


### PR DESCRIPTION
Update native-run to version 2.0.2, which fixes an issue with Android emulator selection.