### PR TITLE
fix(docs): fix typo in CapApp-SPM README

### DIFF
--- a/ios-spm-template/App/CapApp-SPM/README.md
+++ b/ios-spm-template/App/CapApp-SPM/README.md
@@ -1,5 +1,5 @@
 # CapApp-SPM
 
-This SPM is used to host SPM dependencies for your Capacitor project
+This package is used to host SPM dependencies for your Capacitor project
 
 Do not modify the contents of it or there may be unintended consequences.


### PR DESCRIPTION
There was a typo in the CapApp-SPM README. This PR fixes the typo.