### PR TITLE
fix(cli): copy plugin files in CocoaPods projects

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -564,7 +564,7 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
   const isSPM = (await config.ios.packageManager) === 'SPM';
   for (const p of cordovaPlugins) {
     const platformTag = getPluginPlatform(p, platform);
-    if (platformTag.$?.package) {
+    if (isSPM && platformTag.$?.package) {
       continue;
     }
     const sourceFiles = getPlatformElement(p, platform, 'source-file');


### PR DESCRIPTION
If the plugin has `package` in the iOS platform tag, the CLI is not copying files, but should only not copy files in SPM projects, in CocoaPods projects it should still copy them.