### PR TITLE
fix(android): AGP 9.0 no longer supports `proguard-android.txt`

### DIFF
--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -53,7 +53,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
This change replaces the default proguard file `proguard-android.txt` with `proguard-android-optimize.txt` which allows proguard optimizations.

Alternatively, AGP 9 compatibility can be achieved by opting out of the change with `android.r8.globalOptionsInConsumerRules.disallowed=false`

fixes: https://github.com/ionic-team/capacitor/issues/8314