### PR TITLE
fix(SystemBars): avoid extra IME padding on API <= 34 in insets passthrough

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/plugin/SystemBars.java
@@ -204,8 +204,12 @@ public class SystemBars extends Plugin {
             boolean keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
 
             if (shouldPassthroughInsets) {
-                // We need to correct for a possible shown IME
-                v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    // We need to correct for a possible shown IME
+                    // On API <= 34 the window is not edge-to-edge, so the system already
+                    // resizes it for the IME and extra padding would double the space
+                    v.setPadding(0, 0, 0, keyboardVisible ? imeInsets.bottom : 0);
+                }
 
                 Insets safeAreaInsets = calcSafeAreaInsets(insets);
                 injectSafeAreaCSS(safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left);


### PR DESCRIPTION
Fixes #8525

## What

Gates the IME padding in the insets **passthrough** branch of `SystemBars` (WebView >= 140 + `viewport-fit=cover`) behind `Build.VERSION.SDK_INT >= VANILLA_ICE_CREAM`, the same gate that #8439 added to the non-passthrough branch.

## Why

Since 8.3.0 (#8384), when an input is focused on Android 10, a gray area the height of the keyboard appears above the keyboard — reproducible with a fresh `npm init @capacitor/app@latest` app (whose template uses `viewport-fit=cover`, so the passthrough branch is taken on devices with WebView >= 140).

On API <= 34 Capacitor does not run edge-to-edge, so the system already resizes the window when the IME is shown. On API 29 the compat `WindowInsetsCompat.Type.ime()` insets are still reported as the keyboard height after that resize, so `v.setPadding(0, 0, 0, imeInsets.bottom)` compensated for the keyboard a second time, producing the extra gray space. (On API 30–34 the dispatched IME insets are already consumed after the resize, which is why those versions were unaffected.)

#8439 fixed the exact same double-compensation in the non-passthrough branch; the passthrough branch added later in #8424 reintroduced it without the SDK gate. This PR applies the same gate there.

On API 35+ (enforced edge-to-edge) the behavior is unchanged.

## Testing

- `./gradlew compileReleaseJavaWithJavac -b capacitor/build.gradle` passes.
- Repro per the issue: `npm init @capacitor/app@latest`, add an input field, run on Android 10 — the gray space above the keyboard no longer appears, while API 35+ keyboard handling is untouched.
