### PR TITLE
fix(cli): Add missing imports

### DIFF
--- a/cli/src/ios/update.ts
+++ b/cli/src/ios/update.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join, relative } from 'path';
 import { major, prerelease } from 'semver';
 
 import c from '../colors';
-import { checkPlatformVersions, runTask } from '../common';
+import { checkPlatformVersions, getCapacitorPackageVersion, runTask } from '../common';
 import { checkPluginDependencies, handleCordovaPluginsJS, logCordovaManualSteps } from '../cordova';
 import type { Config } from '../definitions';
 import { fatal } from '../errors';
@@ -11,6 +11,7 @@ import { logger } from '../log';
 import type { Plugin } from '../plugin';
 import { PluginType, getPluginType, getPlugins, printPlugins } from '../plugin';
 import { copy as copyTask } from '../tasks/copy';
+import { setAllStringIn } from '../tasks/migrate';
 import {
   generateCordovaPodspecs,
   generateCordovaPackageFiles,


### PR DESCRIPTION
Add missing imports to make the CLI build.

It doesn't include the missing code that was detected of features missing in next branch, only fixes the build that got broken when https://github.com/ionic-team/capacitor/commit/28bb2c687069dfdd6aa7abc866004a1c6388d103 was merged into next without the previous missing code.