### PR TITLE
chore(cli)!: Remove unused livereload method and parameter

### DIFF
--- a/cli/src/util/livereload.ts
+++ b/cli/src/util/livereload.ts
@@ -112,11 +112,7 @@ class CapLiveReload {
     return !all.length ? loopback(family) : all[0];
   }
 
-  async editCapConfigForLiveReload(
-    config: Config,
-    platformName: string,
-    options: RunCommandOptions,
-  ): Promise<void> {
+  async editCapConfigForLiveReload(config: Config, platformName: string, options: RunCommandOptions): Promise<void> {
     const platformAbsPath =
       platformName == config.ios.name
         ? config.ios.nativeTargetDirAbs


### PR DESCRIPTION
Saw some TODOs set to remove code in `livereload.ts`, addressing them in this PR.

Since it's possibly users are consuming `CapLiveReload` directly, this is a breaking change.

Now that we have a next major planned, this can be done in `next` branch.