### PR TITLE
fix(cli): support TypeScript 7 when loading capacitor.config.ts

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -113,7 +113,7 @@ async function loadExtConfigTS(
     }
 
     const ts = require(tsPath); // eslint-disable-line @typescript-eslint/no-var-requires
-    const extConfigObject = requireTS(ts, extConfigFilePath) as any;
+    const extConfigObject = (await requireTS(ts, extConfigFilePath)) as any;
     const extConfig = extConfigObject.default ? await extConfigObject.default : extConfigObject;
 
     return {

--- a/cli/src/util/node.ts
+++ b/cli/src/util/node.ts
@@ -2,16 +2,54 @@ import { existsSync } from 'fs';
 import { readFileSync } from 'fs-extra';
 import { resolve } from 'path';
 import type typescript from 'typescript';
+import { pathToFileURL } from 'url';
 
 interface NodeModuleWithCompile extends NodeJS.Module {
   _compile?(code: string, filename: string): any;
 }
 
 /**
+ * TypeScript 7 dropped the classic compiler API (transpileModule, ModuleKind, etc.) from its
+ * default export -- `require('typescript')` now only exposes `version`/`versionMajorMinor`.
+ * Detect that case so we can fall back to a loading strategy that doesn't depend on it.
+ *
+ * @see https://github.com/ionic-team/capacitor/issues/8531
+ */
+function hasClassicCompilerAPI(ts: typeof typescript): boolean {
+  return typeof ts.transpileModule === 'function';
+}
+
+/**
+ * A plain `import()` here gets downleveled to a `require()` call by tsc when compiling to
+ * CommonJS (our build target), which defeats the purpose -- we specifically need the real ESM
+ * loader so Node's native TypeScript stripping kicks in. Constructing the import from a string
+ * keeps tsc from touching it.
+ */
+const dynamicImport: (specifier: string) => Promise<any> = new Function('specifier', 'return import(specifier)') as any;
+
+/**
  * @see https://github.com/ionic-team/stencil/blob/HEAD/src/compiler/sys/node-require.ts
  */
-export const requireTS = (ts: typeof typescript, p: string): unknown => {
+export const requireTS = async (ts: typeof typescript, p: string): Promise<unknown> => {
   const id = resolve(p);
+
+  if (!hasClassicCompilerAPI(ts)) {
+    // Node has its own built-in TypeScript syntax stripping (stable since Node 23.6, and
+    // available behind --experimental-strip-types since Node 22.6), so we can load the file
+    // directly via the native ESM loader instead of transpiling it ourselves.
+    try {
+      return await dynamicImport(pathToFileURL(id).href);
+    } catch (e: any) {
+      if (e?.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
+        throw new Error(
+          `Your installed version of TypeScript (${ts.version}) no longer provides the compiler API Capacitor previously used to load .ts config files, ` +
+            `and your Node.js runtime (${process.version}) doesn't support loading them natively either.\n` +
+            'Upgrade to Node.js 22.6+ (running with --experimental-strip-types), or Node.js 23.6+, to continue using capacitor.config.ts.',
+        );
+      }
+      throw e;
+    }
+  }
 
   delete require.cache[id];
 


### PR DESCRIPTION
TypeScript 7 dropped the classic compiler API (`transpileModule`, `ModuleKind`, etc.) from its default export, so `requireTS`'s use of `ts.transpileModule` throws on projects with `typescript@7` installed and every command that reads `capacitor.config.ts` fails immediately.

This change detects when that API isn't available and falls back to Node's own built-in TypeScript syntax stripping via a real dynamic `import()` (stable since Node 23.6, available behind `--experimental-strip-types` since Node 22.6) instead of transpiling the file ourselves. Falls back to a clear error if neither is available. Projects on older TypeScript versions are unaffected: the existing `transpileModule` path is unchanged.

Fixes #8531

## Description
<!--- Describe your changes in detail -->

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
TypeScript 7 dropped the classic compiler API (`transpileModule`, `ModuleKind`, etc.) from its default export: `require('typescript')` now only exposes `version`/`versionMajorMinor`, with the replacement living behind non-call-compatible `typescript/unstable/*` subpaths. `requireTS` in `cli/src/util/node.ts` calls `ts.transpileModule(...)` with `module: ts.ModuleKind.CommonJS` to transpile `capacitor.config.ts` on the fly, so on any project with `typescript@7` installed, every command that loads the config (`sync`, `run`, `copy`, `config`, etc.) fails immediately with `TypeError: Cannot read properties of undefined (reading 'CommonJS')`.

This PR detects when the classic compiler API isn't available and falls back to loading the config via a real dynamic `import()`, letting Node's own built-in TypeScript type-stripping do the work instead (stable since Node 23.6, available behind `--experimental-strip-types` since 22.6, Capacitor CLI already requires Node >=22). Projects on TypeScript <7 are unaffected; the existing `transpileModule` path is unchanged.

Fixes #8531

## Tests or Reproductions
Verified against the minimal repro project linked in #8531 ([bradenbiz/cap-ts7-repro](https://github.com/bradenbiz/cap-ts7-repro)), which pins `typescript@7.0.2` and `@capacitor/cli@8.3.3`. `npx cap config` reproduces the exact failure from the issue before this fix, and correctly resolves the config (`appId: 'com.example.repro'`, `appName: 'repro'`, `webDir: 'dist'`) after it.

Also verified in the same project:
- Swapped in `typescript@6` (the repro's own control case) and confirmed the pre-existing `transpileModule` path is untouched and still resolves the config correctly.
- `npm run build` (tsc), `npm run lint` (eslint + prettier), and the full CLI Jest suite (`npm test`, 44 tests) all pass.

## Screenshots / Media
N/A

## Platforms Affected
- [x] Android
- [x] iOS
- [x] Web

## Notes / Comments
`await import()` gets downleveled to a plain `require()` call by `tsc` when compiling to CommonJS (the CLI's build target), which silently defeats this fix since `require()` doesn't invoke Node's ESM loader/type-stripping. Worked around by constructing the import via `new Function('specifier', 'return import(specifier)')`, a standard idiom for preserving genuine dynamic `import()` semantics through a CJS-targeted `tsc` build. Flagging it explicitly here since it looks unusual on first read of the diff.
