### PR TITLE
fix(ios): replace deprecated languageCode/regionCode with iOS 16 Locale APIs

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -12,8 +12,8 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         request = URLRequest(url: url)
         request.httpMethod = method
         headers = [:]
-        if let lang = Locale.autoupdatingCurrent.languageCode {
-            if let country = Locale.autoupdatingCurrent.regionCode {
+        if let lang = Locale.autoupdatingCurrent.language.languageCode?.identifier {
+            if let country = Locale.autoupdatingCurrent.region?.identifier {
                 headers["Accept-Language"] = "\(lang)-\(country),\(lang);q=0.5"
             } else {
                 headers["Accept-Language"] = "\(lang);q=0.5"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace the deprecated `Locale.languageCode` and `Locale.regionCode` calls used in `CapacitorUrlRequest` to build the `Accept-Language` header with their iOS 16 replacements: `Locale.language.languageCode?.identifier` and `Locale.region?.identifier`.

ref: https://outsystemsrd.atlassian.net/browse/RMET-5353

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web
