### PR TITLE
docs(cli): Better descriptions for live-reload parameters

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -244,9 +244,9 @@ export function runProgram(config: Config): void {
     .option('--target <id>', 'use a specific target')
     .option('--no-sync', `do not run ${c.input('sync')}`)
     .option('--forwardPorts <port:port>', 'Automatically run "adb reverse" for better live-reloading support')
-    .option('-l, --live-reload', 'Enable Live Reload')
-    .option('--host <host>', 'Host used for live reload')
-    .option('--port <port>', 'Port used for live reload')
+    .option('-l, --live-reload', 'Set live-reload URL via CLI (uses defaults, overrides server.url config)')
+    .option('--host <host>', 'Configure host for live-reload URL (used with --live-reload)')
+    .option('--port <port>', 'Configure port for live-reload URL (used with --live-reload)')
     .option('--configuration <name>', 'Configuration name of the iOS Scheme')
     .action(
       wrapAction(


### PR DESCRIPTION
## Description

Equivalent to https://github.com/ionic-team/capacitor/pull/8373, but for 7.x maintenance branch.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation

## Rationale / Problems Fixed

The reason why we're including this PR in 7.x is to provide better clarity on live-reload functionality (or lack there-of) in all maintained versions of Capacitor, since it has been a cause for confusion.

Didn't do a straight cherry-pick because 7.x does not have the `--https` feature in the CLI.

## Tests or Reproductions

N/A

## Screenshots / Media

N/A

## Platforms Affected
- [ ] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->

N/A
