### PR TITLE
chore(ci): temporarily disable pod lib lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
       - run: npm install
       - run: npm run verify
         working-directory: ./ios
-      - name: Validate native podspec
-        run: sh ./scripts/native-podspec.sh lint
+#      - name: Validate native podspec
+#        run: sh ./scripts/native-podspec.sh lint
   test-android:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
temporarily disable pod lib lint since the Cordova podspec now depends on Capacitor and it's not published yet, once it's published we can add it back