### PR TITLE
fix(cookies): only send expires param on web if valid date

### DIFF
--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -110,7 +110,7 @@ export class CapacitorCookiesPluginWeb extends WebPlugin implements CapacitorCoo
       const encodedValue = encode(options.value);
 
       // Clean & sanitize options
-      const expires = `; expires=${(options.expires || '').replace('expires=', '')}`; // Default is "; expires="
+      const expires = options.expires ? `; expires=${options.expires.replace('expires=', '')}` : '';
 
       const path = (options.path || '/').replace('path=', ''); // Default is "path=/"
       const domain = options.url != null && options.url.length > 0 ? `domain=${options.url}` : '';


### PR DESCRIPTION
This PR fixes an issue with `CapacitorCookies.setCookie()` on web / PWA where cookies were not being set properly if the expires date was empty or improperly formatted