### PR TITLE
fix: Fix missing `window.Capacitor` on Android after redirection

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -265,8 +265,13 @@ public class Bridge {
         JSInjector injector = getJSInjector();
         if (WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
             String allowedOrigin = Uri.parse(appUrl).buildUpon().path(null).fragment(null).clearQuery().build().toString();
+            final String finalAllowedOrigin = allowedOrigin;
+            Set<String> allowedOrigins = new HashSet<String>() {{
+                add(finalAllowedOrigin);
+                addAll(allowedOriginRules);
+            }};
             try {
-                WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), Collections.singleton(allowedOrigin));
+                WebViewCompat.addDocumentStartJavaScript(webView, injector.getScriptString(), allowedOrigins);
                 injector = null;
             } catch (IllegalArgumentException ex) {
                 Logger.warn("Invalid url, using fallback");


### PR DESCRIPTION
## Description
This fixes #7454 with rebased code from PR #7571

## Change Type
- [x ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
Fix missing `window.Capacitor` on Android after redirection

## Tests or Reproductions
Refer to #7454 

## Platforms Affected
- [ x] Android
- [ ] iOS
- [ ] Web
