### PR TITLE
fix(SystemBars): make `safe-area-inset-x` available on API <= 34

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -91,6 +91,8 @@ public class SystemBars extends Plugin {
     }
 
     private void initSystemBars() {
+        WindowCompat.setDecorFitsSystemWindows(this.getActivity().getWindow(), false);
+
         String style = getConfig().getString("style", STYLE_DEFAULT).toUpperCase(Locale.US);
         boolean hidden = getConfig().getBoolean("hidden", false);
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -91,8 +91,6 @@ public class SystemBars extends Plugin {
     }
 
     private void initSystemBars() {
-        WindowCompat.setDecorFitsSystemWindows(this.getActivity().getWindow(), false);
-
         String style = getConfig().getString("style", STYLE_DEFAULT).toUpperCase(Locale.US);
         boolean hidden = getConfig().getBoolean("hidden", false);
 
@@ -166,8 +164,15 @@ public class SystemBars extends Plugin {
     }
 
     private void initSafeAreaCSSVariables() {
-        View v = (View) this.getBridge().getWebView().getParent();
-        WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
+        WindowInsetsCompat insets;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            View v = (View) this.getBridge().getWebView().getParent();
+            insets = ViewCompat.getRootWindowInsets(v);
+        } else {
+            insets = WindowInsetsCompat.CONSUMED;
+        }
+
         if (insets != null) {
             Insets safeAreaInsets = calcSafeAreaInsets(insets);
             injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -184,10 +184,8 @@ public class SystemBars extends Plugin {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-
                 Insets safeAreaInsets = calcSafeAreaInsets(insets);
                 injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-
 
                 return new WindowInsetsCompat.Builder(insets)
                     .setInsets(
@@ -217,10 +215,8 @@ public class SystemBars extends Plugin {
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();
 
-
             Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
             injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-
 
             return newInsets;
         });

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -164,13 +164,11 @@ public class SystemBars extends Plugin {
     }
 
     private void initSafeAreaCSSVariables() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && insetHandlingEnabled) {
-            View v = (View) this.getBridge().getWebView().getParent();
-            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
-            if (insets != null) {
-                Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-            }
+        View v = (View) this.getBridge().getWebView().getParent();
+        WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(v);
+        if (insets != null) {
+            Insets safeAreaInsets = calcSafeAreaInsets(insets);
+            injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
         }
     }
 
@@ -186,10 +184,10 @@ public class SystemBars extends Plugin {
                 // We need to correct for a possible shown IME
                 v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
-                    Insets safeAreaInsets = calcSafeAreaInsets(insets);
-                    injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-                }
+
+                Insets safeAreaInsets = calcSafeAreaInsets(insets);
+                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+
 
                 return new WindowInsetsCompat.Builder(insets)
                     .setInsets(
@@ -219,10 +217,10 @@ public class SystemBars extends Plugin {
                 .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), Insets.of(0, 0, 0, 0))
                 .build();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && hasViewportCover && insetHandlingEnabled) {
-                Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
-                injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
-            }
+
+            Insets safeAreaInsets = calcSafeAreaInsets(newInsets);
+            injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);
+
 
             return newInsets;
         });


### PR DESCRIPTION
## Description
This PR makes the custom injected `safe-area-inset-x` CSS variables available for Android devices on API <= 34, to make dealing with UI safe area logic more consistent across Android versions.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
fixes: https://github.com/ionic-team/capacitor/issues/8394

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
