### PR TITLE
fix(cli): respect server config for host and port during live reload

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -608,6 +608,14 @@ export interface CapacitorConfig {
      * @default null
      */
     appStartPath?: string;
+
+    /**
+     * The port the local web server should listen on.
+     *
+     * @since 8.2.0
+     * @default 3000
+     */
+    port?: number;
   };
 
   cordova?: {

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -42,10 +42,15 @@ export async function runCommand(
   selectedPlatformName: string,
   options: RunCommandOptions,
 ): Promise<void> {
-  options.host = options.host ?? CapLiveReloadHelper.getIpAddress() ?? 'localhost';
-  if (!options.https && !options.port) {
-    options.port = '3000';
+  const serverConfig = config.app.extConfig?.server;
+  options.host = options.host ?? serverConfig?.hostname ?? serverConfig?.url?.replace(/^https?:\/\//, '').split(':')[0];
+
+  if (!options.host) {
+    options.host = CapLiveReloadHelper.getIpAddress() ?? 'localhost';
   }
+
+  options.port = options.port ?? serverConfig?.port?.toString() ?? serverConfig?.url?.split(':').pop() ?? '3000';
+
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {

--- a/cli/src/util/livereload.ts
+++ b/cli/src/util/livereload.ts
@@ -133,9 +133,13 @@ class CapLiveReload {
     const configJson = { ...config.app.extConfig };
     this.configJsonToRevertTo.json = JSON.stringify(configJson, null, 2);
     this.configJsonToRevertTo.platformPath = capConfigPath;
-    const url = `http://${options.host}:${options.port}`;
+    const protocol = options.https ? 'https' : 'http';
+    const host = options.host ?? config.app.extConfig.server?.hostname ?? 'localhost';
+    const port = options.port ?? config.app.extConfig.server?.port?.toString() ?? '3000';
+    const serverUrl = `${protocol}://${host}:${port}`;
     configJson.server = {
-      url,
+      ...configJson.server,
+      url: serverUrl,
     };
     return configJson;
   }
@@ -161,10 +165,13 @@ class CapLiveReload {
     const configJson = readJSONSync(capConfigPath);
     this.configJsonToRevertTo.json = JSON.stringify(configJson, null, 2);
     this.configJsonToRevertTo.platformPath = capConfigPath;
-    const url = `${options.https ? 'https' : 'http'}://${options.host}${options.port ? `:${options.port}` : ''}`;
+    const protocol = options.https ? 'https' : 'http';
+    const host = options.host ?? config.app.extConfig.server?.hostname ?? 'localhost';
+    const port = options.port ?? config.app.extConfig.server?.port?.toString() ?? '3000';
+    const serverUrl = `${protocol}://${host}:${port}`;
     configJson.server = {
       ...configJson.server,
-      url,
+      url: serverUrl,
     };
     writeJSONSync(capConfigPath, configJson, { spaces: '\t' });
   }


### PR DESCRIPTION
## Description
This PR implements a robust configuration inheritance system for the `npx cap run --live-reload` command. It allows the CLI to automatically detect and use the `hostname`, `url`, and `port` defined in the `capacitor.config.ts` file when they are not explicitly provided via command-line arguments. 

Additionally, it ensures that the temporary server configuration generated for live reload is merged with the existing user configuration rather than overwriting it, preserving critical settings like custom schemes (e.g., `androidScheme` or `iosScheme`).

## Change Type
- [x] Fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
As detailed in #8303, the current CLI behavior forces a default port of `3000` and ignores user-defined server settings during live reload. This creates significant friction for developers using modern bundlers (like Vite on `5173`) who must manually pass flags for every run.

Key fixes in this PR:
- **Respects Configuration**: CLI now looks at `server.hostname` and `server.port` (or parses `server.url`) as a secondary priority after CLI flags.
- **Preserves Custom Schemes**: By performing a shallow merge of the server object in `livereload.ts`, settings like `androidScheme` or `iosScheme` are no longer lost when live reload is active.
- **Missing Type Definitions**: Added the `port` property to the `CapacitorConfig` interface in `declarations.ts`, which was previously supported by the runtime but missing from the types.

Fixes #8303

## Tests or Reproductions
Tested manually in a Capacitor + Vite project:
1. Configured `server: { port: 5173 }` in `capacitor.config.ts`.
2. Ran `npx cap run android -l` without specifying `--port`.
3. **Result**: The app correctly connected to the dev server at port `5173`.
4. Verified that if `--port 8080` is passed via CLI, it correctly takes precedence over the config file.
5. Verified that `androidScheme: 'https'` in the config remains present in the temporary native config during the session.

## Screenshots / Media
N/A

## Platforms Affected
- [x] Android
- [x] iOS
- [ ] Web

## Notes / Comments
This PR provides a comprehensive fix for the issues described in #8303 and offers a more complete architectural solution than #8376 by aligning with the "Single Source of Truth" principle (respecting the project's centralized configuration).
