### PR TITLE
fix(cli): revert live reload config on failure

### DIFF
--- a/cli/src/tasks/run.ts
+++ b/cli/src/tasks/run.ts
@@ -116,6 +116,9 @@ export async function runCommand(
         await sleepForever();
       }
     } catch (e: any) {
+      if (options.liveReload) {
+        await CapLiveReloadHelper.revertCapConfigForLiveReload();
+      }
       if (!isFatal(e)) {
         fatal(e.stack ?? e);
       }


### PR DESCRIPTION
if run/build fails the live reload configuration is kept, should be reverted