### PR TITLE
chore: format java code

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -246,14 +246,14 @@ public class BridgeWebChromeClient extends WebChromeClient {
     public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
         super.onGeolocationPermissionsShowPrompt(origin, callback);
         Logger.debug("onGeolocationPermissionsShowPrompt: DOING IT HERE FOR ORIGIN: " + origin);
-        final String[] geoPermissions = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION };
+        final String[] geoPermissions = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION};
 
         if (!PermissionHelper.hasPermissions(bridge.getContext(), geoPermissions)) {
             permissionListener = (isGranted) -> {
                 if (isGranted) {
                     callback.invoke(origin, true, false);
                 } else {
-                    final String[] coarsePermission = { Manifest.permission.ACCESS_COARSE_LOCATION };
+                    final String[] coarsePermission = {Manifest.permission.ACCESS_COARSE_LOCATION};
                     if (
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                         PermissionHelper.hasPermissions(bridge.getContext(), coarsePermission)
@@ -294,7 +294,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
                         filePathCallback.onReceiveValue(null);
                     }
                 };
-                final String[] camPermission = { Manifest.permission.CAMERA };
+                final String[] camPermission = {Manifest.permission.CAMERA};
                 permissionLauncher.launch(camPermission);
             }
         } else {
@@ -305,7 +305,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
     }
 
     private boolean isMediaCaptureSupported() {
-        String[] permissions = { Manifest.permission.CAMERA };
+        String[] permissions = {Manifest.permission.CAMERA};
         return (
             PermissionHelper.hasPermissions(bridge.getContext(), permissions) ||
             !PermissionHelper.hasDefinedPermission(bridge.getContext(), Manifest.permission.CAMERA)
@@ -343,7 +343,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] { imageFileUri };
+                result = new Uri[] {imageFileUri};
             }
             filePathCallback.onReceiveValue(result);
         };
@@ -362,7 +362,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {
-                result = new Uri[] { activityResult.getData().getData() };
+                result = new Uri[] {activityResult.getData().getData()};
             }
             filePathCallback.onReceiveValue(result);
         };

--- a/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/FileUtils.java
@@ -118,7 +118,7 @@ public class FileUtils {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[] { split[1] };
+                final String[] selectionArgs = new String[] {split[1]};
 
                 return getDataColumn(context, contentUri, selection, selectionArgs);
             }
@@ -195,7 +195,7 @@ public class FileUtils {
         String path = null;
         Cursor cursor = null;
         final String column = "_data";
-        final String[] projection = { column };
+        final String[] projection = {column};
 
         try {
             cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
@@ -292,7 +292,7 @@ public class FileUtils {
     }
 
     private static String sanitizeFilename(String displayName) {
-        String[] badCharacters = new String[] { "..", "/" };
+        String[] badCharacters = new String[] {"..", "/"};
         String[] segments = displayName.split("/");
         String fileName = segments[segments.length - 1];
         for (String suspString : badCharacters) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -465,7 +465,7 @@ public class Plugin {
      * @param callbackName the name of the callback to run when the permission request is complete
      */
     protected void requestPermissionForAlias(@NonNull String alias, @NonNull PluginCall call, @NonNull String callbackName) {
-        requestPermissionForAliases(new String[] { alias }, call, callbackName);
+        requestPermissionForAliases(new String[] {alias}, call, callbackName);
     }
 
     /**
@@ -583,7 +583,7 @@ public class Plugin {
      */
     @Deprecated
     public void pluginRequestPermission(String permission, int requestCode) {
-        ActivityCompat.requestPermissions(getActivity(), new String[] { permission }, requestCode);
+        ActivityCompat.requestPermissions(getActivity(), new String[] {permission}, requestCode);
     }
 
     /**

--- a/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/cordova/MockCordovaWebViewImpl.java
@@ -70,14 +70,12 @@ public class MockCordovaWebViewImpl implements CordovaWebView {
 
         @Override
         public void onNativeToJsMessageAvailable(final NativeToJsMessageQueue queue) {
-            cordova
-                .getActivity()
-                .runOnUiThread(() -> {
-                    String js = queue.popAndEncodeAsJs();
-                    if (js != null) {
-                        webView.evaluateJavascript(js, null);
-                    }
-                });
+            cordova.getActivity().runOnUiThread(() -> {
+                String js = queue.popAndEncodeAsJs();
+                if (js != null) {
+                    webView.evaluateJavascript(js, null);
+                }
+            });
         }
     }
 

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/CapacitorHttp.java
@@ -18,8 +18,8 @@ import java.util.concurrent.Executors;
 
 @CapacitorPlugin(
     permissions = {
-        @Permission(strings = { Manifest.permission.WRITE_EXTERNAL_STORAGE }, alias = "HttpWrite"),
-        @Permission(strings = { Manifest.permission.READ_EXTERNAL_STORAGE }, alias = "HttpRead")
+        @Permission(strings = {Manifest.permission.WRITE_EXTERNAL_STORAGE}, alias = "HttpWrite"),
+        @Permission(strings = {Manifest.permission.READ_EXTERNAL_STORAGE}, alias = "HttpRead")
     }
 )
 public class CapacitorHttp extends Plugin {

--- a/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/ConfigBuildingTest.java
@@ -42,7 +42,7 @@ public class ConfigBuildingTest {
 
             config = new CapConfig.Builder(context)
                 .setAllowMixedContent(true)
-                .setAllowNavigation(new String[] { "http://www.google.com" })
+                .setAllowNavigation(new String[] {"http://www.google.com"})
                 .setAndroidScheme("test")
                 .setCaptureInput(true)
                 .setLoggingEnabled(true)
@@ -64,7 +64,7 @@ public class ConfigBuildingTest {
     @Test
     public void getCoreConfigValues() {
         assertTrue(config.isMixedContentAllowed());
-        assertArrayEquals(new String[] { "http://www.google.com" }, config.getAllowNavigation());
+        assertArrayEquals(new String[] {"http://www.google.com"}, config.getAllowNavigation());
         assertEquals("test", config.getAndroidScheme());
         assertTrue(config.isInputCaptured());
         assertTrue(config.isLoggingEnabled());
@@ -97,7 +97,7 @@ public class ConfigBuildingTest {
 
     @Test
     public void getPluginArray() {
-        String[] comparison = new String[] { "5", "6", "7", "8" };
+        String[] comparison = new String[] {"5", "6", "7", "8"};
         String[] testArray = config.getPluginConfiguration(TEST_PLUGIN_NAME).getArray("var5");
         assertArrayEquals(comparison, testArray);
     }


### PR DESCRIPTION
latest release of prettier-plugin-java doesn't like whitespaces after `{` and before `}` and makes lint to fail.