### PR TITLE
fix(cli): Support wireless iOS devices in `cap run`

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "env-paths": "^2.2.0",
     "fs-extra": "^11.2.0",
     "kleur": "^4.1.5",
-    "native-run": "^2.0.2",
+    "native-run": "^2.0.3",
     "open": "^8.4.0",
     "plist": "^3.1.0",
     "prompts": "^2.4.2",


### PR DESCRIPTION
Via native-run 2.0.3: https://github.com/ionic-team/native-run/pull/398