### PR TITLE
fix(ios): adopt UIScene life cycle in default iOS app templates

### DIFF
--- a/ios-pods-template/App/App.xcodeproj/project.pbxproj
+++ b/ios-pods-template/App/App.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		2C6EFDE1674F365EA0601FC0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +23,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				6197F4D7F73A0E1131CB2963 /* SceneDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -210,6 +213,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				2C6EFDE1674F365EA0601FC0 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios-pods-template/App/App/AppDelegate.swift
+++ b/ios-pods-template/App/App/AppDelegate.swift
@@ -46,4 +46,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    // MARK: UIScene life cycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called
+        // shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they
+        // will not return.
+    }
+
 }

--- a/ios-pods-template/App/App/Info.plist
+++ b/ios-pods-template/App/App/Info.plist
@@ -22,6 +22,25 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios-pods-template/App/App/SceneDelegate.swift
+++ b/ios-pods-template/App/App/SceneDelegate.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// Adopts the UIWindowScene-based life cycle required by newer iOS SDKs (see the
+/// `UIApplicationSceneManifest` entry in Info.plist). Without this class and the
+/// corresponding manifest entry, apps built with a scene-lifecycle-requiring SDK
+/// fail to launch (UIKit logs "UIScene life cycle is required for apps built with
+/// this SDK") even though no crash log is produced.
+///
+/// See: https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // The root view controller (CAPBridgeViewController, via Main.storyboard) is configured
+        // automatically from UISceneStoryboardFile in Info.plist, so no manual window/root view
+        // controller setup is required here.
+        guard scene is UIWindowScene else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific
+        // state information to restore the scene back to its current state.
+    }
+}

--- a/ios-spm-template/App/App.xcodeproj/project.pbxproj
+++ b/ios-spm-template/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		785D74E6F5C248B56B0A9CF9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A43193715767FB78F37E3E9 /* SceneDelegate.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +23,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8A43193715767FB78F37E3E9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				8A43193715767FB78F37E3E9 /* SceneDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -156,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				785D74E6F5C248B56B0A9CF9 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios-spm-template/App/App/AppDelegate.swift
+++ b/ios-spm-template/App/App/AppDelegate.swift
@@ -46,4 +46,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    // MARK: UIScene life cycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called
+        // shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they
+        // will not return.
+    }
+
 }

--- a/ios-spm-template/App/App/Info.plist
+++ b/ios-spm-template/App/App/Info.plist
@@ -24,6 +24,25 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios-spm-template/App/App/SceneDelegate.swift
+++ b/ios-spm-template/App/App/SceneDelegate.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// Adopts the UIWindowScene-based life cycle required by newer iOS SDKs (see the
+/// `UIApplicationSceneManifest` entry in Info.plist). Without this class and the
+/// corresponding manifest entry, apps built with a scene-lifecycle-requiring SDK
+/// fail to launch (UIKit logs "UIScene life cycle is required for apps built with
+/// this SDK") even though no crash log is produced.
+///
+/// See: https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // The root view controller (CAPBridgeViewController, via Main.storyboard) is configured
+        // automatically from UISceneStoryboardFile in Info.plist, so no manual window/root view
+        // controller setup is required here.
+        guard scene is UIWindowScene else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific
+        // state information to restore the scene back to its current state.
+    }
+}


### PR DESCRIPTION
## Problem

Apple's [TN3187 – Migrating to the UIKit scene-based life cycle](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle) states:

> In the next major release following iOS 26, UIScene life cycle will be required when building with the latest SDK; otherwise, your app won't launch.

Both default iOS app templates used by the CLI (`ios-spm-template` and `ios-pods-template`) currently only implement the legacy `AppDelegate`-only life cycle, with no `SceneDelegate` and no `UIApplicationSceneManifest` in `Info.plist`.

**Impact:** any app scaffolded today via `npx cap add ios` (or `--packagemanager CocoaPods`) will fail to launch when built against that newer SDK. There is no crash and no crash log — the process starts, the screen goes black, and the OS silently returns to the Home Screen. This is very hard to diagnose without knowing to look for this specific runtime issue in the Xcode console (`UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption`).

I hit exactly this while testing a Capacitor app on a real device on a newer iOS SDK, and confirmed the fix against Apple's official (and recently revised) documentation before proposing it here.

## Fix

Minimal changes to both templates, following Apple's documented migration path 1:1:

- **`SceneDelegate.swift`** (new): implements `UIWindowSceneDelegate` with the standard lifecycle stubs. Since the app's root view controller (`CAPBridgeViewController`) is loaded from `Main.storyboard`, the system auto-configures the scene's window from `UISceneStoryboardFile` — no manual `UIWindow` setup is required.
- **`AppDelegate.swift`**: adds `application(_:configurationForConnecting:options:)` and `application(_:didDiscardSceneSessions:)`.
- **`Info.plist`**: adds `UIApplicationSceneManifest` with `UIApplicationSupportsMultipleScenes = false` and a single `UIWindowSceneSessionRoleApplication` configuration pointing at `SceneDelegate` and the existing `Main` storyboard — this matches Apple's current official example verbatim (same keys, same `UISceneConfigurationName`/`UISceneDelegateClassName` pattern).
- **`project.pbxproj`**: registers `SceneDelegate.swift` in the `App` target (file reference, build file, group, Sources build phase).

`UIMainStoryboardFile`/`UILaunchStoryboardName` are left untouched — they remain valid and are simply superseded for windowing purposes by the scene manifest, matching Apple's guidance for storyboard-based apps.

## Verification

- `Info.plist` and `project.pbxproj` validated with `plutil -lint` (both templates).
- Applied the identical change pattern to a real Capacitor app project, rebuilt with `xcodebuild`, and verified on a physical device: without the fix the app silently fails to launch (black screen, no crash log); with the fix it launches and runs normally.
- Cross-checked the `Info.plist` snippet and `SceneDelegate` pattern against Apple's official TN3187 example to ensure an exact match (not just "a" fix, but *the* documented fix).

## Notes for reviewers

- This is a non-breaking, additive change (existing storyboard-based launch flow is preserved), so I've targeted `main` per `CONTRIBUTING.md`.
- I don't have `npm install` run against the full monorepo tooling in this environment, so I wasn't able to run the repo's own SwiftLint config end-to-end; I did install SwiftLint locally and manually reviewed the new/changed Swift files against the existing file style (4-space indentation, matching comment style, no trailing whitespace, no force-unwraps). Happy to address any CI lint findings.
- Let me know if you'd like the `AppDelegate.configurationForConnecting` method dropped since it's technically redundant once `Info.plist` fully specifies the scene manifest — I kept it since Apple's own template ships it too and it's harmless, but I'm happy to simplify if preferred.