### PR TITLE
fix(ios): retain WKHTTPCookieStore observer so cookie sync works

### DIFF
--- a/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
+++ b/ios/Capacitor/Capacitor/CAPBridgeViewController.swift
@@ -10,6 +10,12 @@ import Cordova
 
     public fileprivate(set) var webView: WKWebView?
 
+    // WKHTTPCookieStore does not retain observers, so we hold a strong reference here
+    // (else it deallocs immediately and `cookiesDidChange` never fires) plus the store
+    // it was added to, so the observer can be removed in `deinit` as the docs require.
+    private var cookieObserver: CapacitorWKCookieObserver?
+    private weak var cookieObserverStore: WKHTTPCookieStore?
+
     public var isStatusBarVisible = true
     public var statusBarStyle: UIStatusBarStyle = .default
     public var statusBarAnimation: UIStatusBarAnimation = .fade
@@ -26,6 +32,12 @@ import Cordova
         }
         return false
     }()
+
+    deinit {
+        if let cookieObserver = cookieObserver {
+            cookieObserverStore?.remove(cookieObserver)
+        }
+    }
 
     override public final func loadView() {
         // load the configuration and set the logging flag
@@ -118,7 +130,11 @@ import Cordova
      */
     open func webViewConfiguration(for instanceConfiguration: InstanceConfiguration) -> WKWebViewConfiguration {
         let webViewConfiguration = WKWebViewConfiguration()
-        webViewConfiguration.websiteDataStore.httpCookieStore.add(CapacitorWKCookieObserver())
+        let cookieObserver = CapacitorWKCookieObserver()
+        let cookieStore = webViewConfiguration.websiteDataStore.httpCookieStore
+        cookieStore.add(cookieObserver)
+        self.cookieObserver = cookieObserver
+        self.cookieObserverStore = cookieStore
         webViewConfiguration.allowsInlineMediaPlayback = true
         webViewConfiguration.suppressesIncrementalRendering = false
         webViewConfiguration.allowsAirPlayForMediaPlayback = true


### PR DESCRIPTION
## Description
`CAPBridgeViewController.webViewConfiguration(for:)` added a `CapacitorWKCookieObserver` to the web view's `httpCookieStore` but did not keep any reference to it:

```swift
webViewConfiguration.websiteDataStore.httpCookieStore.add(CapacitorWKCookieObserver())
```

Per Apple's docs, `WKHTTPCookieStore` does **not** retain its observers:

> The cookie store doesn't maintain a strong reference to the object you specify. You are responsible for removing your observer object before it becomes invalid.

So the observer was deallocated immediately after `add(_:)` returned, and `cookiesDidChange(in:)` never fired. The result: cookies set inside the `WKWebView` were never synced back to `HTTPCookieStorage`.

This PR holds a strong reference to the observer on the view controller, and also retains the store it was added to so the observer can be removed in `deinit`, as the docs require.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
The cookie observer was dead on arrival — `cookiesDidChange` never ran because the instance had no owner and was released right away. WKWebView → `HTTPCookieStorage` cookie syncing has therefore been silently broken.

The observer is now stored in an optional property assigned at the call site, so a subclass that overrides `webViewConfiguration(for:)` without calling the observer code creates no dangling instance. A weak reference to the exact `WKHTTPCookieStore` is kept so `deinit` can remove the observer per Apple's contract.

## Tests or Reproductions
Tested manually:
- When the response sets a cookie, it is now successfully synced

## Screenshots / Media
N/A

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
The default `websiteDataStore` is the `.default()` singleton, so the store reference stays valid for the controller's lifetime; the weak reference avoids extending the store's lifetime or creating a retain cycle.