### PR TITLE
fix!: replace deprecated `@UIApplicationMain` with `@main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
   lint:
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -48,7 +48,7 @@ jobs:
       - run: npm run lint
   test-cli:
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - setup
       - lint
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./cli
   test-core:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - setup
       - lint
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./core
   test-ios:
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - setup
       - lint
@@ -118,7 +118,7 @@ jobs:
         run: sh ./scripts/native-podspec.sh lint
   test-android:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs:
       - setup
       - lint


### PR DESCRIPTION
This merge request concerns only the iOS platform.

With Swift 6, the @UIApplicationMain has been deprecated and make the build to fail. This MR will use the @main instead on the AppDelegate on the iOS template used when capacitor adds ios as a platform