### PR TITLE
feat(cli): Experimental config for swift-tools-version in SPM apps

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -509,6 +509,42 @@ export interface CapacitorConfig {
     };
   };
 
+  experimental?: {
+    /**
+     * Experimental iOS-specific configuration.
+     *
+     * These options may change or be removed in future versions.
+     *
+     * @since 8.2.0
+     */
+    ios?: {
+      /**
+       * Swift Package Manager (SPM) specific configuration.
+       *
+       * @since 8.2.0
+       */
+      spm?: {
+        /**
+         * Swift tools version to use in Package.swift header.
+         *
+         * Defines the minimum version of the Swift compiler version required to build your app.
+         * For more information check the [swift documentation](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/)
+         *
+         * Warning: Capacitor does not officially support Swift 6 yet.
+         * Setting this property to 6.0 or higher may cause issues.
+         * If you need to set this property to 6.0 or higher, make sure to throughrouly test your iOS app.
+         *
+         * This setting may graduate to `ios.spm.swiftToolsVersion` in a future major release.
+         *
+         * @since 8.2.0
+         * @default '5.9'
+         * @example '6.1'
+         */
+        swiftToolsVersion?: string;
+      };
+    };
+  };
+
   server?: {
     /**
      * Configure the local hostname of the device.

--- a/cli/src/ios/common.ts
+++ b/cli/src/ios/common.ts
@@ -11,6 +11,7 @@ import type { Config } from '../definitions';
 import { logger } from '../log';
 import { PluginType, getPluginPlatform } from '../plugin';
 import type { Plugin } from '../plugin';
+import { checkSwiftToolsVersion } from '../util/spm';
 import { isInstalled, runCommand } from '../util/subprocess';
 
 export async function checkIOSPackage(config: Config): Promise<string | null> {
@@ -32,6 +33,11 @@ export async function getCommonChecks(config: Config): Promise<CheckFunction[]> 
     checks.push(() => checkBundler(config));
   } else if ((await config.ios.packageManager) === 'Cocoapods') {
     checks.push(() => checkCocoaPods(config));
+  } else if ((await config.ios.packageManager) === 'SPM') {
+    const swiftToolsVersion = config.app.extConfig.experimental?.ios?.spm?.swiftToolsVersion;
+    if (swiftToolsVersion) {
+      checks.push(() => checkSwiftToolsVersion(config, swiftToolsVersion));
+    }
   }
   return checks;
 }

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -98,8 +98,9 @@ export async function removeCocoapodsFiles(config: Config): Promise<void> {
 export async function generatePackageText(config: Config, plugins: Plugin[]): Promise<string> {
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
   const iosVersion = getMajoriOSVersion(config);
+  const swiftToolsVersion = config.app.extConfig.experimental?.ios?.spm?.swiftToolsVersion ?? '5.9';
 
-  let packageSwiftText = `// swift-tools-version: 5.9
+  let packageSwiftText = `// swift-tools-version: ${swiftToolsVersion}
 import PackageDescription
 
 // DO NOT MODIFY THIS FILE - managed by Capacitor CLI commands
@@ -186,6 +187,23 @@ export async function addInfoPlistDebugIfNeeded(config: Config): Promise<void> {
   } else {
     logger.warn(infoPlist + ' not found.');
   }
+}
+
+export async function checkSwiftToolsVersion(config: Config, version: string | undefined): Promise<string | null> {
+  if (!version) {
+    return null;
+  }
+
+  const swiftToolsVersionRegex = /^[0-9]+\.[0-9]+(\.[0-9]+)?$/;
+
+  if (!swiftToolsVersionRegex.test(version)) {
+    return (
+      `Invalid Swift tools version: "${version}".\n` +
+      `The Swift tools version must be in major.minor or major.minor.patch format (e.g., "5.9", "6.0", "5.9.2").`
+    );
+  }
+
+  return null;
 }
 
 // Private Functions


### PR DESCRIPTION
## PR Description

⚠️ AI-assisted PR with Claude, manually reviewed and verified by me.

This PR adds a new experimental for setting `swift-tools-version` in the `CapApp-SPM/Package.swift` file. The reason why this feature is marked experimental is because Capacitor does not support Swift 6 yet, and therefore using this config to set `swift-tools-version` to 6.x can cause issues for their apps, depending on the plugins the app has, their dependencies, and what Swift version they were built with.

Usage example in `capacitor.config.json`:

```
{
	// other configs...
	"experimental": {
		"ios": {
			"spm": {
				"swiftToolsVersion": "6.1"
			}
		}
	}
}
```

Related to https://github.com/ionic-team/capacitor/pull/8351, as a way for users to make a more conscious opt-in for Package Traits in SPM.

## Testing

I've tested setting SwiftToolsVersion '6.1', and also '6.2.1' (latest in current stable Xcode version) with most official Capacitor plugins across different apps, and the apps build and plugins working without issues.

Feel free to create your own apps, point to the local version of capacitor (cli) containing this PR branch, add the experimental config, run `cap sync`, build the app with Xcode and test.