### PR TITLE
fix(cli): handle Cordova plugins without iOS source files

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,6 +98,10 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
+    const sourceFiles = getPlatformElement(p, platform, 'source-file');
+    if (sourceFiles.length === 0 && headerFiles.length === 0) {
+      return;
+    }
     const content = `// swift-tools-version: 5.9
 
 import PackageDescription

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -154,7 +154,7 @@ export function getPluginPlatform(p: Plugin, platform: string): any {
     });
     return platforms[0];
   }
-  return [];
+  return undefined;
 }
 
 export function getPlatformElement(p: Plugin, platform: string, elementName: string): any {

--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -154,7 +154,7 @@ export function getPluginPlatform(p: Plugin, platform: string): any {
     });
     return platforms[0];
   }
-  return undefined;
+  return [];
 }
 
 export function getPlatformElement(p: Plugin, platform: string, elementName: string): any {

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -156,21 +156,20 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm")`;
 
   for (const plugin of plugins) {
+    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
       if (platformTag.$?.package) {
-        packageSwiftText += `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
+        pluginText = `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
       } else {
         const sourceFiles = getPlatformElement(plugin, config.ios.name, 'source-file');
         const headerFiles = getPlatformElement(plugin, config.ios.name, 'header-file');
         if (sourceFiles.length === 0 && headerFiles.length === 0) {
-          continue;
+          pluginText = '';
         }
-        packageSwiftText += `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
       }
-    } else {
-      packageSwiftText += `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
     }
+    packageSwiftText += pluginText;
   }
 
   packageSwiftText += `

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -11,7 +11,7 @@ import { fatal } from '../errors';
 import { getMajoriOSVersion } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
-import { getPluginPlatform, getPluginType, PluginType } from '../plugin';
+import { getPlatformElement, getPluginPlatform, getPluginType, PluginType } from '../plugin';
 import { runCommand } from '../util/subprocess';
 
 export interface SwiftPlugin {
@@ -124,6 +124,11 @@ let package = Package(
         const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
         packageSwiftText += `,\n        .package(name: "${plugin.id}", path: "${relPath}")`;
       } else {
+        const sourceFiles = getPlatformElement(plugin, config.ios.name, 'source-file');
+        const headerFiles = getPlatformElement(plugin, config.ios.name, 'header-file');
+        if (sourceFiles.length === 0 && headerFiles.length === 0) {
+          continue;
+        }
         packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
       }
     } else {
@@ -151,14 +156,21 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm")`;
 
   for (const plugin of plugins) {
-    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
       if (platformTag.$?.package) {
-        pluginText = `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
+        packageSwiftText += `,\n                .product(name: "${plugin.id}", package: "${plugin.id}")`;
+      } else {
+        const sourceFiles = getPlatformElement(plugin, config.ios.name, 'source-file');
+        const headerFiles = getPlatformElement(plugin, config.ios.name, 'header-file');
+        if (sourceFiles.length === 0 && headerFiles.length === 0) {
+          continue;
+        }
+        packageSwiftText += `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
       }
+    } else {
+      packageSwiftText += `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
     }
-    packageSwiftText += pluginText;
   }
 
   packageSwiftText += `


### PR DESCRIPTION
- Fix `getPluginPlatform` to return `undefined` instead of `[]` when a plugin has no `<platform>` tags
- Skip `Package.swift` generation for Cordova plugins with `<platform name="ios">` but no source files
- Skip adding those plugins to the generated `CapApp-SPM/Package.swift`

Reference: https://outsystemsrd.atlassian.net/browse/RMET-5159

**Tests**
Validated with three dummy plugins:
`test-plugin-no-platform`: no `<platform>` tags -> correctly skipped as incompatible
`test-plugin-no-sources`: `<platform name="ios">` with only <config-file> entries -> sync completes, config still processed
`test-plugin-with-sources`: `<platform name="ios">` with source files -> continues to work normally