### PR TITLE
fix(cli): upgrade package tar to address high vulnerability

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -58,7 +58,7 @@
     "prompts": "^2.4.2",
     "rimraf": "^6.0.1",
     "semver": "^7.6.3",
-    "tar": "^6.1.11",
+    "tar": "^7.5.4",
     "tslib": "^2.8.1",
     "xml2js": "^0.6.2"
   },
@@ -69,7 +69,6 @@
     "@types/plist": "^3.0.5",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.5.8",
-    "@types/tar": "^6.1.1",
     "@types/tmp": "^0.2.6",
     "@types/xml2js": "0.4.5",
     "jest": "^29.7.0",

--- a/cli/src/util/template.ts
+++ b/cli/src/util/template.ts
@@ -1,7 +1,7 @@
 import { mkdirp } from 'fs-extra';
-import tar from 'tar';
+import { extract } from 'tar';
 
 export async function extractTemplate(src: string, dir: string): Promise<void> {
   await mkdirp(dir);
-  await tar.extract({ file: src, cwd: dir });
+  await extract({ file: src, cwd: dir });
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
     "@types/node": "18.18.6",
-    "@types/tar": "^6.1.2",
     "eslint": "^8.57.0",
     "lerna": "^7.1.3",
     "prettier": "^3.3.0",
@@ -41,6 +40,6 @@
     "rimraf": "^4.4.1",
     "semver": "^7.3.7",
     "swiftlint": "^2.0.0",
-    "tar": "^6.1.11"
+    "tar": "^7.5.4"
   }
 }

--- a/scripts/pack-cli-assets.mjs
+++ b/scripts/pack-cli-assets.mjs
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import tar from 'tar';
+import { create } from 'tar';
 
 import { execute } from './lib/cli.mjs';
 import { mkdir } from './lib/fs.mjs';
@@ -25,7 +25,7 @@ execute(async () => {
 
     const files = await lsfiles(templatePath, { cwd: templatePath });
 
-    await tar.create({ gzip: true, file: dest, cwd: templatePath }, files);
+    await create({ gzip: true, file: dest, cwd: templatePath }, files);
 
     console.log(`Packed ${dest}!`);
   }


### PR DESCRIPTION
Upgrade "tar" to version 7.5.4, the only non-deprecated version of `tar`. This new version of `tar` fixes https://github.com/advisories/GHSA-8qq5-rm4j-mr97

Closes #8310