### PR TITLE
refactor(android)!: Remove deprecated `PathHandler#getResponseHeaders`

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/WebViewLocalServer.java
@@ -128,19 +128,6 @@ public class WebViewLocalServer {
             return reasonPhrase;
         }
 
-        /**
-         * @deprecated This method may return incorrect headers in concurrent range requests.
-         * <p>
-         * Use {@link #buildDefaultResponseHeaders()} instead, which returns a copy of the map.
-         * </p>
-         * This method will be removed in a future major version of Capacitor.
-         * </p>
-         */
-        @Deprecated(forRemoval = true) // adjust version as appropriate
-        public Map<String, String> getResponseHeaders() {
-            return responseHeaders;
-        }
-
         public Map<String, String> buildDefaultResponseHeaders() {
             return new HashMap<>(responseHeaders);
         }


### PR DESCRIPTION
The `PathHandler#getResponseHeaders` is going to be deprecated in Capacitor 8 - from https://github.com/ionic-team/capacitor/pull/8357

This PR removes the method for Capacitor 9, to avoid causing issues for any user that may consume `PathHandler` externally. I don't think there's any benefit to delay the removal, so I'm proposing to do it now.