### PR TITLE
feat(cli): add experimental packageOptions

### DIFF
--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -559,6 +559,13 @@ export interface CapacitorConfig {
          * @since 8.3.0
          */
         packageTraits?: { [pluginId: string]: string[] };
+        /**
+         * Define options to apply to the package.
+         * The key is the plugin ID (e.g. `@capacitor-community/device`)
+         *
+         * @since 8.4.0
+         */
+        packageOptions?: { [pluginId: string]: PackageOptions };
       };
     };
   };
@@ -798,4 +805,17 @@ export interface PluginsConfig {
      */
     animation?: 'FADE' | 'NONE';
   };
+}
+
+export interface PackageOptions {
+  /**
+   * Create a symlink to the plugin folder instead of pointing to the plugin path.
+   * Useful when plugin names conflict.
+   */
+  symlink: boolean;
+  /**
+   * Useful to avoid target name conflicts in dependencies
+   * [see](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/modulealiasing/)
+   */
+  moduleAliases: { [target: string]: string };
 }

--- a/cli/src/declarations.ts
+++ b/cli/src/declarations.ts
@@ -812,10 +812,10 @@ export interface PackageOptions {
    * Create a symlink to the plugin folder instead of pointing to the plugin path.
    * Useful when plugin names conflict.
    */
-  symlink: boolean;
+  symlink?: boolean;
   /**
    * Useful to avoid target name conflicts in dependencies
    * [see](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/modulealiasing/)
    */
-  moduleAliases: { [target: string]: string };
+  moduleAliases?: { [target: string]: string };
 }

--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -639,6 +639,9 @@ async function copyPluginsNativeFiles(config: Config, cordovaPlugins: Plugin[]) 
 
 async function removePluginsNativeFiles(config: Config) {
   await remove(config.ios.cordovaPluginsDirAbs);
+  if ((await config.ios.packageManager) === 'SPM') {
+    await remove(join(config.ios.nativeProjectDirAbs, 'CapApp-SPM', 'symlinks'));
+  }
   await extractTemplate(config.cli.assets.ios.cordovaPluginsTemplateArchiveAbs, config.ios.cordovaPluginsDirAbs);
 }
 

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -1,4 +1,4 @@
-import { pathExists, existsSync, readFileSync, writeFileSync, remove, move, mkdtemp } from 'fs-extra';
+import { ensureSymlink, pathExists, existsSync, readFileSync, writeFileSync, remove, move, mkdtemp } from 'fs-extra';
 import { tmpdir } from 'os';
 import { join, relative, resolve } from 'path';
 import type { PlistObject } from 'plist';
@@ -100,6 +100,7 @@ export async function generatePackageText(config: Config, plugins: Plugin[]): Pr
   const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
   const iosVersion = getMajoriOSVersion(config);
   const packageTraits = config.app.extConfig.experimental?.ios?.spm?.packageTraits ?? {};
+  const packageOptions = config.app.extConfig.experimental?.ios?.spm?.packageOptions ?? {};
   const swiftToolsVersion = config.app.extConfig.experimental?.ios?.spm?.swiftToolsVersion ?? '5.9';
 
   let packageSwiftText = `// swift-tools-version: ${swiftToolsVersion}
@@ -132,7 +133,13 @@ let package = Package(
         packageSwiftText += `,\n        .package(name: "${plugin.name}", path: "../../capacitor-cordova-ios-plugins/sources/${plugin.name}")`;
       }
     } else {
-      const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      const options = packageOptions[plugin.id];
+      const symlink = options?.symlink;
+      const symlinkFolder = join('symlinks', plugin.name);
+      const relPath = symlink ? symlinkFolder : relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      if (symlink) {
+        await ensureSymlink(plugin.rootPath, resolve(config.ios.nativeProjectDirAbs, 'CapApp-SPM', symlinkFolder));
+      }
       const traits = packageTraits[plugin.id];
       const traitsSuffix = traits?.length
         ? `, traits: [${traits
@@ -156,7 +163,15 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm")`;
 
   for (const plugin of plugins) {
-    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}")`;
+    const aliases = Object.entries(packageOptions[plugin.id]?.moduleAliases ?? {});
+    const aliasText = aliases?.length
+      ? `, moduleAliases:  [${aliases
+          .map(([target, replacement]) => {
+            return `"${target}": "${replacement}"`;
+          })
+          .join(', ')}]`
+      : '';
+    let pluginText = `,\n                .product(name: "${plugin.ios?.name}", package: "${plugin.ios?.name}"${aliasText})`;
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
       if (platformTag.$?.package) {


### PR DESCRIPTION
In addition of the folder name conflict, I found another conflict with target names, so for the folder name problem I added `symlink` option, which will create a symbolic link to the node_modules folder inside a new `symlinks` folder (so we can remove it on update to remove old symbolic links before doing the copy and configuration of existing plugins), since we don't keep track of existing plugins, it's better to just remove everything and start over to not have dangling symlinks after plugin removals.

For target name conflicts I added `moduleAliases`, where you put the existing target name, and the name to be used as alias

can be tested on https://github.com/jcesarmobile/devicecollision which has both `@capacitor/device` and `@capacitor-community/device` and when you fix the folder name problem with `symlink: true`, the target name problem appears. Adding this to solve both problems:

```
experimental: {
    ios: {
      spm: {
        packageOptions: {
          '@capacitor-community/device': {
            symlink: true, 
            moduleAliases: {
              'DevicePlugin': 'CommunityDevicePlugin',
            }
        }
        }
      }
    }
  }
  ```
  
closes https://github.com/ionic-team/capacitor/issues/8451
  
We should probably put the packageTraits inside packageOptions, but didn't do it since it would be breaking, we could do it for Capacitor 9, unless we update to Swift 6 and we could make them non experimental.