### PR TITLE
fix(ios): make getArray accesible on Objective-C plugins

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgedJSTypes.h
+++ b/ios/Capacitor/Capacitor/CAPBridgedJSTypes.h
@@ -10,6 +10,7 @@
 - (NSString * _Nullable)getString:(NSString * _Nonnull)key defaultValue:(NSString * _Nullable)defaultValue;
 - (NSDate * _Nullable)getDate:(NSString * _Nonnull)key defaultValue:(NSDate * _Nullable)defaultValue;
 - (NSDictionary * _Nullable)getObject:(NSString * _Nonnull)key defaultValue:(NSDictionary * _Nullable)defaultValue;
+- (NSArray * _Nullable)getArray:(NSString * _Nonnull)key defaultValue:(NSArray * _Nullable)defaultValue;
 - (NSNumber * _Nullable)getNumber:(NSString * _Nonnull)key defaultValue:(NSNumber * _Nullable)defaultValue;
 - (BOOL)getBool:(NSString * _Nonnull)key defaultValue:(BOOL)defaultValue;
 @end

--- a/ios/Capacitor/Capacitor/CAPBridgedJSTypes.m
+++ b/ios/Capacitor/Capacitor/CAPBridgedJSTypes.m
@@ -29,6 +29,14 @@
     return defaultValue;
 }
 
+- (NSArray * _Nullable)getArray:(NSString * _Nonnull)key defaultValue:(NSArray * _Nullable)defaultValue; {
+    id value = [[self dictionaryRepresentation] objectForKey:key];
+    if (value != nil && [value isKindOfClass:[NSArray class]]) {
+        return value;
+    }
+    return defaultValue;
+}
+
 - (NSNumber * _Nullable)getNumber:(NSString * _Nonnull)key defaultValue:(NSNumber * _Nullable)defaultValue {
     id value = [[self dictionaryRepresentation] objectForKey:key];
     if (value != nil && [value isKindOfClass:[NSNumber class]]) {


### PR DESCRIPTION
We have `getArray` available on Swift plugin calls, but not the equivalent Objective-C one.