### PR TITLE
fix(cli): `cap run` fails with renamed outputs for android

### DIFF
--- a/cli/src/android/run.ts
+++ b/cli/src/android/run.ts
@@ -54,7 +54,7 @@ export async function runAndroid(
     config.android.appDir
   }/build/outputs/apk${runFlavor !== '' ? '/' + runFlavor : ''}/debug`;
 
-  const apkName = parseApkNameFromFlavor(runFlavor);
+  const apkName = await parseApkNameFromFlavor(runFlavor, pathToApk);
   const apkPath = resolve(pathToApk, apkName);
 
   const nativeRunArgs = ['android', '--app', apkPath, '--target', target.id];

--- a/cli/src/common.ts
+++ b/cli/src/common.ts
@@ -536,7 +536,15 @@ export async function checkJDKMajorVersion(): Promise<number> {
   }
 }
 
-export function parseApkNameFromFlavor(flavor: string): string {
+export async function parseApkNameFromFlavor(flavor: string, pathToApk: string): Promise<string> {
+  if (!flavor) {
+        const metadataPath = join(pathToApk, 'output-metadata.json');
+        if (await pathExists(metadataPath)) {
+            const metadataContent = await readJSON(metadataPath);
+            if (metadataContent && metadataContent.elements && metadataContent.elements.length && metadataContent.elements[0].outputFile)
+              return metadataContent.elements[0].outputFile;
+        }
+    }
   let convertedName = flavor.replace(/([A-Z])/g, '-$1').toLowerCase();
 
   if (convertedName.startsWith('-')) convertedName = convertedName.replace('-', '');

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -221,7 +221,7 @@ async function loadAndroidConfig(
   if (extConfig.android?.flavor) {
     apkPath = `${apkPath}/${extConfig.android?.flavor}`;
   }
-  const apkName = parseApkNameFromFlavor(flavor);
+  const apkName = await parseApkNameFromFlavor(flavor, `${platformDirAbs}/${apkPath}debug`);
   const buildOutputDir = `${apkPath}/debug`;
   const cordovaPluginsDir = 'capacitor-cordova-android-plugins';
   const studioPath = lazy(() => determineAndroidStudioPath(cliConfig.os));


### PR DESCRIPTION
The changes made in this PR are according to the solution provided in the issue #8040. (This PR closes this issue)

The changes are made to `parseApkNameFromFlavor` function definition present in cli/src/common.ts file. And also in locations where this function is called (like in cli/src/config.ts and cli/src/android/run.ts files) to change the function call structure. I tried to use only the existing library methods.

The new changes work only in the following scenarios. If any of the following scenarios fail, then the code falls back to previous version of `parseApkNameFromFlavor` function definition.

1. No flavor option is present. (I don't want to change the code when flavor is present, as I don't completely understand how that specific use case differs)
2. When output-metadata.json file is present in the intended location. (This fails when we scaffolded a new project which doesn't contain the file or if the filename gets changed in some way)
3. When file's json structure is similar to following json structure. (I don't know if this can be different in other projects but to ensure my code only works for this structure)
```
{
  "version": 3,
  "artifactType": {
    "type": "APK",
    "kind": "Directory"
  },
  "applicationId": "com.example.app",
  "variantName": "debug",
  "elements": [
    {
      "type": "SINGLE",
      "filters": [],
      "attributes": [],
      "versionCode": 1,
      "versionName": "1.0",
      "outputFile": "new-app-name-debug.apk"
    }
  ],
  "elementType": "File",
  "minSdkVersionForDexing": 24
}
```

I have tested this changed version on a scaffolded new project. My tests are:

1. I don't change output filename in build.gradle file and the output-metadata.json file is not present. (apk name stays as "app-debug.apk" and is deployed to android emulator)
2. After changing output filename in build.gradle file. (apk name changes to new name and is deployed to android emulator without any error)