### PR TITLE
docs(cli): Better descriptions for live-reload parameters

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -249,11 +249,11 @@ export function runProgram(config: Config): void {
     )
     .option('--no-sync', `do not run ${c.input('sync')}`)
     .option('--forwardPorts <port:port>', 'Automatically run "adb reverse" for better live-reloading support')
-    .option('-l, --live-reload', 'Set live-reload server URL via CLI (uses defaults, overrides server.url config)')
-    .option('--host <host>', 'Change default host for live-reload server (used with --live-reload)')
-    .option('--port <port>', 'Change default port for live-reload server (used with --live-reload)')
+    .option('-l, --live-reload', 'Set live-reload URL via CLI (uses defaults, overrides server.url config)')
+    .option('--host <host>', 'Configure host for live-reload URL (used with --live-reload)')
+    .option('--port <port>', 'Configure port for live-reload URL (used with --live-reload)')
     .option('--configuration <name>', 'Configuration name of the iOS Scheme')
-    .option('--https', 'Use https:// instead of http:// for live-reload server (used with --live-reload)')
+    .option('--https', 'Use https:// instead of http:// for live-reload URL (used with --live-reload)')
     .action(
       wrapAction(
         telemetryAction(


### PR DESCRIPTION
Alternative PR to https://github.com/ionic-team/capacitor/pull/8370

I had not realised that the `--live-reload` option overrides the `server.url` CapacitorConfig on purpose - In fact, the purpose of this property is really to allow to point to a certain live-reload server in the CLI, without having to set it in Capacitor Config (e.g. to avoid accidentally deploying that URL to production).

The description of the CLI option however was not the best, as it indicated "Enable Live Reload", when it fact it doesn't really do that. You can set `server.url` in Capacitor Config, and run `cap run` without `--live-reload`, and live reload should still work.

Therefore, in this PR I update the descriptions of the live reload CLI options to better reflect what they actually do.

FYI @aolsenjazz 