### PR TITLE
fix(cli): run gradle wrapper after settings.gradle migration to fix first-run failure

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -198,31 +198,6 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
           join(config.android.platformDirAbs, 'gradle', 'wrapper', 'gradle-wrapper.properties'),
         );
 
-        if (!installFailed && gte(gradleVersion, gradleWrapperVersion)) {
-          try {
-            await runTask(`Upgrading gradle wrapper`, () => {
-              return updateGradleWrapperFiles(config.android.platformDirAbs);
-            });
-            // Run twice as first time it only updates the wrapper properties file
-            await runTask(`Upgrading gradle wrapper files`, () => {
-              return updateGradleWrapperFiles(config.android.platformDirAbs);
-            });
-          } catch (e: any) {
-            if (e.includes('EACCES')) {
-              logger.error(
-                `gradlew file does not have executable permissions. This can happen if the Android platform was added on a Windows machine. Please run ${c.input(
-                  `chmod +x ./${config.android.platformDir}/gradlew`,
-                )} and ${c.input(
-                  `cd ${config.android.platformDir} && ./gradlew wrapper --distribution-type all --gradle-version ${gradleVersion} --warning-mode all`,
-                )} to update the files manually`,
-              );
-            } else {
-              logger.error(`gradle wrapper files were not updated`);
-            }
-          }
-        } else {
-          logger.warn('Skipped upgrading gradle wrapper files');
-        }
         await runTask(`Migrating root build.gradle file.`, () => {
           return updateBuildGradle(join(config.android.platformDirAbs, 'build.gradle'), variablesAndClasspaths);
         });
@@ -247,6 +222,32 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
             writeFileSync(settingsPath, txt, { encoding: 'utf-8' });
           })();
         });
+
+        if (!installFailed && gte(gradleVersion, gradleWrapperVersion)) {
+          try {
+            await runTask(`Upgrading gradle wrapper`, () => {
+              return updateGradleWrapperFiles(config.android.platformDirAbs);
+            });
+            // Run twice as first time it only updates the wrapper properties file
+            await runTask(`Upgrading gradle wrapper files`, () => {
+              return updateGradleWrapperFiles(config.android.platformDirAbs);
+            });
+          } catch (e: any) {
+            if (e.includes('EACCES')) {
+              logger.error(
+                `gradlew file does not have executable permissions. This can happen if the Android platform was added on a Windows machine. Please run ${c.input(
+                  `chmod +x ./${config.android.platformDir}/gradlew`,
+                )} and ${c.input(
+                  `cd ${config.android.platformDir} && ./gradlew wrapper --distribution-type all --gradle-version ${gradleVersion} --warning-mode all`,
+                )} to update the files manually`,
+              );
+            } else {
+              logger.error(`gradle wrapper files were not updated\n${e}`);
+            }
+          }
+        } else {
+          logger.warn('Skipped upgrading gradle wrapper files');
+        }
 
         // Variables gradle
         await runTask(`Migrating variables.gradle file.`, () => {


### PR DESCRIPTION
## Description

> ⚠️ 🤖 AI-assisted PR with Claude code with human input and testing

Android-specific: In Cap migrate command, for Capacitor 9, have switched the order of the gradle wrapper update to run after the `build.gradle` and `settings.gradle` migrations. This is related to Cordova Optional Changes where in conjunction with Cap 9 migrate were causing the gradle wrapper update to fail the first time, having to re-run `cap migrate` a second time to finish updating gradle. More context in "Rationale / Problems Fixed" section.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

The actual error in the CLI is as follows

```java
✖ Upgrading gradle wrapper - failed!
[error] gradle wrapper files were not updated
        
        (...)
        
        * What went wrong:
        A problem occurred evaluating project ':capacitor-cordova-android-plugins'.
        > Could not get unknown property 'cdvPluginPostBuildExtras' for project ':capacitor-cordova-android-plugins' of
        type org.gradle.api.Project.
```

> I added an exception message display to the cli as well (as in other places in the migrate command) so that we (and developers) get more info on the error.

Internal Jira Reference: https://outsystemsrd.atlassian.net/browse/RMET-5377

### Root cause analysis

The `capacitor-cordova-android-plugins` subproject's build.gradle references cdvPluginPostBuildExtras — a Cordova-specific property that no longer exists in Capacitor 9. Gradle fails trying to evaluate it, so ./gradlew wrapper never completes.

The settings.gradle migration step that removes those two lines was already in the code, just running after the Gradle wrapper step. So on the first run, the wrapper fails. On the second run, settings.gradle was already cleaned up from the first run, so Gradle has no broken subproject to evaluate and the wrapper succeeds.

## Tests or Reproductions

I have tested with https://github.com/OS-pedrogustavobilro/cap9-migrate-fails-first-time-android, locally buidling and packing the CLI with this fix to use in the repo, now `cap migrate` works the first time, with and without Cordova Plugins. You may try it out yourself if you'd like, creating new Capacitor 8 apps, then updating to use the tar from that repo and running `cap migrate`.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

