### PR TITLE
fix(ios): support Cordova plugins with Package.swift

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -12,12 +12,14 @@ import {
   getAllElements,
   getFilePath,
   getPlatformElement,
+  getPluginPlatform,
   getPluginType,
   getPlugins,
   printPlugins,
 } from '../plugin';
 import type { Plugin } from '../plugin';
 import { copy as copyTask } from '../tasks/copy';
+import { setAllStringIn } from '../tasks/migrate';
 import { convertToUnixPath } from '../util/fs';
 import { generateIOSPackageJSON } from '../util/iosplugin';
 import { resolveNode } from '../util/node';
@@ -83,7 +85,20 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
             publicHeadersPath: "."`;
   }
 
-  const content = `// swift-tools-version: 5.9
+  const platformTag = getPluginPlatform(p, platform);
+  if (platformTag.$.package) {
+    const packageSwiftPath = join(p.rootPath, 'Package.swift');
+    let content = await readFile(packageSwiftPath, { encoding: 'utf-8' });
+    content = content.replace(`apache`, `ionic-team`).replaceAll(`cordova-ios`, `capacitor-swift-pm`);
+    content = setAllStringIn(
+      content,
+      `url: "https://github.com/ionic-team/capacitor-swift-pm.git",`,
+      `)`,
+      ` from: "${iosPlatformVersion}"`,
+    );
+    await writeFile(packageSwiftPath, content);
+  } else {
+    const content = `// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -109,7 +124,9 @@ let package = Package(
         )
     ]
 )`;
-  await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
+
+    await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
+  }
 }
 
 export async function installCocoaPodsPlugins(config: Config, plugins: Plugin[], deployment: boolean): Promise<void> {
@@ -388,12 +405,16 @@ function getLinkerFlags(config: Config) {
 
 async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
   for (const p of cordovaPlugins) {
+    const platformTag = getPluginPlatform(p, platform);
+    if (platformTag.$.package) {
+      continue;
+    }
     const sourceFiles = getPlatformElement(p, platform, 'source-file');
     const headerFiles = getPlatformElement(p, platform, 'header-file');
     const codeFiles = sourceFiles.concat(headerFiles);
     const frameworks = getPlatformElement(p, platform, 'framework');
     let sourcesFolderName = 'sources';
-    if (needsStaticPod(p)) {
+    if ((await config.ios.packageManager) !== 'SPM' && needsStaticPod(p)) {
       sourcesFolderName += 'static';
     }
     const sourcesFolder = join(config.ios.cordovaPluginsDirAbs, sourcesFolderName, p.name);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -86,7 +86,7 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
   }
 
   const platformTag = getPluginPlatform(p, platform);
-  if (platformTag.$.package) {
+  if (platformTag.$?.package) {
     const packageSwiftPath = join(p.rootPath, 'Package.swift');
     let content = await readFile(packageSwiftPath, { encoding: 'utf-8' });
     content = content.replace(`apache`, `ionic-team`).replaceAll(`cordova-ios`, `capacitor-swift-pm`);
@@ -406,7 +406,7 @@ function getLinkerFlags(config: Config) {
 async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
-    if (platformTag.$.package) {
+    if (platformTag.$?.package) {
       continue;
     }
     const sourceFiles = getPlatformElement(p, platform, 'source-file');

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -579,7 +579,7 @@ async function updateFile(
   return false;
 }
 
-function setAllStringIn(data: string, start: string, end: string, replacement: string): string {
+export function setAllStringIn(data: string, start: string, end: string, replacement: string): string {
   let position = 0;
   let result = data;
   let replaced = true;

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -11,7 +11,7 @@ import { fatal } from '../errors';
 import { getMajoriOSVersion } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
-import { getPluginType, PluginType } from '../plugin';
+import { getPluginPlatform, getPluginType, PluginType } from '../plugin';
 import { runCommand } from '../util/subprocess';
 
 export interface SwiftPlugin {
@@ -118,7 +118,13 @@ let package = Package(
 
   for (const plugin of plugins) {
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
-      packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
+      const platformTag = getPluginPlatform(plugin, config.ios.name);
+      if (platformTag.$.package) {
+        const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+        packageSwiftText += `,\n        .package(name: "${plugin.id}", path: "${relPath}")`;
+      } else {
+        packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
+      }
     } else {
       const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
       const traits = packageTraits[plugin.id];
@@ -144,7 +150,14 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm")`;
 
   for (const plugin of plugins) {
-    packageSwiftText += `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
+    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
+    if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
+      const platformTag = getPluginPlatform(plugin, config.ios.name);
+      if (platformTag.$.package) {
+        pluginText = `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
+      }
+    }
+    packageSwiftText += pluginText;
   }
 
   packageSwiftText += `

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -52,7 +52,6 @@ export async function generatePackageFile(config: Config, plugins: Plugin[]): Pr
 
 export async function checkPluginsForPackageSwift(config: Config, plugins: Plugin[]): Promise<Plugin[]> {
   const iOSCapacitorPlugins = plugins.filter((p) => getPluginType(p, 'ios') === PluginType.Core);
-
   const packageSwiftPluginList = await pluginsWithPackageSwift(iOSCapacitorPlugins);
 
   if (plugins.length == packageSwiftPluginList.length) {
@@ -119,7 +118,7 @@ let package = Package(
   for (const plugin of plugins) {
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
-      if (platformTag.$.package) {
+      if (platformTag.$?.package) {
         const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
         packageSwiftText += `,\n        .package(name: "${plugin.id}", path: "${relPath}")`;
       } else {
@@ -153,7 +152,7 @@ let package = Package(
     let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
-      if (platformTag.$.package) {
+      if (platformTag.$?.package) {
         pluginText = `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
       }
     }


### PR DESCRIPTION
If the Cordova plugin already has a Package.swift, point to that file instead of generating a new one, but patching the repository url and version to point to the Capacitor one, also, in that case, don't copy the plugin files to `capacitor-cordova-ios-plugins` folder since it will be using the ones in `node_modules`

Also fixes an issue where the plugin files were copied to `capacitor-cordova-ios-plugins/sourcesstatic/pluginName` but the `Package.swift` was being generated, and pointed to `capacitor-cordova-ios-plugins/sources/pluginName` and failed to link the plugin since it had no files. The `sourcesstatic` folder is only needed for some CocoaPods plugins, not when using SPM.

