### PR TITLE
fix(android): restore verify script

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -23,7 +23,7 @@
     "capacitor-cordova/src/main/"
   ],
   "scripts": {
-    "verify": "./gradlew clean lint build test -b capacitor/build.gradle"
+    "verify": "./gradlew :capacitor-android:clean :capacitor-android:lint :capacitor-android:build :capacitor-android:test"
   },
   "peerDependencies": {
     "@capacitor/core": "^9.0.0-alpha.4"


### PR DESCRIPTION
this change was done by rui on https://github.com/ionic-team/capacitor/pull/8498 as it's needed for gradle 9
but got reverted on latest main merge https://github.com/ionic-team/capacitor/commit/fe3421d6ad7700c3838aab69003865b197fede2b#diff-10ebfa76344c6839bc4a83850fe3ac817c729e2c976e3aa68ebe0e3b6427906e