### PR TITLE
fix(cli): iOS allow provision update on build XArchive

### DIFF
--- a/cli/src/ios/build.ts
+++ b/cli/src/ios/build.ts
@@ -49,6 +49,8 @@ export async function buildiOS(config: Config, buildOptions: BuildCommandOptions
 
   if (buildOptions.xcodeSigningType == 'manual') {
     buildArgs.push(`PROVISIONING_PROFILE_SPECIFIER=${buildOptions.xcodeProvisioningProfile}`);
+  } else {
+    buildArgs.push('-allowProvisioningUpdates');
   }
 
   await runTask('Building xArchive', async () =>


### PR DESCRIPTION
## Description
On iOS build, set the flag `-allowProvisioningUpdates` on the build xArchieve step when using the automatic signing type

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
The build process for iOS using the `automatic` signing type only set the flag `-allowProvisioningUpdates` on the IPA Build step, if the provision previously used is modified, the process will fail on the xArchieve step.

In my case, after I changed the app entitlements to allow the `carplay-audio`, the build started failing, because the current provisioning didn't had the carplay capability and it wasn't automatically being updated.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<img width="2024" height="202" alt="image" src="https://github.com/user-attachments/assets/e5b7c3e0-2bad-4ea0-a5b4-533257d79427" />
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
