### PR TITLE
fix(cli): add cSettings support for compiler flags in generated Package.swift

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -99,7 +99,7 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     await writeFile(packageSwiftPath, content);
   } else {
     const sourceFiles = getPlatformElement(p, platform, 'source-file');
-    const cSettingsText = buildCSettingsText(sourceFiles);
+    const cSettingsText = buildCSettingsText(p, sourceFiles);
 
     const content = `// swift-tools-version: 5.9
 
@@ -132,7 +132,8 @@ let package = Package(
   }
 }
 
-function buildCSettingsText(sourceFiles: any[]): string {
+function buildCSettingsText(p: Plugin, sourceFiles: any[]): string {
+  const pluginId = p.id;
   const allFlags = new Set<string>();
   for (const sourceFile of sourceFiles) {
     const flags = sourceFile.$?.['compiler-flags'];
@@ -150,6 +151,7 @@ function buildCSettingsText(sourceFiles: any[]): string {
   }
 
   const entries: string[] = [];
+  const unsupportedFlags: string[] = [];
 
   for (const flag of allFlags) {
     if (flag.startsWith('-D')) {
@@ -162,7 +164,16 @@ function buildCSettingsText(sourceFiles: any[]): string {
       } else {
         entries.push(`                .define("${definition}")`);
       }
+    } else {
+      unsupportedFlags.push(flag);
     }
+  }
+
+  if (unsupportedFlags.length > 0) {
+    logger.warn(
+      `${pluginId}: the following compiler flags are not supported in SPM and were ignored: ${unsupportedFlags.join(', ')}. ` +
+        `This may cause the plugin to fail to compile.`,
+    );
   }
 
   return `,

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,6 +98,9 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
+    const sourceFiles = getPlatformElement(p, platform, 'source-file');
+    const cSettingsText = buildCSettingsText(sourceFiles);
+
     const content = `// swift-tools-version: 5.9
 
 import PackageDescription
@@ -120,13 +123,52 @@ let package = Package(
             dependencies: [
                 .product(name: "Cordova", package: "capacitor-swift-pm")
             ],
-            path: "."${headersText}
+            path: "."${headersText}${cSettingsText}
         )
     ]
 )`;
 
     await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
   }
+}
+
+function buildCSettingsText(sourceFiles: any[]): string {
+  const allFlags = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    const flags = sourceFile.$?.['compiler-flags'];
+    if (flags) {
+      flags
+        .split(/\s+/)
+        .map((f: string) => f.trim())
+        .filter((f: string) => f.length > 0)
+        .forEach((f: string) => allFlags.add(f));
+    }
+  }
+
+  if (allFlags.size === 0) {
+    return '';
+  }
+
+  const entries: string[] = [];
+
+  for (const flag of allFlags) {
+    if (flag.startsWith('-D')) {
+      const definition = flag.slice(2);
+      const eqIndex = definition.indexOf('=');
+      if (eqIndex !== -1) {
+        const name = definition.slice(0, eqIndex);
+        const value = definition.slice(eqIndex + 1);
+        entries.push(`                .define("${name}", to: "${value}")`);
+      } else {
+        entries.push(`                .define("${definition}")`);
+      }
+    }
+  }
+
+  return `,
+            cSettings: [
+${entries.join(',\n')}
+            ]`;
 }
 
 export async function installCocoaPodsPlugins(config: Config, plugins: Plugin[], deployment: boolean): Promise<void> {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -465,7 +465,6 @@ function getLinkerFlags(config: Config) {
 }
 
 async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
-  const isSPM = (await config.ios.packageManager) === 'SPM';
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
     if (platformTag.$?.package) {
@@ -476,7 +475,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
     const codeFiles = sourceFiles.concat(headerFiles);
     const frameworks = getPlatformElement(p, platform, 'framework');
     let sourcesFolderName = 'sources';
-    if (!isSPM && needsStaticPod(p)) {
+    if ((await config.ios.packageManager) !== 'SPM' && needsStaticPod(p)) {
       sourcesFolderName += 'static';
     }
     const sourcesFolder = join(config.ios.cordovaPluginsDirAbs, sourcesFolderName, p.name);
@@ -487,7 +486,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
         fileName = 'lib' + fileName;
       }
       let destFolder = sourcesFolderName;
-      if (!isSPM && codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
+      if (codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
         destFolder = 'noarc';
       }
       const filePath = getFilePath(config, p, codeFile.$.src);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -98,37 +98,7 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
-    const sourceFiles = getPlatformElement(p, platform, 'source-file');
-    const cSettingsText = buildCSettingsText(p, sourceFiles);
-
-    const content = `// swift-tools-version: 5.9
-
-import PackageDescription
-
-let package = Package(
-    name: "${p.name}",
-    platforms: [.iOS(.v${iosVersion})],
-    products: [
-        .library(
-            name: "${p.name}",
-            targets: ["${p.name}"]
-        )
-    ],
-    dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "${iosPlatformVersion}")
-    ],
-    targets: [
-        .target(
-            name: "${p.name}",
-            dependencies: [
-                .product(name: "Cordova", package: "capacitor-swift-pm")
-            ],
-            path: "."${headersText}${cSettingsText}
-        )
-    ]
-)`;
-
-    await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
+    await writeGeneratedPackageSwift(p, config, iosVersion, iosPlatformVersion, headersText);
   }
 }
 
@@ -180,6 +150,46 @@ function buildCSettingsText(p: Plugin, sourceFiles: any[]): string {
             cSettings: [
 ${entries.join(',\n')}
             ]`;
+}
+
+async function writeGeneratedPackageSwift(
+  p: Plugin,
+  config: Config,
+  iosVersion: string,
+  iosPlatformVersion: string,
+  headersText: string,
+) {
+  const sourceFiles = getPlatformElement(p, platform, 'source-file');
+  const cSettingsText = buildCSettingsText(p, sourceFiles);
+
+  const content = `// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "${p.name}",
+    platforms: [.iOS(.v${iosVersion})],
+    products: [
+        .library(
+            name: "${p.name}",
+            targets: ["${p.name}"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "${iosPlatformVersion}")
+    ],
+    targets: [
+        .target(
+            name: "${p.name}",
+            dependencies: [
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "."${headersText}${cSettingsText}
+        )
+    ]
+)`;
+
+  await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
 }
 
 export async function installCocoaPodsPlugins(config: Config, plugins: Plugin[], deployment: boolean): Promise<void> {

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -77,13 +77,6 @@ async function generateCordovaPackageFiles(cordovaPlugins: Plugin[], config: Con
 
 async function generateCordovaPackageFile(p: Plugin, config: Config) {
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
-  const iosVersion = getMajoriOSVersion(config);
-  const headerFiles = getPlatformElement(p, platform, 'header-file');
-  let headersText = '';
-  if (headerFiles.length > 0) {
-    headersText = `,
-            publicHeadersPath: "."`;
-  }
 
   const platformTag = getPluginPlatform(p, platform);
   if (platformTag.$?.package) {
@@ -98,7 +91,7 @@ async function generateCordovaPackageFile(p: Plugin, config: Config) {
     );
     await writeFile(packageSwiftPath, content);
   } else {
-    await writeGeneratedPackageSwift(p, config, iosVersion, iosPlatformVersion, headersText);
+    await writeGeneratedPackageSwift(p, config, iosPlatformVersion);
   }
 }
 
@@ -142,8 +135,12 @@ function buildCSettingsText(p: Plugin, sourceFiles: any[]): string {
   if (unsupportedFlags.length > 0) {
     logger.warn(
       `${pluginId}: the following compiler flags are not supported in SPM and were ignored: ${unsupportedFlags.join(', ')}. ` +
-        `This may cause the plugin to fail to compile.`,
+        `This might cause the plugin to fail to compile.`,
     );
+  }
+
+  if (entries.length === 0) {
+    return '';
   }
 
   return `,
@@ -152,13 +149,14 @@ ${entries.join(',\n')}
             ]`;
 }
 
-async function writeGeneratedPackageSwift(
-  p: Plugin,
-  config: Config,
-  iosVersion: string,
-  iosPlatformVersion: string,
-  headersText: string,
-) {
+async function writeGeneratedPackageSwift(p: Plugin, config: Config, iosPlatformVersion: string) {
+  const iosVersion = getMajoriOSVersion(config);
+  const headerFiles = getPlatformElement(p, platform, 'header-file');
+  const headersText =
+    headerFiles.length > 0
+      ? `,
+            publicHeadersPath: "."`
+      : '';
   const sourceFiles = getPlatformElement(p, platform, 'source-file');
   const cSettingsText = buildCSettingsText(p, sourceFiles);
 
@@ -467,6 +465,7 @@ function getLinkerFlags(config: Config) {
 }
 
 async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
+  const isSPM = (await config.ios.packageManager) === 'SPM';
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
     if (platformTag.$?.package) {
@@ -477,7 +476,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
     const codeFiles = sourceFiles.concat(headerFiles);
     const frameworks = getPlatformElement(p, platform, 'framework');
     let sourcesFolderName = 'sources';
-    if ((await config.ios.packageManager) !== 'SPM' && needsStaticPod(p)) {
+    if (!isSPM && needsStaticPod(p)) {
       sourcesFolderName += 'static';
     }
     const sourcesFolder = join(config.ios.cordovaPluginsDirAbs, sourcesFolderName, p.name);
@@ -488,7 +487,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
         fileName = 'lib' + fileName;
       }
       let destFolder = sourcesFolderName;
-      if (codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
+      if (!isSPM && codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
         destFolder = 'noarc';
       }
       const filePath = getFilePath(config, p, codeFile.$.src);

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -465,6 +465,7 @@ function getLinkerFlags(config: Config) {
 }
 
 async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) {
+  const isSPM = (await config.ios.packageManager) === 'SPM';
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
     if (platformTag.$?.package) {
@@ -475,7 +476,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
     const codeFiles = sourceFiles.concat(headerFiles);
     const frameworks = getPlatformElement(p, platform, 'framework');
     let sourcesFolderName = 'sources';
-    if ((await config.ios.packageManager) !== 'SPM' && needsStaticPod(p)) {
+    if (!isSPM && needsStaticPod(p)) {
       sourcesFolderName += 'static';
     }
     const sourcesFolder = join(config.ios.cordovaPluginsDirAbs, sourcesFolderName, p.name);
@@ -486,7 +487,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
         fileName = 'lib' + fileName;
       }
       let destFolder = sourcesFolderName;
-      if (codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
+      if (!isSPM && codeFile.$['compiler-flags'] && codeFile.$['compiler-flags'] === '-fno-objc-arc') {
         destFolder = 'noarc';
       }
       const filePath = getFilePath(config, p, codeFile.$.src);


### PR DESCRIPTION
Parse `compiler-flags` from `plugin.xml` and generate `cSettings` in the SPM Package.swift.

Note: this PR will likely conflict with RMET-5159 (https://github.com/ionic-team/capacitor/pull/8443) in the `generateCordovaPackageFile` function, as both PRs declare `const sourceFiles` in the same else block. Easy to resolve.

Reference: https://outsystemsrd.atlassian.net/browse/RMET-5161