### PR TITLE
fix(ios): prevent Cordova package generation race condition

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -68,9 +68,11 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
 }
 
 async function generateCordovaPackageFiles(cordovaPlugins: Plugin[], config: Config) {
-  cordovaPlugins.map((plugin: any) => {
-    generateCordovaPackageFile(plugin, config);
-  });
+  await Promise.all(
+    cordovaPlugins.map((plugin: any) => {
+      return generateCordovaPackageFile(plugin, config);
+    })
+  );
 }
 
 async function generateCordovaPackageFile(p: Plugin, config: Config) {
@@ -238,8 +240,8 @@ function isFramework(framework: any) {
 async function generateCordovaPodspecs(cordovaPlugins: Plugin[], config: Config) {
   const staticPlugins = cordovaPlugins.filter((p) => needsStaticPod(p));
   const noStaticPlugins = cordovaPlugins.filter((el) => !staticPlugins.includes(el));
-  generateCordovaPodspec(noStaticPlugins, config, false);
-  generateCordovaPodspec(staticPlugins, config, true);
+  await generateCordovaPodspec(noStaticPlugins, config, false);
+  await generateCordovaPodspec(staticPlugins, config, true);
 }
 
 async function generateCordovaPodspec(cordovaPlugins: Plugin[], config: Config, isStatic: boolean) {


### PR DESCRIPTION
This PR fixes the issue reported in #8251 where the CLI does not wait for Cordova package `.swift` and `.podspec` files to finish generating before continuing the update flow.

The package manager checks were addressed in #8321, and this PR addresses the remaining race condition.

Changes:
- Await `generateCordovaPackageFile` inside `generateCordovaPackageFiles`.
- Await `generateCordovaPodspec` inside `generateCordovaPodspecs`.

Fixes #8251