### PR TITLE
feat(cli)!: merge live-reload options into `--url`

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -604,7 +604,7 @@ export interface CapacitorConfig {
      * Configure the local scheme on Android.
      *
      * Custom schemes on Android are unable to change the URL path as of Webview 117. Changing this value from anything other than `http` or `https` can result in your
-     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarentees that this
+     * application unable to resolve routing. If you must change this for some reason, consider using a hash-based url strategy, but there are no guarantees that this
      * will continue to work long term as allowing non-standard schemes to modify query parameters and url fragments is only allowed for compatibility reasons.
      * https://ionic.io/blog/capacitor-android-customscheme-issue-with-chrome-117
      *

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -249,11 +249,8 @@ export function runProgram(config: Config): void {
     )
     .option('--no-sync', `do not run ${c.input('sync')}`)
     .option('--forwardPorts <port:port>', 'Automatically run "adb reverse" for better live-reloading support')
-    .option('-l, --live-reload', 'Set live-reload URL via CLI (uses defaults, overrides server.url config)')
-    .option('--host <host>', 'Configure host for live-reload URL (used with --live-reload)')
-    .option('--port <port>', 'Configure port for live-reload URL (used with --live-reload)')
+    .option('--url <url>', 'Load an external URL in the Web View, useful for live-reload (overrides server.url config)')
     .option('--configuration <name>', 'Configuration name of the iOS Scheme')
-    .option('--https', 'Use https:// instead of http:// for live-reload URL (used with --live-reload)')
     .action(
       wrapAction(
         telemetryAction(
@@ -270,11 +267,8 @@ export function runProgram(config: Config): void {
               targetNameSdkVersion,
               sync,
               forwardPorts,
-              liveReload,
-              host,
-              port,
+              url,
               configuration,
-              https,
             },
           ) => {
             const { runCommand } = await import('./tasks/run');
@@ -288,11 +282,8 @@ export function runProgram(config: Config): void {
               targetNameSdkVersion,
               sync,
               forwardPorts,
-              liveReload,
-              host,
-              port,
+              url,
               configuration,
-              https,
             });
           },
         ),

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -30,11 +30,8 @@ export interface RunCommandOptions {
   targetNameSdkVersion?: string;
   sync?: boolean;
   forwardPorts?: string;
-  liveReload?: boolean;
-  host?: string;
-  port?: string;
+  url?: string;
   configuration?: string;
-  https?: boolean;
 }
 
 export async function runCommand(
@@ -42,7 +39,16 @@ export async function runCommand(
   selectedPlatformName: string,
   options: RunCommandOptions,
 ): Promise<void> {
-  options.host = options.host ?? CapLiveReloadHelper.getIpAddress() ?? 'localhost';
+  if (options.url) {
+    try {
+      const parsed = new URL(options.url);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        fatal(`Invalid --url: must use http:// or https:// (got "${parsed.protocol}//")`);
+      }
+    } catch {
+      fatal(`Invalid --url: "${options.url}" is not a valid URL`);
+    }
+  }
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {
     const platformDir = resolvePlatform(config, selectedPlatformName);
     if (platformDir) {
@@ -91,14 +97,14 @@ export async function runCommand(
         await sync(config, platformName, false, true);
       }
       const cordovaPlugins = await getCordovaPlugins(config, platformName);
-      if (options.liveReload) {
+      if (options.url) {
         await CapLiveReloadHelper.editCapConfigForLiveReload(config, platformName, options);
         if (platformName === config.android.name) {
           await await writeCordovaAndroidManifest(cordovaPlugins, config, platformName, true);
         }
       }
       await run(config, platformName, options);
-      if (options.liveReload) {
+      if (options.url) {
         new Promise((resolve) => process.on('SIGINT', resolve))
           .then(async () => {
             await CapLiveReloadHelper.revertCapConfigForLiveReload();
@@ -107,9 +113,7 @@ export async function runCommand(
             }
           })
           .then(() => process.exit());
-        logger.info(
-          `App running with live reload listing for: ${options.https ? 'https' : 'http'}://${options.host}${options.port ? `:${options.port}` : ''}. Press Ctrl+C to quit.`,
-        );
+        logger.info(`App running with live reload listening for: ${options.url}. Press Ctrl+C to quit.`);
         await sleepForever();
       }
     } catch (e: any) {

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -118,7 +118,7 @@ export async function runCommand(
         await sleepForever();
       }
     } catch (e: any) {
-      if (options.liveReload) {
+      if (options.url) {
         await CapLiveReloadHelper.revertCapConfigForLiveReload();
       }
       if (!isFatal(e)) {

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -40,13 +40,14 @@ export async function runCommand(
   options: RunCommandOptions,
 ): Promise<void> {
   if (options.url) {
+    let parsed: URL;
     try {
-      const parsed = new URL(options.url);
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        fatal(`Invalid --url: must use http:// or https:// (got "${parsed.protocol}//")`);
-      }
+      parsed = new URL(options.url);
     } catch {
       fatal(`Invalid --url: "${options.url}" is not a valid URL`);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      fatal(`Invalid --url: must use http:// or https:// (got "${parsed.protocol}//")`);
     }
   }
   if (selectedPlatformName && !(await isValidPlatform(selectedPlatformName))) {

--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -116,6 +116,9 @@ export async function runCommand(
         await sleepForever();
       }
     } catch (e: any) {
+      if (options.liveReload) {
+        await CapLiveReloadHelper.revertCapConfigForLiveReload();
+      }
       if (!isFatal(e)) {
         fatal(e.stack ?? e);
       }

--- a/cli/src/util/livereload.ts
+++ b/cli/src/util/livereload.ts
@@ -1,5 +1,4 @@
 import { readJSONSync, writeJSONSync } from 'fs-extra';
-import { networkInterfaces } from 'os';
 import { join } from 'path';
 
 import type { Config } from '../definitions';
@@ -18,100 +17,6 @@ class CapLiveReload {
     // nothing to do
   }
 
-  getIpAddress(name?: string, family?: any) {
-    const interfaces: any = networkInterfaces() ?? {};
-
-    const _normalizeFamily = (family?: any) => {
-      if (family === 4) {
-        return 'ipv4';
-      }
-      if (family === 6) {
-        return 'ipv6';
-      }
-      return family ? family.toLowerCase() : 'ipv4';
-    };
-    const isLoopback = (addr: string) => {
-      return (
-        /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/.test(addr) ||
-        /^fe80::1$/.test(addr) ||
-        /^::1$/.test(addr) ||
-        /^::$/.test(addr)
-      );
-    };
-    const isPrivate = (addr: string) => {
-      return (
-        /^(::f{4}:)?10\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
-        /^(::f{4}:)?192\.168\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
-        /^(::f{4}:)?172\.(1[6-9]|2\d|30|31)\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
-        /^(::f{4}:)?127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
-        /^(::f{4}:)?169\.254\.([0-9]{1,3})\.([0-9]{1,3})$/i.test(addr) ||
-        /^f[cd][0-9a-f]{2}:/i.test(addr) ||
-        /^fe80:/i.test(addr) ||
-        /^::1$/.test(addr) ||
-        /^::$/.test(addr)
-      );
-    };
-    const isPublic = (addr: string) => {
-      return !isPrivate(addr);
-    };
-    const loopback = (family?: any) => {
-      //
-      // Default to `ipv4`
-      //
-      family = _normalizeFamily(family);
-
-      if (family !== 'ipv4' && family !== 'ipv6') {
-        throw new Error('family must be ipv4 or ipv6');
-      }
-
-      return family === 'ipv4' ? '127.0.0.1' : 'fe80::1';
-    };
-
-    //
-    // Default to `ipv4`
-    //
-    family = _normalizeFamily(family);
-
-    //
-    // If a specific network interface has been named,
-    // return the address.
-    //
-    if (name && name !== 'private' && name !== 'public') {
-      const res = interfaces[name].filter((details: any) => {
-        const itemFamily = _normalizeFamily(details.family);
-        return itemFamily === family;
-      });
-      if (res.length === 0) {
-        return undefined;
-      }
-      return res[0].address;
-    }
-
-    const all = Object.keys(interfaces)
-      .map((nic) => {
-        //
-        // Note: name will only be `public` or `private`
-        // when this is called.
-        //
-        const addresses = interfaces[nic].filter((details: any) => {
-          details.family = _normalizeFamily(details.family);
-          if (details.family !== family || isLoopback(details.address)) {
-            return false;
-          }
-          if (!name) {
-            return true;
-          }
-
-          return name === 'public' ? isPrivate(details.address) : isPublic(details.address);
-        });
-
-        return addresses.length ? addresses[0].address : undefined;
-      })
-      .filter(Boolean);
-
-    return !all.length ? loopback(family) : all[0];
-  }
-
   async editCapConfigForLiveReload(config: Config, platformName: string, options: RunCommandOptions): Promise<void> {
     const platformAbsPath =
       platformName == config.ios.name
@@ -125,10 +30,9 @@ class CapLiveReload {
     const configJson = readJSONSync(capConfigPath);
     this.configJsonToRevertTo.json = JSON.stringify(configJson, null, 2);
     this.configJsonToRevertTo.platformPath = capConfigPath;
-    const url = `${options.https ? 'https' : 'http'}://${options.host}${options.port ? `:${options.port}` : ''}`;
     configJson.server = {
       ...configJson.server,
-      url,
+      url: options.url,
     };
     writeJSONSync(capConfigPath, configJson, { spaces: '\t' });
   }


### PR DESCRIPTION
# ⚠️🤖  AI-Assisted development with Claude Code 🤖⚠️

## Description

This PR unifies the live reload CLI arguments in cap run`--live-reload` (or `-l`) `--host` `--port` `--https` -> into a single `--url` argument. if we wanted to point to a local network vite server, we had to separate host from the port like so:

```
npx cap run -l --host 192.168.1.181 --port 5173
```

Now it's simply copy the url from the command line that vite outputs and paste it into can run command:

```
npx cap run --url http://192.168.1.181:5173
```

There was a bit of logic related to getting a local IP in the CLI that now becomes unused, so I removed it.

## Change Type
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [x] Breaking Change - to go in Capacitor 9. Since the CLI options change it can break existing apps that are using the current live reload parameters.
- [ ] Documentation

## Rationale / Problems Fixed

Alternative solution to a recent PR that removed a default port in live reload, as suggested in https://github.com/ionic-team/capacitor/pull/8376#issuecomment-4067299292, that some time ago the team internally agreed was better, but never reserved the time to do it.

## Tests or Reproductions

You can test this updated functionality in any capacitor app. For convenience I have https://github.com/OS-pedrogustavobilro/capacitor-test-livereload.

There you need to run `npm ci`, `npm run build` + `npx cap sync`. So start a vite server you do `npm run dev`, to use HTTPS you can use a tool like ngrok `ngrok http 5173`; in another terminal tab you paste the url from vite / ngrok into the cap run command.