### PR TITLE
fix(cli): correct Capacitor plugin SPM compat check

### DIFF
--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -55,7 +55,9 @@ export async function checkPluginsForPackageSwift(config: Config, plugins: Plugi
   const packageSwiftPluginList = await pluginsWithPackageSwift(iOSCapacitorPlugins);
 
   if (iOSCapacitorPlugins.length == packageSwiftPluginList.length) {
-    logger.debug(`Found ${iOSCapacitorPlugins.length} Capacitor iOS plugins, ${packageSwiftPluginList.length} have a Package.swift file`);
+    logger.debug(
+      `Found ${iOSCapacitorPlugins.length} Capacitor iOS plugins, ${packageSwiftPluginList.length} have a Package.swift file`,
+    );
     logger.info('All Capacitor plugins have a Package.swift file and will be included in Package.swift');
   } else {
     logger.warn('Some installed Capacitor plugins are not compatible with SPM');

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -54,11 +54,11 @@ export async function checkPluginsForPackageSwift(config: Config, plugins: Plugi
   const iOSCapacitorPlugins = plugins.filter((p) => getPluginType(p, 'ios') === PluginType.Core);
   const packageSwiftPluginList = await pluginsWithPackageSwift(iOSCapacitorPlugins);
 
-  if (plugins.length == packageSwiftPluginList.length) {
-    logger.debug(`Found ${plugins.length} iOS plugins, ${packageSwiftPluginList.length} have a Package.swift file`);
-    logger.info('All plugins have a Package.swift file and will be included in Package.swift');
+  if (iOSCapacitorPlugins.length == packageSwiftPluginList.length) {
+    logger.debug(`Found ${iOSCapacitorPlugins.length} Capacitor iOS plugins, ${packageSwiftPluginList.length} have a Package.swift file`);
+    logger.info('All Capacitor plugins have a Package.swift file and will be included in Package.swift');
   } else {
-    logger.warn('Some installed packages are not compatable with SPM');
+    logger.warn('Some installed Capacitor plugins are not compatible with SPM');
   }
 
   return packageSwiftPluginList;


### PR DESCRIPTION
While reviewing https://github.com/ionic-team/capacitor/pull/8438, Pedro noticed the `Some installed packages are not compatable with SPM` warning was appearing when having Cordova plugins installed (and a typo in compatable)

Since the method checks for Capacitor plugins only, I've changed the messages to refer to Capacitor plugins only and changed the length check to use the Capacitor plugins length instead of the total plugins length.