### PR TITLE
fix(ios): eliminate double comma in SPM generation

### DIFF
--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -162,10 +162,10 @@ let package = Package(
         .target(
             name: "CapApp-SPM",
             dependencies: [
-                .product(name: "Capacitor", package: "capacitor-swift-pm"),`;
+                .product(name: "Capacitor", package: "capacitor-swift-pm")`;
 
   if (enableCordova) {
-    packageSwiftText += `                .product(name: "Cordova", package: "capacitor-swift-pm")`;
+    packageSwiftText += `,\n               .product(name: "Cordova", package: "capacitor-swift-pm")`;
   }
 
   for (const plugin of plugins) {

--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -165,7 +165,7 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm")`;
 
   if (enableCordova) {
-    packageSwiftText += `,\n               .product(name: "Cordova", package: "capacitor-swift-pm")`;
+    packageSwiftText += `,\n                .product(name: "Cordova", package: "capacitor-swift-pm")`;
   }
 
   for (const plugin of plugins) {


### PR DESCRIPTION
## Description
Changes `spm.ts` to move where the comma is added

## Change Type
- [X] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
Closes #8504
