### PR TITLE
fix(cli)!: Remove default port for --live-reload

### DIFF
--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -43,9 +43,6 @@ export async function runCommand(
   options: RunCommandOptions,
 ): Promise<void> {
   options.host = options.host ?? CapLiveReloadHelper.getIpAddress() ?? 'localhost';
-  if (!options.https && !options.port) {
-    options.port = '3000';
-  }
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {


### PR DESCRIPTION
## Description

This PR removes the default `--port` value for `--live-reload`. When adding the [--https](), we already opted out of having a default, and with this (breaking) change there's consistency.

With this PR, if no `--port` nor `--http` is specified, the url will be like so `http://<host>`; in other words, will run in the default port for http (80).

An alternative to this is to merge `--host`, `--port`, and `--https` CLI args into a single `--url` or `--live-reload-url` arg, that would directly override `server.url` config. I am inclined to open a separate PR for that and the team can decide which one is preferable.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed

Port '3000' isn't widely used for local servers, maybe it made sense once upon a time, but not anymore.

There has been confusion regarding the use of a default port for `--live-reload` (there's probably older links, but these should suffice to justify the change):

- https://github.com/ionic-team/capacitor/issues/8303
- https://github.com/ionic-team/capacitor/pull/8194#pullrequestreview-3862531009 

Since the port may change depending on what's the underlying stack used to setup live-reload, the framework shouldn't make assumptions on the port to use.

## Tests or Reproductions

You can use any existing capacitor app to test, you just need to point to the local capacitor cli version from this PR's branch.

For reference, I used https://github.com/OS-pedrogustavobilro/capacitor-test-livereload

## Screenshots / Media

Not relevant

## Platforms Affected
- [ ] Android
- [ ] iOS
- [ ] Web

## Notes / Comments

N/A