### PR TITLE
docs: Update Contributing guide branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,10 @@ On web, this means do not add any third party libraries such as Firebase or Loda
 
 ### Branches
 
-* [`main`](https://github.com/ionic-team/capacitor/tree/main): Latest Capacitor development branch
-* [`6.x`](https://github.com/ionic-team/capacitor/tree/6.x): Capacitor 6
+* [`main`](https://github.com/ionic-team/capacitor/tree/main): Latest Stable Capacitor branch. In general PRs containing bugfixes and non-breaking features should be pointed to `main`. 
+* [`next`](https://github.com/ionic-team/capacitor/tree/next): Future major version functionality. Any PRs that contain breaking changes should be pointed to `next`.
+* [`7.x`](https://github.com/ionic-team/capacitor/tree/7.x): Capacitor 7
+* [`6.x`](https://github.com/ionic-team/capacitor/tree/6.x): Capacitor 6 (not maintained)
 * [`5.x`](https://github.com/ionic-team/capacitor/tree/5.x): Capacitor 5 (not maintained)
 * [`4.x`](https://github.com/ionic-team/capacitor/tree/4.x): Capacitor 4 (not maintained)
 * [`3.x`](https://github.com/ionic-team/capacitor/tree/3.x): Capacitor 3 (not maintained)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ On web, this means do not add any third party libraries such as Firebase or Loda
 
 ### Branches
 
-* [`main`](https://github.com/ionic-team/capacitor/tree/main): Latest Stable Capacitor branch. In general PRs containing bugfixes and non-breaking features should be pointed to `main`. 
+* [`main`](https://github.com/ionic-team/capacitor/tree/main): Latest stable Capacitor branch. In general PRs containing bugfixes and non-breaking features should be pointed to `main`. 
 * [`next`](https://github.com/ionic-team/capacitor/tree/next): Future major version functionality. Any PRs that contain breaking changes should be pointed to `next`.
 * [`7.x`](https://github.com/ionic-team/capacitor/tree/7.x): Capacitor 7
 * [`6.x`](https://github.com/ionic-team/capacitor/tree/6.x): Capacitor 6 (not maintained)


### PR DESCRIPTION
## Description

Add more content to `main` and new `next` branch, to better distinguish when to use one or the other. Add missing `7.x` branch.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation

## Rationale / Problems Fixed

Capacitor 7 branch was missing and 6 is outdated (no longer maintained). Also we're starting to adopt a new branching pattern with `main` and `next` branches, that was not yet clear in the contributing docs.
