### PR TITLE
fix: add missing logic from merge

### DIFF
--- a/cli/src/util/cordova-ios.ts
+++ b/cli/src/util/cordova-ios.ts
@@ -13,8 +13,8 @@ import {
   getPluginPlatform,
   getPluginType,
 } from '../plugin';
-import { setAllStringIn } from '../tasks/migrate';
 import type { Plugin } from '../plugin';
+import { setAllStringIn } from '../tasks/migrate';
 import { extractTemplate } from '../util/template';
 
 const platform = 'ios';
@@ -393,6 +393,6 @@ let package = Package(
         )
     ]
 )`;
-  await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
+    await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
   }
 }

--- a/cli/src/util/cordova-ios.ts
+++ b/cli/src/util/cordova-ios.ts
@@ -13,6 +13,7 @@ import {
   getPluginPlatform,
   getPluginType,
 } from '../plugin';
+import { setAllStringIn } from '../tasks/migrate';
 import type { Plugin } from '../plugin';
 import { extractTemplate } from '../util/template';
 
@@ -352,7 +353,21 @@ export async function generateCordovaPackageFile(p: Plugin, config: Config): Pro
             publicHeadersPath: "."`;
   }
 
-  const content = `// swift-tools-version: 5.9
+  const platformTag = getPluginPlatform(p, platform);
+
+  if (platformTag.$?.package) {
+    const packageSwiftPath = join(p.rootPath, 'Package.swift');
+    let content = await readFile(packageSwiftPath, { encoding: 'utf-8' });
+    content = content.replace(`apache`, `ionic-team`).replaceAll(`cordova-ios`, `capacitor-swift-pm`);
+    content = setAllStringIn(
+      content,
+      `url: "https://github.com/ionic-team/capacitor-swift-pm.git",`,
+      `)`,
+      ` from: "${iosPlatformVersion}"`,
+    );
+    await writeFile(packageSwiftPath, content);
+  } else {
+    const content = `// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -379,4 +394,5 @@ let package = Package(
     ]
 )`;
   await writeFile(join(config.ios.cordovaPluginsDirAbs, 'sources', p.name, 'Package.swift'), content);
+  }
 }


### PR DESCRIPTION
## Description
Added logic to `cordova-ios.ts` to match upstream, missed in a merge.

Needs #8516 to pass.


## Change Type
- [X] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Platforms Affected
- [ ] Android
- [X] iOS
- [ ] Web

