### PR TITLE
feat(cli): capture ios_package_manager in telemetry

### DIFF
--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
 import Debug from 'debug';
+import { pathExists } from 'fs-extra';
 
 import c from './colors';
-import type { Config } from './definitions';
+import type { Config, PackageManager } from './definitions';
 import { send } from './ipc';
 import { output } from './log';
 import { readConfig, writeConfig } from './sysconfig';
@@ -26,6 +27,7 @@ export interface CommandMetricData {
   error: string | null;
   node_version: string;
   os: string;
+  ios_package_manager: PackageManager | 'unknown';
 }
 
 export interface Metric<N extends string, D> {
@@ -80,8 +82,11 @@ export function telemetryAction(config: Config, action: CommanderAction): Comman
       error: error ? (error.message ? error.message : String(error)) : null,
       node_version: process.version,
       os: config.cli.os,
+      ios_package_manager: await getIOSPackageManager(config),
       ...Object.fromEntries(versions),
     };
+
+    debug('metric payload: %O', data);
 
     if (isInteractive()) {
       let sysconfig = await readConfig();
@@ -123,6 +128,24 @@ export async function sendMetric<D>(
     await send({ type: 'telemetry', data: message });
   } else {
     debug('Telemetry is off (user choice, non-interactive terminal, or CI)--not sending metric');
+  }
+}
+
+/**
+ * Resolve the iOS dependency manager for telemetry. Returns 'unknown' for
+ * non-iOS projects or when detection throws, so callers never have to handle
+ * errors from this signal.
+ */
+export async function getIOSPackageManager(config: Config): Promise<PackageManager | 'unknown'> {
+  try {
+    if (!(await pathExists(config.ios.platformDirAbs))) {
+      return 'unknown';
+    }
+
+    return await config.ios.packageManager;
+  } catch (e) {
+    debug('Could not resolve iOS package manager for telemetry: %O', e);
+    return 'unknown';
   }
 }
 

--- a/cli/test/telemetry.spec.ts
+++ b/cli/test/telemetry.spec.ts
@@ -1,0 +1,60 @@
+import { pathExists } from 'fs-extra';
+
+import type { Config, IOSConfig } from '../src/definitions';
+import { getIOSPackageManager } from '../src/telemetry';
+
+jest.mock('fs-extra', () => ({
+  pathExists: jest.fn(),
+}));
+
+const mockedPathExists = pathExists as unknown as jest.Mock;
+
+function makeConfig(ios: Partial<IOSConfig>): Config {
+  return { ios } as unknown as Config;
+}
+
+describe('getIOSPackageManager', () => {
+  beforeEach(() => {
+    mockedPathExists.mockReset();
+  });
+
+  it('returns "unknown" when the iOS platform directory does not exist', async () => {
+    mockedPathExists.mockResolvedValueOnce(false);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/no-such-dir/ios',
+        packageManager: Promise.resolve('SPM'),
+      }),
+    );
+
+    expect(result).toBe('unknown');
+    expect(mockedPathExists).toHaveBeenCalledWith('/tmp/no-such-dir/ios');
+  });
+
+  it('returns the resolved package manager when iOS is present', async () => {
+    mockedPathExists.mockResolvedValueOnce(true);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/app/ios',
+        packageManager: Promise.resolve('SPM'),
+      }),
+    );
+
+    expect(result).toBe('SPM');
+  });
+
+  it('returns "unknown" when packageManager resolution throws', async () => {
+    mockedPathExists.mockResolvedValueOnce(true);
+
+    const result = await getIOSPackageManager(
+      makeConfig({
+        platformDirAbs: '/tmp/app/ios',
+        packageManager: Promise.reject(new Error('boom')),
+      }),
+    );
+
+    expect(result).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Description
Adds `ios_package_manager` to the Capacitor CLI's telemetry payload so every command emitted from a project with an iOS platform reports the dependency manager in use (`Cocoapods | bundler | SPM | unknown`). Detection reuses the existing memoized `config.ios.packageManager` promise and is guarded so non-iOS projects or detection failures yield `'unknown'` and never throw out of `telemetryAction`. The existing `app_id` continues to be sent unchanged and remains the dedup key — no new identifier, no paths, no bundle IDs.

## Change Type
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
Need real-world data to prioritize SPM tooling work and plan CocoaPods deprecation; the CLI is the only signal source. Because `cap sync` runs many times per day, raw event counts would overstate adoption — emitting the new field alongside the existing `app_id` lets downstream consumers dedup per project. Dashboard and metrics-backend work to consume this signal is intentionally out of scope and will be tracked in a separate follow-up.

## Tests or Reproductions
Unit tests in `cli/test/telemetry.spec.ts` cover the three behavioral branches of `getIOSPackageManager`:
- iOS platform dir missing → `'unknown'`
- iOS present, `packageManager` resolves → returns the value
- iOS present, `packageManager` rejects → `'unknown'`

Manually verified against four fixture apps with `DEBUG=capacitor:telemetry npx cap sync <platform>`:

Also, and more importantly, checked that the new `ios_package_manager` field is getting to our endpoint and then being sent to Snowflake.

| Fixture | Setup | `ios_package_manager` |
|---|---|---|
| SPM app | `CapApp-SPM/` (default iOS template) | `'SPM'` |
| CocoaPods app | `Podfile`, no `Gemfile` | `'Cocoapods'` |
| Bundler app | `Podfile` + `Gemfile` with `gem 'cocoapods'` + `bundle` on PATH | `'bundler'` |
| Android-only app | no iOS platform dir | `'unknown'` |

Each fixture emits a distinct `app_id`, confirming the dedup key still works per project. AC coverage for `sync`, `update`, `copy`, `build`, `run`, `open` is automatic: the new field is added inside `telemetryAction` itself, so every wrapped command picks it up.

## Screenshots / Media
n/a

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
Includes a `debug('metric payload: %O', data)` line in `telemetry.ts` to make local inspection cheap (silent unless `DEBUG=capacitor:telemetry` is set). Happy to drop it before merge if reviewers prefer to keep the diff strictly scoped to the AC.
