### PR TITLE
Do not pass data: fetch requests to the native http request handler

### DIFF
--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -508,7 +508,7 @@ const initBridge = (w: any): void => {
             options.headers = headers;
           }
           const request = new Request(resource, options);
-          if (request.url.startsWith(`${cap.getServerUrl()}/`)) {
+          if (request.url.startsWith(`${cap.getServerUrl()}/`) || request.url.startsWith('data:')) {
             return win.CapacitorWebFetch(resource, options);
           }
           const { method } = request;


### PR DESCRIPTION
For all sorts of reasons, a fetch request of data URI might be executed.

```js
fetch(new URL('data:text/css,body{background:red}'))
```

At the moment these requests are forwarded to the native request, causing crashes like the one that PR #8304 is trying to solve. With this PR, `data:` requests will not be forwarded anymore to native request layer.

Just to explain why, in my app, I am fetching a DATA CSS Uri.
- in my app the following code `fetch(new URL('./file.css'))`
- is compiled by Vite as `fetch(new URL('data:text/css,body{background:red}'))`
- so, while I am not intentionally fetching a data URI, it is compiled as such, because the resource is so small that Vite modifies it to [an inline asset](https://vite.dev/guide/assets#importing-asset-as-url)