### PR TITLE
fix(http): Fix throwing data URI requests on iOS

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
+++ b/ios/Capacitor/Capacitor/Plugins/HttpRequestHandler.swift
@@ -238,7 +238,13 @@ open class HttpRequestHandler {
                 var output = [:] as [String: Any]
                 output["status"] = 200
                 output["headers"] = headers
-                output["data"] = String(data: data!, encoding: .utf8)
+
+                if let data = data {
+                    output["data"] = String(data: data, encoding: .utf8)
+                } else {
+                    output["data"] = ""
+                }
+
                 call.resolve(output)
             } else {
                 call.reject("Unknown response kind")


### PR DESCRIPTION
Since Capacitor 8.0 data: requests throw because NSURLResponse is not a HTTPURLRepsonse