### PR TITLE
fix(SystemBars): use native safe area insets on Android

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -82,12 +82,6 @@ public class SystemBars extends Plugin {
     }
 
     @Override
-    protected void handleOnResume() {
-        super.handleOnResume();
-        getBridge().executeOnMainThread(() -> getBridge().getWebView().requestApplyInsets());
-    }
-
-    @Override
     protected void handleOnConfigurationChanged(Configuration newConfig) {
         super.handleOnConfigurationChanged(newConfig);
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -73,8 +73,8 @@ public class SystemBars extends Plugin {
             new WebViewListener() {
                 @Override
                 public void onPageCommitVisible(WebView view, String url) {
-                super.onPageCommitVisible(view, url);
-                getBridge().getWebView().requestApplyInsets();
+                    super.onPageCommitVisible(view, url);
+                    getBridge().getWebView().requestApplyInsets();
                 }
             }
         );
@@ -194,24 +194,30 @@ public class SystemBars extends Plugin {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-                return new WindowInsetsCompat.Builder(insets).setInsets(
-                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
-                    Insets.of(
-                        systemBarsInsets.left,
-                        systemBarsInsets.top,
-                        systemBarsInsets.right,
-                        getBottomInset(systemBarsInsets, keyboardVisible)
+                return new WindowInsetsCompat.Builder(insets)
+                    .setInsets(
+                        WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                        Insets.of(
+                            systemBarsInsets.left,
+                            systemBarsInsets.top,
+                            systemBarsInsets.right,
+                            getBottomInset(systemBarsInsets, keyboardVisible)
+                        )
                     )
-                ).build();
+                    .build();
             }
 
             // We need to correct for a possible shown IME
-            v.setPadding(systemBarsInsets.left, systemBarsInsets.top, systemBarsInsets.right, keyboardVisible ? imeInsets.bottom : systemBarsInsets.bottom);
+            v.setPadding(
+                systemBarsInsets.left,
+                systemBarsInsets.top,
+                systemBarsInsets.right,
+                keyboardVisible ? imeInsets.bottom : systemBarsInsets.bottom
+            );
 
-            return new WindowInsetsCompat.Builder(insets).setInsets(
-                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
-                Insets.of(0, 0, 0, 0)
-            ).build();
+            return new WindowInsetsCompat.Builder(insets)
+                .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
+                .build();
         });
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -103,7 +103,7 @@ public class SystemBars extends Plugin {
         }
 
         initWindowInsetsListener();
-        initSafeAreaInsets();
+        initSafeAreaCSSVariables();
 
         getBridge().executeOnMainThread(() -> {
             setStyle(style, "");
@@ -166,7 +166,7 @@ public class SystemBars extends Plugin {
         return Insets.of(safeArea.left, safeArea.top, safeArea.right, safeArea.bottom);
     }
 
-    private void initSafeAreaInsets() {
+    private void initSafeAreaCSSVariables() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
             View v = (View) this.getBridge().getWebView().getParent();
             WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
@@ -185,7 +185,7 @@ public class SystemBars extends Plugin {
             Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
             boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
 
-            if (hasViewportCover) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
                 Insets safeAreaInsets = calcSafeAreaInsets(insets);
                 injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
             }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -36,6 +36,9 @@ public class SystemBars extends Plugin {
     static final String INSETS_HANDLING_CSS = "css";
     static final String INSETS_HANDLING_DISABLE = "disable";
 
+    private static final int WEBVIEW_VERSION_WITH_SAFE_AREA_FIX = 140;
+    private static final int WEBVIEW_VERSION_WITH_SAFE_AREA_KEYBOARD_FIX = 144;
+
     static final String viewportMetaJSFunction = """
         function capacitorSystemBarsCheckMetaViewport() {
             const meta = document.querySelectorAll("meta[name=viewport]");
@@ -70,11 +73,17 @@ public class SystemBars extends Plugin {
             new WebViewListener() {
                 @Override
                 public void onPageCommitVisible(WebView view, String url) {
-                    super.onPageCommitVisible(view, url);
-                    getBridge().getWebView().requestApplyInsets();
+                super.onPageCommitVisible(view, url);
+                getBridge().getWebView().requestApplyInsets();
                 }
             }
         );
+    }
+
+    @Override
+    protected void handleOnResume() {
+        super.handleOnResume();
+        getBridge().executeOnMainThread(() -> getBridge().getWebView().requestApplyInsets());
     }
 
     @Override
@@ -169,32 +178,67 @@ public class SystemBars extends Plugin {
     }
 
     private void initWindowInsetsListener() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
-            ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
-                boolean hasBrokenWebViewVersion = getWebViewMajorVersion() <= 139;
+        ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
+            boolean shouldPassthroughInsets = getWebViewMajorVersion() >= WEBVIEW_VERSION_WITH_SAFE_AREA_FIX && hasViewportCover;
 
-                if (hasViewportCover) {
-                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-                }
+            Insets systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
+            boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
 
-                if (hasBrokenWebViewVersion) {
-                    if (hasViewportCover && v.hasWindowFocus() && v.isShown()) {
-                        boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
-                        if (keyboardVisible) {
-                            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
-                            setViewMargins(v, Insets.of(0, 0, 0, imeInsets.bottom));
-                        } else {
-                            setViewMargins(v, Insets.NONE);
-                        }
+            if (hasViewportCover) {
+                Insets safeAreaInsets = calcSafeAreaInsets(insets);
+                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+            }
 
-                        return WindowInsetsCompat.CONSUMED;
-                    }
-                }
+            if (shouldPassthroughInsets) {
+                // We need to correct for a possible shown IME
+                v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-                return insets;
-            });
-        }
+                return new WindowInsetsCompat.Builder(insets).setInsets(
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                    Insets.of(
+                        systemBarsInsets.left,
+                        systemBarsInsets.top,
+                        systemBarsInsets.right,
+                        getBottomInset(systemBarsInsets, keyboardVisible)
+                    )
+                ).build();
+            }
+
+            // We need to correct for a possible shown IME
+            v.setPadding(systemBarsInsets.left, systemBarsInsets.top, systemBarsInsets.right, keyboardVisible ? imeInsets.bottom : systemBarsInsets.bottom);
+
+            return new WindowInsetsCompat.Builder(insets).setInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                Insets.of(0, 0, 0, 0)
+            ).build();
+        });
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
+//            ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
+//                boolean hasBrokenWebViewVersion = getWebViewMajorVersion() <= 139;
+//
+//                if (hasViewportCover) {
+//                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
+//                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+//                }
+//
+//                if (hasBrokenWebViewVersion) {
+//                    if (hasViewportCover && v.hasWindowFocus() && v.isShown()) {
+//                        boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
+//                        if (keyboardVisible) {
+//                            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
+//                            setViewMargins(v, Insets.of(0, 0, 0, imeInsets.bottom));
+//                        } else {
+//                            setViewMargins(v, Insets.NONE);
+//                        }
+//
+//                        return WindowInsetsCompat.CONSUMED;
+//                    }
+//                }
+//
+//                return insets;
+//            });
+//        }
     }
 
     private void setViewMargins(View v, Insets insets) {
@@ -304,5 +348,19 @@ public class SystemBars extends Plugin {
         }
 
         return 0;
+    }
+
+    private int getBottomInset(Insets systemBarsInsets, boolean keyboardVisible) {
+        if (getWebViewMajorVersion() < WEBVIEW_VERSION_WITH_SAFE_AREA_KEYBOARD_FIX) {
+            // This is a workaround for webview versions that have a bug
+            // that causes the bottom inset to be incorrect if the IME is visible
+            // See: https://issues.chromium.org/issues/457682720
+
+            if (keyboardVisible) {
+                return 0;
+            }
+        }
+
+        return systemBarsInsets.bottom;
     }
 }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -213,41 +213,6 @@ public class SystemBars extends Plugin {
                 Insets.of(0, 0, 0, 0)
             ).build();
         });
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
-//            ViewCompat.setOnApplyWindowInsetsListener((View) getBridge().getWebView().getParent(), (v, insets) -> {
-//                boolean hasBrokenWebViewVersion = getWebViewMajorVersion() <= 139;
-//
-//                if (hasViewportCover) {
-//                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
-//                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-//                }
-//
-//                if (hasBrokenWebViewVersion) {
-//                    if (hasViewportCover && v.hasWindowFocus() && v.isShown()) {
-//                        boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
-//                        if (keyboardVisible) {
-//                            Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
-//                            setViewMargins(v, Insets.of(0, 0, 0, imeInsets.bottom));
-//                        } else {
-//                            setViewMargins(v, Insets.NONE);
-//                        }
-//
-//                        return WindowInsetsCompat.CONSUMED;
-//                    }
-//                }
-//
-//                return insets;
-//            });
-//        }
-    }
-
-    private void setViewMargins(View v, Insets insets) {
-        ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-        mlp.leftMargin = insets.left;
-        mlp.bottomMargin = insets.bottom;
-        mlp.rightMargin = insets.right;
-        mlp.topMargin = insets.top;
-        v.setLayoutParams(mlp);
     }
 
     private void injectSafeAreaCSS(int top, int right, int bottom, int left) {

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -185,14 +185,14 @@ public class SystemBars extends Plugin {
             Insets imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime());
             boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
-                Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-            }
-
             if (shouldPassthroughInsets) {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
+                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
+                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+                }
 
                 return new WindowInsetsCompat.Builder(insets)
                     .setInsets(
@@ -215,9 +215,16 @@ public class SystemBars extends Plugin {
                 keyboardVisible ? imeInsets.bottom : systemBarsInsets.bottom
             );
 
-            return new WindowInsetsCompat.Builder(insets)
+            WindowInsetsCompat newInsets = new WindowInsetsCompat.Builder(insets)
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
+                Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
+                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+            }
+
+            return newInsets;
         });
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -7,7 +7,6 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.util.TypedValue;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
@@ -36,7 +35,9 @@ public class SystemBars extends Plugin {
     static final String INSETS_HANDLING_CSS = "css";
     static final String INSETS_HANDLING_DISABLE = "disable";
 
+    // https://issues.chromium.org/issues/40699457
     private static final int WEBVIEW_VERSION_WITH_SAFE_AREA_FIX = 140;
+    // https://issues.chromium.org/issues/457682720
     private static final int WEBVIEW_VERSION_WITH_SAFE_AREA_KEYBOARD_FIX = 144;
 
     static final String viewportMetaJSFunction = """
@@ -215,6 +216,9 @@ public class SystemBars extends Plugin {
                 keyboardVisible ? imeInsets.bottom : systemBarsInsets.bottom
             );
 
+            // Returning `WindowInsetsCompat.CONSUMED` breaks recalculation of safe area insets
+            // So we have to explicitly set insets to `0`
+            // See: https://issues.chromium.org/issues/461332423
             WindowInsetsCompat newInsets = new WindowInsetsCompat.Builder(insets)
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -713,7 +713,7 @@ export interface PluginsConfig {
      *
      * `css` = Injects CSS variables (`--safe-area-inset-*`) containing correct safe area inset values into the webview.
      *
-     * `disable` = Disable all inset handling.
+     * `disable` = Disable CSS variables injection.
      *
      * @default "css"
      */

--- a/core/system-bars.md
+++ b/core/system-bars.md
@@ -73,7 +73,7 @@ const setStatusBarAnimation = async () => {
 ## Configuration
 | Prop          | Type                 | Description                                                               | Default            |
 | ------------- | -------------------- | ------------------------------------------------------------------------- | ------------------ |
-| **`insetsHandling`** | <code>string</code> | Specifies how to handle problematic insets on Android.  This option is only supported on Android.<br>`css` = Injects CSS variables (`--safe-area-inset-*`) containing correct safe area inset values into the webview.<br>`disable` = Disable all inset handling. | <code>css</code> |
+| **`insetsHandling`** | <code>string</code> | Specifies how to handle problematic insets on Android.  This option is only supported on Android.<br>`css` = Injects CSS variables (`--safe-area-inset-*`) containing correct safe area inset values into the webview.<br>`disable` = Disable CSS variables injection. | <code>css</code> |
 | **`style`** | <code>string</code> | The style of the text and icons of the system bars. | <code>DEFAULT</code> |
 | **`hidden`** | <code>boolean</code> | Hide the system bars on start. | <code>false</code> |
 | **`animation`** | <code>string</code> | The type of status bar animation used when showing or hiding.  This option is only supported on iOS. | <code>FADE</code> |


### PR DESCRIPTION
## Description
This PR implements native safe area inset handling as demonstrated in https://github.com/capacitor-community/safe-area

(CSS Safe Area vars are still intact for OS upstream)

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
closes https://github.com/ionic-team/capacitor/issues/8343
closes https://github.com/ionic-team/capacitor/issues/8329
closes https://github.com/ionic-team/capacitor/issues/8287

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
