### PR TITLE
fix(http): correctly serialize Blob objects in request bodies and FormData

### DIFF
--- a/android/capacitor/src/main/assets/native-bridge.js
+++ b/android/capacitor/src/main/assets/native-bridge.js
@@ -48,14 +48,14 @@ var nativeBridge = (function (exports) {
         const newFormData = [];
         for (const pair of formData.entries()) {
             const [key, value] = pair;
-            if (value instanceof File) {
+            if (value instanceof Blob) {
                 const base64File = await readFileAsBase64(value);
                 newFormData.push({
                     key,
                     value: base64File,
                     type: 'base64File',
                     contentType: value.type,
-                    fileName: value.name,
+                    fileName: value.name || 'blob',
                 });
             }
             else {
@@ -128,7 +128,7 @@ var nativeBridge = (function (exports) {
                 type: 'formData',
             };
         }
-        else if (body instanceof File) {
+        else if (body instanceof Blob) {
             const fileData = await readFileAsBase64(body);
             return {
                 data: fileData,

--- a/core/native-bridge.ts
+++ b/core/native-bridge.ts
@@ -18,7 +18,7 @@ import { CapacitorException } from './src/util';
 // eslint-disable-next-line
 let dummy = {};
 
-const readFileAsBase64 = (file: File): Promise<string> =>
+const readFileAsBase64 = (file: Blob): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onloadend = () => {
@@ -34,14 +34,14 @@ const convertFormData = async (formData: FormData): Promise<any> => {
   const newFormData: CapFormDataEntry[] = [];
   for (const pair of formData.entries()) {
     const [key, value] = pair;
-    if (value instanceof File) {
+    if (value instanceof Blob) {
       const base64File = await readFileAsBase64(value);
       newFormData.push({
         key,
         value: base64File,
         type: 'base64File',
         contentType: value.type,
-        fileName: value.name,
+        fileName: (value as any).name || 'blob',
       });
     } else {
       newFormData.push({ key, value, type: 'string' });
@@ -110,7 +110,7 @@ const convertBody = async (
       data: await convertFormData(body),
       type: 'formData',
     };
-  } else if (body instanceof File) {
+  } else if (body instanceof Blob) {
     const fileData = await readFileAsBase64(body);
     return {
       data: fileData,

--- a/ios/Capacitor/Capacitor/assets/native-bridge.js
+++ b/ios/Capacitor/Capacitor/assets/native-bridge.js
@@ -48,14 +48,14 @@ var nativeBridge = (function (exports) {
         const newFormData = [];
         for (const pair of formData.entries()) {
             const [key, value] = pair;
-            if (value instanceof File) {
+            if (value instanceof Blob) {
                 const base64File = await readFileAsBase64(value);
                 newFormData.push({
                     key,
                     value: base64File,
                     type: 'base64File',
                     contentType: value.type,
-                    fileName: value.name,
+                    fileName: value.name || 'blob',
                 });
             }
             else {
@@ -128,7 +128,7 @@ var nativeBridge = (function (exports) {
                 type: 'formData',
             };
         }
-        else if (body instanceof File) {
+        else if (body instanceof Blob) {
             const fileData = await readFileAsBase64(body);
             return {
                 data: fileData,


### PR DESCRIPTION
## Bug Report / Context
When using `CapacitorHttp` to intercept requests, dynamically generated `Blob` objects appended to `FormData` or passed as the request body are silently corrupted. Because the native bridge only checks `if (value instanceof File)`, generic `Blob`s fall through the type check and are improperly serialized as the literal string `"[object Blob]"`. 

## What This PR Does
Changes the strict `File` instance checks to `Blob` in `native-bridge.ts`. Since all `File` objects are instances of `Blob`, and `FileReader.readAsBinaryString()` natively accepts a `Blob`, this safely fixes the data corruption for both pure `Blob`s and `File`s without introducing any breaking changes.

- Replaced `instanceof File` with `instanceof Blob` in `convertFormData` and `convertBody`.
- Updated `readFileAsBase64` signature to accept `Blob`.
- Added a fallback `fileName` for generic Blobs that do not inherently have a `.name` property.
