### PR TITLE
fix(cli): generate binaryTarget entries for custom xcframeworks in Package.swift

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,6 +98,25 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
+    const frameworks = getPlatformElement(p, platform, 'framework');
+    const customXcframeworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.xcframework'));
+    const binaryTargetsText = customXcframeworks
+      .map((f: any) => {
+        const name = f.$.src.split('/').pop().replace('.xcframework', '');
+        return `,
+        .binaryTarget(
+            name: "${name}",
+            path: "${f.$.src}"
+        )`;
+      })
+      .join('');
+    const binaryDepsText = customXcframeworks
+      .map((f: any) => {
+        const name = f.$.src.split('/').pop().replace('.xcframework', '');
+        return `,\n                .target(name: "${name}")`;
+      })
+      .join('');
+
     const content = `// swift-tools-version: 5.9
 
 import PackageDescription
@@ -118,10 +137,10 @@ let package = Package(
         .target(
             name: "${p.name}",
             dependencies: [
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm")${binaryDepsText}
             ],
             path: "."${headersText}
-        )
+        )${binaryTargetsText}
     ]
 )`;
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,17 +98,7 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
-    const frameworks = getPlatformElement(p, platform, 'framework');
-    const { binaryTargetsText, binaryDepsText } = buildBinaryTargetEntries(p, frameworks);
-    await writeGeneratedPackageSwift(
-      p,
-      config,
-      iosVersion,
-      iosPlatformVersion,
-      headersText,
-      binaryTargetsText,
-      binaryDepsText,
-    );
+    await writeGeneratedPackageSwift(p, config, iosVersion, iosPlatformVersion, headersText);
   }
 }
 
@@ -151,9 +141,9 @@ async function writeGeneratedPackageSwift(
   iosVersion: string,
   iosPlatformVersion: string,
   headersText: string,
-  binaryTargetsText: string,
-  binaryDepsText: string,
 ) {
+  const frameworks = getPlatformElement(p, platform, 'framework');
+  const { binaryTargetsText, binaryDepsText } = buildBinaryTargetEntries(p, frameworks);
   const content = `// swift-tools-version: 5.9
 
 import PackageDescription

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -152,7 +152,7 @@ async function writeGeneratedPackageSwift(
   iosPlatformVersion: string,
   headersText: string,
   binaryTargetsText: string,
-  binaryDepsText: string
+  binaryDepsText: string,
 ) {
   const content = `// swift-tools-version: 5.9
 

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -99,32 +99,54 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     await writeFile(packageSwiftPath, content);
   } else {
     const frameworks = getPlatformElement(p, platform, 'framework');
-    const customXcframeworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.xcframework'));
-    const customFrameworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.framework'));
-    if (customFrameworks.length > 0) {
-      customFrameworks.forEach((f: any) => {
-        logger.warn(
-          `${p.id}: custom .framework files are not supported as binaryTarget in SPM (${f.$.src}). Convert to .xcframework for SPM compatibility.`,
-        );
-      });
-    }
-    const binaryTargetsText = customXcframeworks
-      .map((f: any) => {
-        const name = f.$.src.split('/').pop().replace('.xcframework', '');
-        return `,
+    const { binaryTargetsText, binaryDepsText } = buildBinaryTargetEntries(p, frameworks);
+    await writeGeneratedPackageSwift(
+      p,
+      config,
+      iosVersion,
+      iosPlatformVersion,
+      headersText,
+      binaryTargetsText,
+      binaryDepsText,
+    );
+  }
+}
+
+function buildBinaryTargetEntries(p: Plugin, frameworks: any[]): { binaryTargetsText: string; binaryDepsText: string } {
+  const customXcframeworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.xcframework'));
+  const customFrameworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.framework'));
+
+  if (customFrameworks.length > 0) {
+    customFrameworks.forEach((f: any) => {
+      logger.warn(
+        `${p.id}: custom .framework files are not supported as binaryTarget in SPM (${f.$.src}). Convert to .xcframework for SPM compatibility.`,
+      );
+    });
+  }
+
+  const binaryTargetsText = customXcframeworks
+    .map((f: any) => {
+      const name = f.$.src.split('/').pop().replace('.xcframework', '');
+      return `,
         .binaryTarget(
             name: "${name}",
             path: "${f.$.src}"
         )`;
-      })
-      .join('');
-    const binaryDepsText = customXcframeworks
-      .map((f: any) => {
-        const name = f.$.src.split('/').pop().replace('.xcframework', '');
-        return `,\n                .target(name: "${name}")`;
-      })
-      .join('');
-    const content = `// swift-tools-version: 5.9
+    })
+    .join('');
+
+  const binaryDepsText = customXcframeworks
+    .map((f: any) => {
+      const name = f.$.src.split('/').pop().replace('.xcframework', '');
+      return `,\n                .target(name: "${name}")`;
+    })
+    .join('');
+
+  return { binaryTargetsText, binaryDepsText };
+}
+
+async function writeGeneratedPackageSwift(p: Plugin, config: Config, iosVersion: string, iosPlatformVersion: string, headersText: string, binaryTargetsText: string, binaryDepsText: string) {
+  const content = `// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -151,8 +173,7 @@ let package = Package(
     ]
 )`;
 
-    await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
-  }
+  await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
 }
 
 export async function installCocoaPodsPlugins(config: Config, plugins: Plugin[], deployment: boolean): Promise<void> {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -145,7 +145,15 @@ function buildBinaryTargetEntries(p: Plugin, frameworks: any[]): { binaryTargets
   return { binaryTargetsText, binaryDepsText };
 }
 
-async function writeGeneratedPackageSwift(p: Plugin, config: Config, iosVersion: string, iosPlatformVersion: string, headersText: string, binaryTargetsText: string, binaryDepsText: string) {
+async function writeGeneratedPackageSwift(
+  p: Plugin,
+  config: Config,
+  iosVersion: string,
+  iosPlatformVersion: string,
+  headersText: string,
+  binaryTargetsText: string,
+  binaryDepsText: string
+) {
   const content = `// swift-tools-version: 5.9
 
 import PackageDescription

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -108,12 +108,6 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
         );
       });
     }
-    const systemFrameworks = frameworks.filter((f: any) => !f.$.custom && f.$.src.endsWith('.framework'));
-    const hasWeakFrameworks = systemFrameworks.some((f: any) => f.$.weak === 'true');
-    const requiredSystemFrameworks = systemFrameworks.filter((f: any) => f.$.weak !== 'true');
-
-    const libraryTypeText = hasWeakFrameworks ? `\n            type: .dynamic,` : '';
-
     const binaryTargetsText = customXcframeworks
       .map((f: any) => {
         const name = f.$.src.split('/').pop().replace('.xcframework', '');
@@ -130,14 +124,6 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
         return `,\n                .target(name: "${name}")`;
       })
       .join('');
-    const linkerSettingsText =
-      requiredSystemFrameworks.length > 0
-        ? `,
-            linkerSettings: [
-${requiredSystemFrameworks.map((f: any) => `                .linkedFramework("${f.$.src.replace('.framework', '')}")`).join(',\n')}
-            ]`
-        : '';
-
     const content = `// swift-tools-version: 5.9
 
 import PackageDescription
@@ -147,7 +133,7 @@ let package = Package(
     platforms: [.iOS(.v${iosVersion})],
     products: [
         .library(
-            name: "${p.name}",${libraryTypeText}
+            name: "${p.name}",
             targets: ["${p.name}"]
         )
     ],
@@ -160,7 +146,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Cordova", package: "capacitor-swift-pm")${binaryDepsText}
             ],
-            path: "."${headersText}${linkerSettingsText}
+            path: "."${headersText}
         )${binaryTargetsText}
     ]
 )`;

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -100,6 +100,20 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
   } else {
     const frameworks = getPlatformElement(p, platform, 'framework');
     const customXcframeworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.xcframework'));
+    const customFrameworks = frameworks.filter((f: any) => f.$.custom === 'true' && f.$.src.endsWith('.framework'));
+    if (customFrameworks.length > 0) {
+      customFrameworks.forEach((f: any) => {
+        logger.warn(
+          `${p.id}: custom .framework files are not supported as binaryTarget in SPM (${f.$.src}). Convert to .xcframework for SPM compatibility.`,
+        );
+      });
+    }
+    const systemFrameworks = frameworks.filter((f: any) => !f.$.custom && f.$.src.endsWith('.framework'));
+    const hasWeakFrameworks = systemFrameworks.some((f: any) => f.$.weak === 'true');
+    const requiredSystemFrameworks = systemFrameworks.filter((f: any) => f.$.weak !== 'true');
+
+    const libraryTypeText = hasWeakFrameworks ? `\n            type: .dynamic,` : '';
+
     const binaryTargetsText = customXcframeworks
       .map((f: any) => {
         const name = f.$.src.split('/').pop().replace('.xcframework', '');
@@ -116,6 +130,13 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
         return `,\n                .target(name: "${name}")`;
       })
       .join('');
+    const linkerSettingsText =
+      requiredSystemFrameworks.length > 0
+        ? `,
+            linkerSettings: [
+${requiredSystemFrameworks.map((f: any) => `                .linkedFramework("${f.$.src.replace('.framework', '')}")`).join(',\n')}
+            ]`
+        : '';
 
     const content = `// swift-tools-version: 5.9
 
@@ -126,7 +147,7 @@ let package = Package(
     platforms: [.iOS(.v${iosVersion})],
     products: [
         .library(
-            name: "${p.name}",
+            name: "${p.name}",${libraryTypeText}
             targets: ["${p.name}"]
         )
     ],
@@ -139,7 +160,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Cordova", package: "capacitor-swift-pm")${binaryDepsText}
             ],
-            path: "."${headersText}
+            path: "."${headersText}${linkerSettingsText}
         )${binaryTargetsText}
     ]
 )`;


### PR DESCRIPTION
When Capacitor CLI generates a `Package.swift` for a Cordova plugin in SPM mode, custom `.xcframework` files declared via `<framework custom="true" src="..." />` in `plugin.xml` were not being translated into `binaryTarget` entries. The xcframework was already being copied to the correct location by `copyPluginsNativeFiles`, but the generated `Package.swift` had no reference to it, causing build failures.

This PR adds `binaryTarget` entries and the corresponding target dependencies for each custom `.xcframework` found in the plugin's `plugin.xml`.

Reference https://outsystemsrd.atlassian.net/browse/RMET-5155