### PR TITLE
fix(ios) Canceling a WKURLSchemeTask cancels the associated URLSessionTask

### DIFF
--- a/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
+++ b/ios/Capacitor/Capacitor.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		A38C3D7B2848BE6F004B3680 /* CapacitorCookieManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38C3D7A2848BE6F004B3680 /* CapacitorCookieManager.swift */; };
 		A71289E627F380A500DADDF3 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71289E527F380A500DADDF3 /* Router.swift */; };
 		A71289EB27F380FD00DADDF3 /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71289EA27F380FD00DADDF3 /* RouterTests.swift */; };
+		CA57000000000000000000B1 /* WebViewAssetHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57000000000000000000F1 /* WebViewAssetHandlerTests.swift */; };
 		A7187FD22BD1CB7D00093C45 /* CAPPluginMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */; };
 		A76739792B98E09700795F7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */; };
 		A771ADEE2C8B845000AF234D /* DateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A771ADED2C8B845000AF234D /* DateCodableTests.swift */; };
@@ -248,6 +249,7 @@
 		A38C3D7A2848BE6F004B3680 /* CapacitorCookieManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapacitorCookieManager.swift; sourceTree = "<group>"; };
 		A71289E527F380A500DADDF3 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		A71289EA27F380FD00DADDF3 /* RouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
+		CA57000000000000000000F1 /* WebViewAssetHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewAssetHandlerTests.swift; sourceTree = "<group>"; };
 		A7187FD12BD1CB7D00093C45 /* CAPPluginMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAPPluginMethod.swift; sourceTree = "<group>"; };
 		A76739782B98E09700795F7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A771ADED2C8B845000AF234D /* DateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCodableTests.swift; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 				62E79C712638B23300414164 /* JSExportTests.swift */,
 				62959BBD2526510200A3D7F1 /* Info.plist */,
 				A71289EA27F380FD00DADDF3 /* RouterTests.swift */,
+				CA57000000000000000000F1 /* WebViewAssetHandlerTests.swift */,
 			);
 			path = CapacitorTests;
 			sourceTree = "<group>";
@@ -777,6 +780,7 @@
 				62FABD2325AE60BA007B3814 /* BridgedTypesTests.m in Sources */,
 				621ECCC3254204B700D3D615 /* BridgedTypesTests.swift in Sources */,
 				A71289EB27F380FD00DADDF3 /* RouterTests.swift in Sources */,
+				CA57000000000000000000B1 /* WebViewAssetHandlerTests.swift in Sources */,
 				6263686025F6EC0100576C1C /* PluginCallAccessorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
+++ b/ios/Capacitor/Capacitor/WebViewAssetHandler.swift
@@ -7,6 +7,9 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
     private var router: Router
     private var serverUrl: URL?
 
+    // Session used for proxied http(s) requests; overridable for testing.
+    var urlSession: URLSession = .shared
+
     public init(router: Router) {
         self.router = router
         super.init()
@@ -102,6 +105,8 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
 
     open func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
         urlSchemeTask.stopped = true
+        urlSchemeTask.dataTask?.cancel()
+        urlSchemeTask.dataTask = nil
     }
 
     open func mimeTypeForExtension(pathExtension: String) -> String {
@@ -139,9 +144,10 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             urlRequest.url = URL(string: targetUrl)
         }
 
-        let urlSession = URLSession.shared
+        let urlSession = self.urlSession
         let task = urlSession.dataTask(with: urlRequest) { (data, response, error) in
             DispatchQueue.main.async {
+                urlSchemeTask.dataTask = nil
                 guard !urlSchemeTask.stopped else { return }
                 if let error = error {
                     urlSchemeTask.didFailWithError(error)
@@ -183,6 +189,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
             }
         }
 
+        urlSchemeTask.dataTask = task
         task.resume()
     }
 
@@ -537,6 +544,7 @@ open class WebViewAssetHandler: NSObject, WKURLSchemeHandler {
 }
 
 private var stoppedKey = malloc(1)
+private var dataTaskKey = malloc(1)
 
 private extension WKURLSchemeTask {
     var stopped: Bool {
@@ -545,6 +553,15 @@ private extension WKURLSchemeTask {
         }
         set {
             objc_setAssociatedObject(self, &stoppedKey, newValue, .OBJC_ASSOCIATION_ASSIGN)
+        }
+    }
+
+    var dataTask: URLSessionDataTask? {
+        get {
+            return objc_getAssociatedObject(self, &dataTaskKey) as? URLSessionDataTask
+        }
+        set {
+            objc_setAssociatedObject(self, &dataTaskKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 }

--- a/ios/Capacitor/CapacitorTests/WebViewAssetHandlerTests.swift
+++ b/ios/Capacitor/CapacitorTests/WebViewAssetHandlerTests.swift
@@ -1,0 +1,68 @@
+//
+//  WebViewAssetHandlerTests.swift
+//  CapacitorTests
+//
+
+import WebKit
+import XCTest
+@testable import Capacitor
+
+class WebViewAssetHandlerTests: XCTestCase {
+
+    // A stub protocol that starts a request but never completes it, so the only
+    // way `stopLoading` fires is the session cancelling the task.
+    final class HangingURLProtocol: URLProtocol {
+        static var onStartLoading: (() -> Void)?
+        static var onStopLoading: (() -> Void)?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() { HangingURLProtocol.onStartLoading?() }
+        override func stopLoading() { HangingURLProtocol.onStopLoading?() }
+    }
+
+    final class MockURLSchemeTask: NSObject, WKURLSchemeTask {
+        let request: URLRequest
+        init(request: URLRequest) { self.request = request }
+        func didReceive(_ response: URLResponse) {}
+        func didReceive(_ data: Data) {}
+        func didFinish() {}
+        func didFailWithError(_ error: Error) {}
+    }
+
+    override func tearDown() {
+        HangingURLProtocol.onStartLoading = nil
+        HangingURLProtocol.onStopLoading = nil
+        super.tearDown()
+    }
+
+    // When WebKit stops a scheme task (e.g. an AbortSignal timeout), the handler
+    // must cancel the underlying URLSession task so its connection is released.
+    func testStopCancelsInFlightProxiedRequest() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HangingURLProtocol.self]
+
+        let handler = WebViewAssetHandler(router: CapacitorRouter())
+        handler.urlSession = URLSession(configuration: configuration)
+
+        let started = expectation(description: "proxied request started")
+        let cancelled = expectation(description: "proxied request cancelled")
+        HangingURLProtocol.onStartLoading = { started.fulfill() }
+        HangingURLProtocol.onStopLoading = { cancelled.fulfill() }
+
+        // Build an interceptor URL exactly as the JS bridge does for a GET.
+        let target = "https://example.com/api/next"
+        let encoded = target.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+        let interceptorURL = URL(string: "capacitor://localhost"
+            + CapacitorBridge.httpInterceptorStartIdentifier
+            + "?" + CapacitorBridge.httpInterceptorUrlParam + "=" + encoded)!
+        let schemeTask = MockURLSchemeTask(request: URLRequest(url: interceptorURL))
+        let webView = WKWebView()
+
+        handler.webView(webView, start: schemeTask)
+        wait(for: [started], timeout: 5)
+
+        handler.webView(webView, stop: schemeTask)
+        wait(for: [cancelled], timeout: 5)
+    }
+}


### PR DESCRIPTION
Hi!

When WebKit cancels a request (due to navigating to a new page, client JS manually cancelling a `fetch` via `AbortController`, etc), it calls the handler's `webView(_:stop:)` method. Today, that only sets a "stopped" flag on the `WKURLSchemeTask` (an associated bool added via an extension) but doesn't actually stop the underlying network request.

In other words: cancelling a network request using native browser semantics does not actually cancel said network request.

In my own app this causes a production issue. We cancel requests with a manual timeout, but since the underlying `URLSession` task is never cancelled, each timed-out request keeps running and holds one of `URLSession.shared`'s limited per-host connections until its internal (much longer) timeout fires. These orphaned requests pile up faster than they time out and exhaust the connection pool. New requests queue behind them, causing all network requests to become slower. That causes a cascade in my app's case, since these slow requests now trigger my client-side timeout, cancel via AbortController, and thus contribute to the pool of phantom dead-but-not-properly-cancelled network requests.

This PR now stores the `URLSessionDataTask` alongside the `WKURLSchemeTask` (as an associated object in an extension, like `stopped`), so that when `stop()` is called, we can cancel the request.

There's a test as well. It just shows that, previously, stopping a request via the web view did not in fact stop the underlying network request, while now it does. It's green now; if you remove my WebViewAssetHandler.swift change it goes red.

Note that this change only affects iOS; I am unclear if the Android implementation has similar issues, but that's out of scope for this PR.

Additionally calling out that adding an internal `urlSession` property instead of hardcoding `URLSession.shared` is a change that technically only exists for testing, but as an internal-only change (it's not public, only used in test via `@testable`) I don't think it's egregious here. If you wanted to merge this change without merging the test, I'd remove that as well.

Thank you!