### PR TITLE
feat(cli): support custom SPM subdirectory in plugin manifest

### DIFF
--- a/cli/src/plugin.ts
+++ b/cli/src/plugin.ts
@@ -17,6 +17,9 @@ export const enum PluginType {
 export interface PluginManifest {
   readonly ios?: {
     readonly src?: string;
+    readonly spm?: {
+      readonly path?: string;
+    };
   };
   readonly android?: {
     readonly src?: string;

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -1,6 +1,6 @@
 import { pathExists, existsSync, readFileSync, writeFileSync, remove, move, mkdtemp } from 'fs-extra';
 import { tmpdir } from 'os';
-import { join, relative, resolve } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import type { PlistObject } from 'plist';
 import { build, parse } from 'plist';
 import { extract } from 'tar';
@@ -127,7 +127,7 @@ let package = Package(
         packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
       }
     } else {
-      const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      const relPath = relative(config.ios.nativeXcodeProjDirAbs, getPluginPackageDir(plugin));
       const traits = packageTraits[plugin.id];
       const traitsSuffix = traits?.length
         ? `, traits: [${traits
@@ -263,10 +263,23 @@ export async function checkPackageTraitsRequirements(config: Config): Promise<st
 
 // Private Functions
 
+function getPluginPackageDir(plugin: Plugin): string {
+  const spmPath = plugin.manifest?.ios?.spm?.path;
+  if (!spmPath) {
+    return plugin.rootPath;
+  }
+  if (isAbsolute(spmPath) || spmPath.split(/[\\/]/).includes('..')) {
+    fatal(
+      `Invalid ${plugin.id} manifest: capacitor.ios.spm.path must be a relative path within the plugin and cannot contain "..".`,
+    );
+  }
+  return join(plugin.rootPath, spmPath);
+}
+
 async function pluginsWithPackageSwift(plugins: Plugin[]): Promise<Plugin[]> {
   const pluginList: Plugin[] = [];
   for (const plugin of plugins) {
-    const packageSwiftFound = await pathExists(join(plugin.rootPath, 'Package.swift'));
+    const packageSwiftFound = await pathExists(join(getPluginPackageDir(plugin), 'Package.swift'));
     if (packageSwiftFound) {
       pluginList.push(plugin);
     } else {


### PR DESCRIPTION
Closes #8451.

## What

Adds optional `capacitor.ios.spm.path` to the plugin manifest. When set, the CLI uses that subdirectory to locate `Package.swift` and emits the same path in the consumer `CapApp-SPM/Package.swift`, so SwiftPM derives identity from a basename the plugin author controls.

## Why

`name:` on `.package(name:path:)` is ignored for local-path packages, so identity comes from the npm directory name. Collisions like `@capacitor/app` vs `@capacitor-firebase/app` (hard error) or `@capacitor-firebase/app-check` vs the transitive `github.com/google/app-check` (warning, will be escalated) can't be resolved without renaming the npm package.

## Compatibility

Plugins without `spm.path` behave exactly as before. Absolute paths and `..` are rejected.

## Verification

- `npm run build` and `npm test` pass in `cli/`.
- Reproduction: https://github.com/capawesome-team/capacitor-firebase-plugin-demo/tree/chore/ios-spm-migration