### PR TITLE
fix(cli): use POSIX paths in CapApp-SPM Package.swift

### DIFF
--- a/cli/src/util/spm.ts
+++ b/cli/src/util/spm.ts
@@ -12,6 +12,7 @@ import { getMajoriOSVersion } from '../ios/common';
 import { logger } from '../log';
 import type { Plugin } from '../plugin';
 import { getPlatformElement, getPluginPlatform, getPluginType, PluginType } from '../plugin';
+import { convertToUnixPath } from '../util/fs';
 import { runCommand } from '../util/subprocess';
 
 export interface SwiftPlugin {
@@ -122,7 +123,7 @@ let package = Package(
     if (getPluginType(plugin, config.ios.name) === PluginType.Cordova) {
       const platformTag = getPluginPlatform(plugin, config.ios.name);
       if (platformTag.$?.package) {
-        const relPath = relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+        const relPath = convertToUnixPath(relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath));
         packageSwiftText += `,\n        .package(name: "${plugin.id}", path: "${relPath}")`;
       } else {
         const sourceFiles = getPlatformElement(plugin, config.ios.name, 'source-file');
@@ -136,7 +137,9 @@ let package = Package(
       const options = packageOptions[plugin.id];
       const symlink = options?.symlink;
       const symlinkFolder = join('symlinks', plugin.name);
-      const relPath = symlink ? symlinkFolder : relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath);
+      const relPath = symlink
+        ? symlinkFolder
+        : convertToUnixPath(relative(config.ios.nativeXcodeProjDirAbs, plugin.rootPath));
       if (symlink) {
         await ensureSymlink(plugin.rootPath, resolve(config.ios.nativeProjectDirAbs, 'CapApp-SPM', symlinkFolder));
       }


### PR DESCRIPTION
## Summary
- On Windows, `cap sync` / `cap update` writes `CapApp-SPM/Package.swift` plugin `path:` values using `path.relative()`, which produces backslashes.
- Swift string literals treat `\` as an escape, so Xcode reports **Invalid escape sequence in literal** (e.g. `\@`, `\a` in `..\node_modules\@capacitor\app`).
- Normalize those relative paths with `convertToUnixPath`, matching existing Android settings.gradle and iOS CocoaPods Podfile generation.

## Test plan
- [ ] On Windows: `npx cap sync ios` with an SPM app and local Capacitor plugins
- [ ] Confirm `ios/App/CapApp-SPM/Package.swift` dependency paths use `/` only (no `\`)
- [ ] On macOS: open the project in Xcode and confirm Package.swift parses with no escape-sequence errors
- [ ] On macOS: `npx cap sync ios` still produces correct paths (no regression)

Related prior fix for the same class of bug on CocoaPods: https://github.com/ionic-team/capacitor/issues/5494