### PR TITLE
fix(android): explicitly grant URI permissions for image capture intent

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/BridgeWebChromeClient.java
@@ -340,6 +340,7 @@ public class BridgeWebChromeClient extends WebChromeClient {
             return false;
         }
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, imageFileUri);
+        takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         activityListener = (activityResult) -> {
             Uri[] result = null;
             if (activityResult.getResultCode() == Activity.RESULT_OK) {


### PR DESCRIPTION
## Summary
Android 18 removes automatic URI permission grants for `ACTION_SEND`, `ACTION_SEND_MULTIPLE`, and `ACTION_IMAGE_CAPTURE` intents (apps must now explicitly request them). `BridgeWebChromeClient.showImageCapturePicker()` launches the camera with a FileProvider `content://` URI in `EXTRA_OUTPUT` but never explicitly granted read/write access to it, so on Android 18+ the camera app would silently fail to write the captured photo back into that URI.

- Add `FLAG_GRANT_WRITE_URI_PERMISSION` and `FLAG_GRANT_READ_URI_PERMISSION` to the `ACTION_IMAGE_CAPTURE` intent.

Part of [RMET-5241](https://outsystemsrd.atlassian.net/browse/RMET-5241).

## Test plan
- [x] Manual: triggered a web `<input type="file" accept="image/*" capture>` photo capture flow via a minimal Capacitor test app and confirmed the captured photo loads back into the WebView.
- [x] Verified on Android 7 (API 25) and Android 17 — no regressions, capture works identically to pre-fix behavior on both.

[RMET-5241]: https://outsystemsrd.atlassian.net/browse/RMET-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ