### PR TITLE
chore(cli): update cap migrate plugins with changes

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -396,7 +396,17 @@ async function installLatestLibs(dependencyManager: string, runInstall: boolean,
 }
 
 async function writeBreakingChanges() {
-  const breaking = ['@capacitor/push-notifications', '@capacitor/splash-screen'];
+  const breaking = [
+    '@capacitor/action-sheet',
+    '@capacitor/barcode-scanner',
+    '@capacitor/browser',
+    '@capacitor/camera',
+    '@capacitor/geolocation',
+    '@capacitor/google-maps',
+    '@capacitor/inappbrowser',
+    '@capacitor/push-notifications',
+    '@capacitor/splash-screen',
+  ];
   const broken = [];
   for (const lib of breaking) {
     if (allDependencies[lib]) {


### PR DESCRIPTION
## Description

Several plugins had updates that will be referenced in Capacitor docs for Cap 9. This PR adds them to the `cap migrate` command so that users get a link to the docs if they have one of the plugins with changes.

Particularly, this PR adds plugins that had gradle dependency variable updates outside those (typically we've added these in other Cap docs, [like updates to Cap 8](https://capacitorjs.com/docs/updating/8-0#plugins), which is why I'm adding them here as well; you can think of them as a soft breaking change).

Plugin list:

- Action Sheet and Browser: Updates to android dependency variables via https://github.com/ionic-team/capacitor-plugins/pull/2573 
- Barcode scanner: https://github.com/ionic-team/capacitor-barcode-scanner/pull/134  
- Camera: https://github.com/ionic-team/capacitor-camera/pull/65 
- Geolocation: https://github.com/ionic-team/capacitor-geolocation/pull/92 
- Google Maps: https://github.com/ionic-team/capacitor-google-maps/pull/173 
- InAppBrowser: https://github.com/ionic-team/capacitor-os-inappbrowser/pull/117 

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Internal JIRA References: https://outsystemsrd.atlassian.net/browse/RMET-5382 + https://outsystemsrd.atlassian.net/browse/RMET-5329

