### PR TITLE
fix(android): Handle activity result without plugin handle

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -1270,6 +1270,7 @@ public class Bridge {
                 // This is a bit hacky but required to return the boolean out of the cordova interface
                 return cordovaPlugin.hasRequiredPermissions();
             }
+            return false;
         }
 
         // deprecated, to be removed


### PR DESCRIPTION
## Description

Add a missing return statement for `Bridge#onActivityResult` when there is no `PluginHandle` instance.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed

Prior to Cordova Optional PR the return was always done 

```
if (plugin == null || plugin.getInstance() == null) {
            Logger.debug("Unable to find a Capacitor plugin to handle requestCode, trying Cordova plugins " + requestCode);
            return cordovaInterface.onActivityResult(requestCode, resultCode, data);
```

And after the PR it was moved to inside an `if` statement specific for Cordova. The problem lies when there are no cordova plugins, so `__CordovaPlugin` is not defined, causing no return to occur, and the code proceeds to outside the null-check if to `PluginCall lastCall = plugin.getInstance().getSavedCall();`, but for most Capacitor Plugins, this will be null (causing the crash), because Capacitor Plugins now use `ActivityCallback` for activity results. Adding the `return false` maintains the same behavior as 8.x (`cordovaInterface.onActivityResult` returns false in the described scenario).

Internal reference: https://outsystemsrd.atlassian.net/browse/RMET-5085 

## Tests or Reproductions

To test the crash

1. Run [eric-horodyski/cap9dev-capacitor-only](https://github.com/eric-horodyski/cap9dev-capacitor-only) on an Android device/emulator.

2. Press the Camera button and take a photo.

3. Attempt to return to the app by pressing the checkmark.

4. Observe the application crash.

To test the fix: 

1. Either clone this capacitor repo repo and checkout the PR's branch and point capacitor versions in package.json of [eric-horodyski/cap9dev-capacitor-only](https://github.com/eric-horodyski/cap9dev-capacitor-only) to the local directory; or (imo quicker) open the app project in Android Studio and copy the line from the PR. Then run the Android app on physical device or emulator

2. Press the Camera button and take a photo.

3. Attempt to return to the app by pressing the checkmark.

4. Should now not crash and return result back to app.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

