### PR TITLE
fix(http): handle URL objects on fetch

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -506,7 +506,8 @@ var nativeBridge = (function (exports) {
                                 return await win.CapacitorWebFetch(createProxyUrl(resource, win), options);
                             }
                             else if (resource instanceof URL) {
-                                return await win.CapacitorWebFetch(createProxyUrl(resource.toString(), win), options);
+                                const modifiedURL = new URL(createProxyUrl(resource.toString(), win));
+                                return await win.CapacitorWebFetch(modifiedURL, options);
                             }
                             else if (resource instanceof Request) {
                                 const modifiedRequest = new Request(createProxyUrl(resource.url, win), resource);

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -533,7 +533,8 @@ const initBridge = (w: any): void => {
             if (typeof resource === 'string') {
               return await win.CapacitorWebFetch(createProxyUrl(resource, win), options);
             } else if (resource instanceof URL) {
-              return await win.CapacitorWebFetch(createProxyUrl(resource.toString(), win), options);
+              const modifiedURL = new URL(createProxyUrl(resource.toString(), win));
+              return await win.CapacitorWebFetch(modifiedURL, options);
             } else if (resource instanceof Request) {
               const modifiedRequest = new Request(createProxyUrl(resource.url, win), resource);
               return await win.CapacitorWebFetch(modifiedRequest, options);

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -506,7 +506,8 @@ var nativeBridge = (function (exports) {
                                 return await win.CapacitorWebFetch(createProxyUrl(resource, win), options);
                             }
                             else if (resource instanceof URL) {
-                                return await win.CapacitorWebFetch(createProxyUrl(resource.toString(), win), options);
+                                const modifiedURL = new URL(createProxyUrl(resource.toString(), win));
+                                return await win.CapacitorWebFetch(modifiedURL, options);
                             }
                             else if (resource instanceof Request) {
                                 const modifiedRequest = new Request(createProxyUrl(resource.url, win), resource);


### PR DESCRIPTION
We are not handling `URL` objects inside `fetch` calls at the moment, which causes issues with `data://` URLs as described on https://github.com/ionic-team/capacitor/pull/8347 and https://github.com/ionic-team/capacitor/pull/8304 and also any `fetch` call using `URL` object is not being handled properly as it won't go to the `WebViewAssetHandler`