### PR TITLE
fix(android): stop using deprecated hasPermission to read Cordova prefs

### DIFF
--- a/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
+++ b/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
@@ -84,13 +84,6 @@ public class CordovaPlugin extends Plugin implements CordovaBridgeConfig {
     }
 
     @Override
-    public boolean hasDefinedRequiredPermissions() {
-        boolean currentPermissionResult = pluginHadPermissionResult;
-        pluginHadPermissionResult = false;
-        return currentPermissionResult;
-    }
-
-    @Override
     public boolean shouldKeepRunning() {
         return preferences.getBoolean("KeepRunning", true);
     }
@@ -98,6 +91,13 @@ public class CordovaPlugin extends Plugin implements CordovaBridgeConfig {
     @Override
     public boolean isDeployDisabled() {
         return preferences.getBoolean("DisableDeploy", false);
+    }
+
+    @Override
+    public boolean hasDefinedRequiredPermissions() {
+        boolean currentPermissionResult = pluginHadPermissionResult;
+        pluginHadPermissionResult = false;
+        return currentPermissionResult;
     }
 
     @Override

--- a/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
+++ b/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
@@ -84,20 +84,20 @@ public class CordovaPlugin extends Plugin implements CordovaBridgeConfig {
     }
 
     @Override
-    public boolean shouldKeepRunning() {
-        return preferences.getBoolean("KeepRunning", true);
-    }
-
-        @Override
-    public boolean isDeployDisabled() {
-        return preferences.getBoolean("DisableDeploy", false);
-    }
-
-    @Override
     public boolean hasDefinedRequiredPermissions() {
         boolean currentPermissionResult = pluginHadPermissionResult;
         pluginHadPermissionResult = false;
         return currentPermissionResult;
+    }
+
+    @Override
+    public boolean shouldKeepRunning() {
+        return preferences.getBoolean("KeepRunning", true);
+    }
+
+    @Override
+    public boolean isDeployDisabled() {
+        return preferences.getBoolean("DisableDeploy", false);
     }
 
     @Override

--- a/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
+++ b/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
@@ -84,13 +84,13 @@ public class CordovaPlugin extends Plugin implements CordovaBridgeConfig {
     }
 
     @Override
-    public boolean isDeployDisabled() {
-        return preferences.getBoolean("DisableDeploy", false);
-    }
-
-    @Override
     public boolean shouldKeepRunning() {
         return preferences.getBoolean("KeepRunning", true);
+    }
+
+        @Override
+    public boolean isDeployDisabled() {
+        return preferences.getBoolean("DisableDeploy", false);
     }
 
     @Override

--- a/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
+++ b/android/capacitor-cordova/src/main/java/com/getcapacitor/cordova/CordovaPlugin.java
@@ -3,6 +3,7 @@ package com.getcapacitor.cordova;
 import android.content.Intent;
 import android.os.Bundle;
 import android.webkit.WebView;
+import com.getcapacitor.CordovaBridgeConfig;
 import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.annotation.CapacitorPlugin;
@@ -16,7 +17,7 @@ import org.apache.cordova.PluginManager;
 import org.json.JSONException;
 
 @CapacitorPlugin(name = "__CordovaPlugin")
-public class CordovaPlugin extends Plugin {
+public class CordovaPlugin extends Plugin implements CordovaBridgeConfig {
 
     private MockCordovaInterfaceImpl cordovaInterface;
     private CordovaWebView webView;
@@ -83,16 +84,13 @@ public class CordovaPlugin extends Plugin {
     }
 
     @Override
-    public boolean hasPermission(String permission) {
-        if (permission.equals("DisableDeploy")) {
-            return preferences.getBoolean(permission, false);
-        }
+    public boolean isDeployDisabled() {
+        return preferences.getBoolean("DisableDeploy", false);
+    }
 
-        if (permission.equals("KeepRunning")) {
-            return preferences.getBoolean(permission, true);
-        }
-
-        return false;
+    @Override
+    public boolean shouldKeepRunning() {
+        return preferences.getBoolean("KeepRunning", true);
     }
 
     @Override

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -379,18 +379,19 @@ public class Bridge {
         return null;
     }
 
-    public boolean isDeployDisabled() {
-        Plugin cordova = this.cordova();
-        if (cordova instanceof CordovaBridgeConfig) {
-            return ((CordovaBridgeConfig) cordova).isDeployDisabled();
-        }
-        return false;
-    }
 
     public boolean shouldKeepRunning() {
         Plugin cordova = this.cordova();
         if (cordova instanceof CordovaBridgeConfig) {
             return ((CordovaBridgeConfig) cordova).shouldKeepRunning();
+        }
+        return false;
+    }
+
+    public boolean isDeployDisabled() {
+        Plugin cordova = this.cordova();
+        if (cordova instanceof CordovaBridgeConfig) {
+            return ((CordovaBridgeConfig) cordova).isDeployDisabled();
         }
         return false;
     }

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -380,22 +380,6 @@ public class Bridge {
     }
 
 
-    public boolean shouldKeepRunning() {
-        Plugin cordova = this.cordova();
-        if (cordova instanceof CordovaBridgeConfig) {
-            return ((CordovaBridgeConfig) cordova).shouldKeepRunning();
-        }
-        return false;
-    }
-
-    public boolean isDeployDisabled() {
-        Plugin cordova = this.cordova();
-        if (cordova instanceof CordovaBridgeConfig) {
-            return ((CordovaBridgeConfig) cordova).isDeployDisabled();
-        }
-        return false;
-    }
-
     public void handleAppUrlLoadError(Exception ex) {
         if (ex instanceof SocketTimeoutException) {
             Logger.error(

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -379,6 +379,21 @@ public class Bridge {
         return null;
     }
 
+    public boolean shouldKeepRunning() {
+        Plugin cordova = this.cordova();
+        if (cordova instanceof CordovaBridgeConfig) {
+            return ((CordovaBridgeConfig) cordova).shouldKeepRunning();
+        }
+        return false;
+    }
+
+    public boolean isDeployDisabled() {
+        Plugin cordova = this.cordova();
+        if (cordova instanceof CordovaBridgeConfig) {
+            return ((CordovaBridgeConfig) cordova).isDeployDisabled();
+        }
+        return false;
+    }
 
     public void handleAppUrlLoadError(Exception ex) {
         if (ex instanceof SocketTimeoutException) {

--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -381,20 +381,18 @@ public class Bridge {
 
     public boolean isDeployDisabled() {
         Plugin cordova = this.cordova();
-        if (cordova != null) {
-            return cordova.hasPermission("DisableDeploy");
-        } else {
-            return false;
+        if (cordova instanceof CordovaBridgeConfig) {
+            return ((CordovaBridgeConfig) cordova).isDeployDisabled();
         }
+        return false;
     }
 
     public boolean shouldKeepRunning() {
         Plugin cordova = this.cordova();
-        if (cordova != null) {
-            return cordova.hasPermission("KeepRunning");
-        } else {
-            return false;
+        if (cordova instanceof CordovaBridgeConfig) {
+            return ((CordovaBridgeConfig) cordova).shouldKeepRunning();
         }
+        return false;
     }
 
     public void handleAppUrlLoadError(Exception ex) {

--- a/android/capacitor/src/main/java/com/getcapacitor/CordovaBridgeConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CordovaBridgeConfig.java
@@ -1,0 +1,6 @@
+package com.getcapacitor;
+
+public interface CordovaBridgeConfig {
+    boolean isDeployDisabled();
+    boolean shouldKeepRunning();
+}

--- a/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
+++ b/ios/Capacitor/Capacitor/Plugins/CapacitorUrlRequest.swift
@@ -12,8 +12,8 @@ open class CapacitorUrlRequest: NSObject, URLSessionTaskDelegate {
         request = URLRequest(url: url)
         request.httpMethod = method
         headers = [:]
-        if let lang = Locale.autoupdatingCurrent.languageCode {
-            if let country = Locale.autoupdatingCurrent.regionCode {
+        if let lang = Locale.autoupdatingCurrent.language.languageCode?.identifier {
+            if let country = Locale.autoupdatingCurrent.region?.identifier {
                 headers["Accept-Language"] = "\(lang)-\(country),\(lang);q=0.5"
             } else {
                 headers["Accept-Language"] = "\(lang);q=0.5"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`Bridge.isDeployDisabled()` and `Bridge.shouldKeepRunning()` used `Plugin.hasPermission(String)`, a
deprecated Android permission API to fetch the Cordova `DisableDeploy` and `KeepRunning` preferences
from the internal `CordovaPlugin`. Those strings are not Android permissions, they are Cordova
`config.xml` preferences.

Introduce a small `CordovaBridgeConfig` interface in `com.getcapacitor`, implemented by `CordovaPlugin` (in `capacitor-cordova-android`). The Bridge now queries the plugin instance via `instanceof` and reads the preferences through the interface. The misleading `hasPermission` override in `CordovaPlugin` is removed.

ref: https://outsystemsrd.atlassian.net/browse/RMET-5358

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
`Plugin.hasPermission(String)` has been `@Deprecated` for a while and is meant for Android runtime permissions, not for reading arbitrary configuration values. The `CordovaPlugin` was overriding it to intercept two strings (`DisableDeploy`, `KeepRunning`) and route them to `preferences.getBoolean()`, which does not match the API's intent and produces deprecation warnings at both call sites in Bridge.

The new `CordovaBridgeConfig` interface:
  - Uses semantically correct names (`isDeployDisabled`, `shouldKeepRunning`)
  - Keeps the module boundary intact, `capacitor-android` does not depend on `capacitor-cordova-android`, so the interface acts as the bridge between them
  - Removes the two deprecation warnings on every build

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Validated using `capacitor-testapp` with runtime validation. A Cordova plugin was registered and `config.xml` preferences set:

  ```xml
  <preference name="DisableDeploy" value="true" />
  <preference name="KeepRunning" value="false" />
```
Bridge returned `isDeployDisabled=true`, `shouldKeepRunning=false` meaning values read correctly through the interface. Fallback path (no Cordova plugin registered) returns false for both, matching prior behavior.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

