### PR TITLE
chore(cli): cap migrate update android dependencies

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -302,7 +302,6 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
               androidxBrowserVersion: '1.10.0',
               androidxMaterialVersion: '1.14.0',
               androidxExifInterfaceVersion: '1.4.2',
-              androidxCoreKTXVersion: '1.17.0',
               googleMapsPlayServicesVersion: '20.0.0',
               googleMapsUtilsVersion: '5.0.0',
               googleMapsKtxVersion: '6.0.1',

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -298,16 +298,16 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
             }
             const pluginVariables: { [key: string]: string } = {
               firebaseMessagingVersion: '25.0.1',
-              playServicesLocationVersion: '21.3.0',
-              androidxBrowserVersion: '1.9.0',
-              androidxMaterialVersion: '1.13.0',
-              androidxExifInterfaceVersion: '1.4.1',
+              playServicesLocationVersion: '21.4.0',
+              androidxBrowserVersion: '1.10.0',
+              androidxMaterialVersion: '1.14.0',
+              androidxExifInterfaceVersion: '1.4.2',
               androidxCoreKTXVersion: '1.17.0',
-              googleMapsPlayServicesVersion: '19.2.0',
-              googleMapsUtilsVersion: '3.19.1',
-              googleMapsKtxVersion: '5.2.1',
-              googleMapsUtilsKtxVersion: '5.2.1',
-              kotlinxCoroutinesVersion: '1.10.2',
+              googleMapsPlayServicesVersion: '20.0.0',
+              googleMapsUtilsVersion: '5.0.0',
+              googleMapsKtxVersion: '6.0.1',
+              googleMapsUtilsKtxVersion: '6.0.1',
+              kotlinxCoroutinesVersion: '1.11.0',
               coreSplashScreenVersion: '1.2.0',
             };
             for (const variable of Object.keys(pluginVariables)) {


### PR DESCRIPTION
Based on plugin updates made for Capacitor 9. Also removed `androidxCoreKTXVersion` since plugins should use androidx core instead of core-ktx (since version 1.19, used by Cap 9, core-ktx is bundled into core).

Internal JIRA References: https://outsystemsrd.atlassian.net/browse/RMET-5329 + https://outsystemsrd.atlassian.net/browse/RMET-5393