### PR TITLE
fix(android): show only the requested system bar

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -288,11 +288,12 @@ public class SystemBars extends Plugin {
         WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, window.getDecorView());
 
         if (hide) {
-            if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
-                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
-            }
-            if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
-                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
+            if (bar.isEmpty()) {
+              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
+            } else if (bar.equals(BAR_STATUS_BAR)) {
+              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
+            } else if (bar.equals(BAR_GESTURE_BAR)) {
+              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
             }
             return;
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -305,11 +305,11 @@ public class SystemBars extends Plugin {
 
         if (hide) {
             if (bar.isEmpty()) {
-              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
+                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.systemBars());
             } else if (bar.equals(BAR_STATUS_BAR)) {
-              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
+                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.statusBars());
             } else if (bar.equals(BAR_GESTURE_BAR)) {
-              windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
+                windowInsetsControllerCompat.hide(WindowInsetsCompat.Type.navigationBars());
             }
             return;
         }

--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -297,10 +297,11 @@ public class SystemBars extends Plugin {
             return;
         }
 
-        if (bar.isEmpty() || bar.equals(BAR_STATUS_BAR)) {
+        if (bar.isEmpty()) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.systemBars());
-        }
-        if (bar.isEmpty() || bar.equals(BAR_GESTURE_BAR)) {
+        } else if (bar.equals(BAR_STATUS_BAR)) {
+            windowInsetsControllerCompat.show(WindowInsetsCompat.Type.statusBars());
+        } else if (bar.equals(BAR_GESTURE_BAR)) {
             windowInsetsControllerCompat.show(WindowInsetsCompat.Type.navigationBars());
         }
     }

--- a/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/plugin/SystemBarsTest.java
@@ -1,0 +1,73 @@
+package com.getcapacitor.plugin;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.view.View;
+import android.view.Window;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import com.getcapacitor.Bridge;
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class SystemBarsTest {
+
+    @Test
+    public void showWithEmptyBarShowsSystemBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("");
+
+        verify(controller).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithStatusBarShowsOnlyStatusBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("StatusBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.statusBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.navigationBars());
+    }
+
+    @Test
+    public void showWithNavigationBarShowsOnlyNavigationBars() throws Exception {
+        WindowInsetsControllerCompat controller = invokeSetHidden("NavigationBar");
+
+        verify(controller).show(WindowInsetsCompat.Type.navigationBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.systemBars());
+        verify(controller, never()).show(WindowInsetsCompat.Type.statusBars());
+    }
+
+    private WindowInsetsControllerCompat invokeSetHidden(String bar) throws Exception {
+        SystemBars plugin = new SystemBars();
+        Bridge bridge = mock(Bridge.class);
+        AppCompatActivity activity = mock(AppCompatActivity.class);
+        Window window = mock(Window.class);
+        View decorView = mock(View.class);
+        WindowInsetsControllerCompat controller = mock(WindowInsetsControllerCompat.class);
+
+        when(bridge.getActivity()).thenReturn(activity);
+        when(activity.getWindow()).thenReturn(window);
+        when(window.getDecorView()).thenReturn(decorView);
+
+        plugin.setBridge(bridge);
+
+        try (MockedStatic<WindowCompat> windowCompat = mockStatic(WindowCompat.class)) {
+            windowCompat.when(() -> WindowCompat.getInsetsController(window, decorView)).thenReturn(controller);
+
+            Method setHidden = SystemBars.class.getDeclaredMethod("setHidden", boolean.class, String.class);
+            setHidden.setAccessible(true);
+            setHidden.invoke(plugin, false, bar);
+        }
+
+        return controller;
+    }
+}


### PR DESCRIPTION
## Summary
- show only the requested Android system bar when `SystemBars.show({ bar })` is called
- add a focused Android unit test covering the `show()` mapping for the empty, status-bar, and navigation-bar cases

## Why
The Android `hide()` path already treats `StatusBar` and `NavigationBar` separately, but `show(StatusBar)` was calling `WindowInsetsCompat.Type.systemBars()`, which also reveals the navigation bar.

Fixes #8479.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/hoangvu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hoangvu/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew -p capacitor testDebugUnitTest --tests com.getcapacitor.plugin.SystemBarsTest`