### PR TITLE
fix(http): make HttpResponse data type generic

### DIFF
--- a/core/http.md
+++ b/core/http.md
@@ -44,7 +44,11 @@ export default config;
 ## Example
 
 ```typescript
-import { CapacitorHttp } from '@capacitor/core';
+import { CapacitorHttp, type HttpResponse } from '@capacitor/core';
+
+interface MyResponse {
+  foo: string;
+}
 
 // Example of a GET request
 const doGet = () => {
@@ -54,7 +58,7 @@ const doGet = () => {
     params: { size: 'XL' },
   };
 
-  const response: HttpResponse = await CapacitorHttp.get(options);
+  const response: HttpResponse<MyResponse> = await CapacitorHttp.get(options);
 
   // or...
   // const response = await CapacitorHttp.request({ ...options, method: 'GET' })
@@ -69,7 +73,7 @@ const doPost = () => {
     data: { foo: 'bar' },
   };
 
-  const response: HttpResponse = await CapacitorHttp.post(options);
+  const response: HttpResponse<MyResponse> = await CapacitorHttp.post(options);
 
   // or...
   // const response = await CapacitorHttp.request({ ...options, method: 'POST' })
@@ -205,11 +209,11 @@ Make a Http DELETE Request to a server using native libraries.
 ### Interfaces
 
 
-#### HttpResponse
+#### HttpResponse<T = any>
 
 | Prop          | Type                                                | Description                                       |
 | ------------- | --------------------------------------------------- | ------------------------------------------------- |
-| **`data`**    | <code>any</code>                                    | Additional data received with the Http response.  |
+| **`data`**    | <code>T</code>                                      | Additional data received with the Http response.  |
 | **`status`**  | <code>number</code>                                 | The status code received from the Http response.  |
 | **`headers`** | <code><a href="#httpheaders">HttpHeaders</a></code> | The headers received from the Http response.      |
 | **`url`**     | <code>string</code>                                 | The response URL received from the Http response. |

--- a/core/src/core-plugins.ts
+++ b/core/src/core-plugins.ts
@@ -262,11 +262,11 @@ export interface HttpHeaders {
   [key: string]: string;
 }
 
-export interface HttpResponse {
+export interface HttpResponse<T = any> {
   /**
    * Additional data received with the Http response.
    */
-  data: any;
+  data: T;
   /**
    * The status code received from the Http response.
    */


### PR DESCRIPTION
## Description

This change makes HttpResponse generic so callers can type the response payload with HttpResponse<T>. It remains backward-compatible because the default type parameter is any, so existing usages of HttpResponse continue to work unchanged. The result is a small TypeScript API improvement with no runtime impact.     

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
