### PR TITLE
chore(android): remove targetSdkVersion declarations

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -6,7 +6,6 @@ android {
     defaultConfig {
         applicationId "com.getcapacitor.app"
         minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -1,6 +1,7 @@
 ext {
     minSdkVersion = 26
     compileSdkVersion = 37
+    targetSdkVersion = 37
     androidxActivityVersion = '1.11.0'
     androidxAppCompatVersion = '1.7.1'
     androidxCoordinatorLayoutVersion = '1.3.0'

--- a/android-template/variables.gradle
+++ b/android-template/variables.gradle
@@ -1,7 +1,6 @@
 ext {
     minSdkVersion = 26
     compileSdkVersion = 37
-    targetSdkVersion = 37
     androidxActivityVersion = '1.11.0'
     androidxAppCompatVersion = '1.7.1'
     androidxCoordinatorLayoutVersion = '1.3.0'

--- a/android/capacitor-cordova/build.gradle
+++ b/android/capacitor-cordova/build.gradle
@@ -20,7 +20,6 @@ android {
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 37
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 26
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 37
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'

--- a/android/capacitor/build.gradle
+++ b/android/capacitor/build.gradle
@@ -43,7 +43,6 @@ android {
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 37
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 26
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 37
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'

--- a/capacitor-cordova-android-plugins/build.gradle
+++ b/capacitor-cordova-android-plugins/build.gradle
@@ -20,7 +20,6 @@ android {
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 37
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 26
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 37
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove the explicit `targetSdkVersion` declarations from Capacitor's Android library modules, the Android template, and the Cordova plugins template. AGP 9 infers `targetSdkVersion` from `compileSdkVersion` when unset, so the explicit declarations were redundant.

 Reference: [RMET-5256](https://outsystemsrd.atlassian.net/browse/RMET-5256)

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
AGP 9.0 changed the default behavior so that `targetSdkVersion` is inferred from `compileSdkVersion` when not explicitly set (via the `android.sdk.defaultTargetSdkToCompileSdkIfUnset` property, which flipped
to `true` by default). With both values aligned at `37` today, the explicit declarations were noise. Removing them simplifies the build configuration without any change in build output, the inferred value matches the previously declared one.

This is a follow-up from the AGP 9 / Gradle 9 upgrade (#8498).

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
- `./gradlew assembleDebug` in `android/`: **BUILD SUCCESSFUL**
- `./gradlew :capacitor-android:testDebugUnitTest :capacitor-cordova-android:testDebugUnitTest`: **BUILD SUCCESSFUL**
- `npm run build` in `cli/`: regenerated templates tarballs successfully
- Generated a fresh Capacitor app with the local CLI, built with `./gradlew assembleDebug`: **BUILD SUCCESSFUL**, and confirmed the merged manifest reports `android:targetSdkVersion="37"` (inferred from `compileSdkVersion`)
- Tested the override path on the same app: adding `targetSdkVersion` back to `variables.gradle` and `app/build.gradle` correctly sets the explicit value in the merged manifest (verified with `targetSdkVersion = 35`)

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web


[RMET-5256]: https://outsystemsrd.atlassian.net/browse/RMET-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ