### PR TITLE
fix(core): properly propagate rejections in addListenerNative

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -149,7 +149,7 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
         );
       };
 
-      const p = new Promise((resolve) => call.then(() => resolve({ remove })));
+      const p = call.then(() => ({ remove }));
 
       (p as any).remove = async () => {
         console.warn(`Using addListener() without 'await' is deprecated.`);


### PR DESCRIPTION
Currently, `addListenerNative` creates a new promise that only handles the success case of the underlying `addListener` call, causing it to hang on failure. This PR refactors it to use `.then()` on the original call, ensuring that rejections are correctly propagated. This also fixes an unhandled rejection.