### PR TITLE
refactor(android-template)!: remove capacitor-cordova-android-plugins module

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -24,12 +24,6 @@ android {
     }
 }
 
-repositories {
-    flatDir{
-        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
-    }
-}
-
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
@@ -39,7 +33,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android-template/settings.gradle
+++ b/android-template/settings.gradle
@@ -1,5 +1,3 @@
 include ':app'
-include ':capacitor-cordova-android-plugins'
-project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
 
 apply from: 'capacitor.settings.gradle'


### PR DESCRIPTION


## Description
This just removes the capacitor-cordova-android-plugins module from the android-template.
Will follow up with a PR that modifies the CLI to conditionally add the module to the project if Cordova plugins are installed.

It's a breaking change since we are modifying the template, migrate command will have to remove it or users will have to manually remove it.

## Change Type
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking Change
- [ ] Documentation

