### PR TITLE
fix(cli): check CAPACITOR_COCOAPODS_PATH in determinePackageManager

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -434,6 +434,10 @@ async function determinePackageManager(
     return 'SPM';
   }
 
+  if (process.env.CAPACITOR_COCOAPODS_PATH) {
+    return 'Cocoapods';
+  }
+
   let gemfilePath = '';
   if (await pathExists(resolve(rootDir, 'Gemfile'))) {
     gemfilePath = resolve(rootDir, 'Gemfile');


### PR DESCRIPTION
If `CAPACITOR_COCOAPODS_PATH` is set the `PackageManager` should be considered `CocoaPods` 

closes https://github.com/ionic-team/capacitor/issues/8388