### PR TITLE
fix(cli): add system framework and weak framework support in SPM Package.swift

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,6 +98,20 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
+    const frameworks = getPlatformElement(p, platform, 'framework');
+    const systemFrameworks = frameworks.filter((f: any) => !f.$.custom && f.$.src.endsWith('.framework'));
+    const hasWeakFrameworks = systemFrameworks.some((f: any) => f.$.weak === 'true');
+    const requiredSystemFrameworks = systemFrameworks.filter((f: any) => f.$.weak !== 'true');
+
+    const libraryTypeText = hasWeakFrameworks ? `\n            type: .dynamic,` : '';
+    const linkerSettingsText =
+      requiredSystemFrameworks.length > 0
+        ? `,
+            linkerSettings: [
+${requiredSystemFrameworks.map((f: any) => `                .linkedFramework("${f.$.src.replace('.framework', '')}")`).join(',\n')}
+            ]`
+        : '';
+
     const content = `// swift-tools-version: 5.9
 
 import PackageDescription
@@ -107,7 +121,7 @@ let package = Package(
     platforms: [.iOS(.v${iosVersion})],
     products: [
         .library(
-            name: "${p.name}",
+            name: "${p.name}",${libraryTypeText}
             targets: ["${p.name}"]
         )
     ],
@@ -120,7 +134,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Cordova", package: "capacitor-swift-pm")
             ],
-            path: "."${headersText}
+            path: "."${headersText}${linkerSettingsText}
         )
     ]
 )`;


### PR DESCRIPTION
Adds support for translating `<framework src="..." />` declarations from `plugin.xml` into `linkerSettings` entries in the generated `Package.swift`. Frameworks marked as `weak="true"` are handled by setting `type: .dynamic` on the library product, following the same approach used in [ion-ios-camera](https://github.com/ionic-team/ion-ios-camera/commit/123ba380ba06720bb9885c5706f225c6602cf4bf).
Tested with a dummy plugin declaring `SwiftUICore.framework`with `weak="true"`, no crash on iOS 15 simulator, successful build on a physical device.

Reference: https://outsystemsrd.atlassian.net/browse/RMET-5154