### PR TITLE
fix(cli): Allow to run update on non macOS

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -136,10 +136,12 @@ async function updatePodfile(config: Config, plugins: Plugin[], deployment: bool
     await runCommand('bundle', ['exec', 'pod', 'install', ...(deployment ? ['--deployment'] : [])], {
       cwd: config.ios.nativeProjectDirAbs,
     });
-  } else {
+  } else if (await isInstalled('pod')) {
     await runCommand(podPath, ['install', ...(deployment ? ['--deployment'] : [])], {
       cwd: config.ios.nativeProjectDirAbs,
     });
+  } else {
+    logger.warn('Skipping pod install because CocoaPods is not installed');
   }
 
   const isXcodebuildAvailable = await isInstalled('xcodebuild');


### PR DESCRIPTION
On https://github.com/ionic-team/capacitor/pull/8321 I forgot we need to allow update to work on linux/windows, by skipping the pod install step if not installed

closes https://github.com/ionic-team/capacitor/issues/8342