### PR TITLE
fix(cli): patch Capacitor SPM dependency version in plugins

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -1,5 +1,6 @@
 import { copy, remove, pathExists, readFile, realpath, writeFile } from 'fs-extra';
 import { basename, dirname, join, relative } from 'path';
+import { major } from 'semver';
 
 import c from '../colors';
 import { checkPlatformVersions, getCapacitorPackageVersion, runTask } from '../common';
@@ -58,6 +59,28 @@ async function updatePluginFiles(config: Config, plugins: Plugin[], deployment: 
     await generateCordovaPackageFiles(cordovaPlugins, config);
 
     const validSPMPackages = await checkPluginsForPackageSwift(config, plugins);
+    await Promise.all(
+      validSPMPackages.map(async (plugin) => {
+        const iosPlatformVersion = await getCapacitorPackageVersion(config, config.ios.name);
+        const packageSwiftPath = join(plugin.rootPath, 'Package.swift');
+        let content = await readFile(packageSwiftPath, { encoding: 'utf-8' });
+        const regex = new RegExp(
+          'url:\\s*"https://github.com/ionic-team/capacitor-swift-pm\\.git",\\s*from:\\s*"([^"]+)"',
+        );
+        const version = content.match(regex)?.[1];
+        const majorCapVersion = major(iosPlatformVersion);
+        if (version && major(version) != majorCapVersion) {
+          content = setAllStringIn(
+            content,
+            `url: "https://github.com/ionic-team/capacitor-swift-pm.git",`,
+            `)`,
+            ` from: "${majorCapVersion}.0.0"`,
+          );
+          await writeFile(packageSwiftPath, content);
+          logger.warn(`${plugin.id} is built for Capacitor ${major(version)}, it might cause issues`);
+        }
+      }),
+    );
 
     await generatePackageFile(config, validSPMPackages.concat(cordovaPlugins));
   } else {


### PR DESCRIPTION
If a plugin is using a different version for the Capacitor SPM dependency, patch it to use the locally installed one and warn about possible issues