### PR TITLE
fix(core): make SystemBars hide and show options optional

### DIFF
--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -617,14 +617,14 @@ export interface SystemBarsPlugin {
    *
    * @since 8.0.0
    */
-  show(options: SystemBarsVisibilityOptions): Promise<void>;
+  show(options?: SystemBarsVisibilityOptions): Promise<void>;
 
   /**
    * Hide the system bars.
    *
    * @since 8.0.0
    */
-  hide(options: SystemBarsVisibilityOptions): Promise<void>;
+  hide(options?: SystemBarsVisibilityOptions): Promise<void>;
 
   /**
    * Set the animation to use when showing / hiding the status bar.

--- a/core/system-bars.md
+++ b/core/system-bars.md
@@ -39,7 +39,7 @@ To control this behavior, use the `insetsHandling` configuration setting.
 ## Example
 
 ```typescript
-import { SystemBars, SystemBarsStyle } from '@capacitor/core';
+import { SystemBars, SystemBarsStyle, SystemBarType } from '@capacitor/core';
 
 const setSystemBarStyleDark = async () => {
   await SystemBars.setStyle({ style: SystemBarsStyle.Dark });
@@ -152,7 +152,7 @@ Set the current style of the system bars.
 ### show(...)
 
 ```typescript
-show(options: SystemBarsVisibilityOptions) => Promise<void>
+show(options?: SystemBarsVisibilityOptions) => Promise<void>
 ```
 
 Show the system bars.
@@ -169,7 +169,7 @@ Show the system bars.
 ### hide(...)
 
 ```typescript
-hide(options: SystemBarsVisibilityOptions) => Promise<void>
+hide(options?: SystemBarsVisibilityOptions) => Promise<void>
 ```
 
 Hide the system bars.


### PR DESCRIPTION
`SystemBars.hide();` and `SystemBars.show();` code in the example is not compiling because the options were not made optional, changing them to optional since the attributes of the object can both be optional.

Also `SystemBarType` is being used in the example but not imported, so added it to the import line.