### PR TITLE
fix(cli): properly copy all valid SSL certs and fix log typo

### DIFF
--- a/cli/src/tasks/copy.ts
+++ b/cli/src/tasks/copy.ts
@@ -254,13 +254,13 @@ async function copySSLCert(sslCertPaths: string[], rootDir: string, targetDir: s
           `SSL Certificate does not exist at specified path.`,
       );
 
-      return;
+      continue;
     }
     validCertPaths.push(certAbsFromPath);
   }
   const certsDirAbsToPath = join(targetDir, 'certs');
   const certsDirRelToDir = relative(rootDir, targetDir);
-  await runTask(`Copying SSL Certificates from to ${certsDirRelToDir}`, async () => {
+  await runTask(`Copying SSL Certificates to ${certsDirRelToDir}`, async () => {
     const promises: Promise<void>[] = [];
     for (const certPath of validCertPaths) {
       promises.push(fsCopy(certPath, join(certsDirAbsToPath, basename(certPath))));


### PR DESCRIPTION
Currently, `copySSLCert` returns early if any given certificate path is invalid, preventing other valid certificates from being copied. Also, there is a typo in the log message. This PR fixes both.