### PR TITLE
refactor(android)!: remove deprecated Java APIs for Capacitor 9

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -87,11 +87,6 @@ public class Bridge {
     public static final String CAPACITOR_FILE_START = "/_capacitor_file_";
     public static final String CAPACITOR_CONTENT_START = "/_capacitor_content_";
     public static final String CAPACITOR_HTTP_INTERCEPTOR_START = "/_capacitor_http_interceptor_";
-
-    /** @deprecated CAPACITOR_HTTPS_INTERCEPTOR_START is no longer required. All proxied requests are handled via CAPACITOR_HTTP_INTERCEPTOR_START instead */
-    @Deprecated
-    public static final String CAPACITOR_HTTPS_INTERCEPTOR_START = "/_capacitor_https_interceptor_";
-
     public static final String CAPACITOR_HTTP_INTERCEPTOR_URL_PARAM = "u";
 
     public static final int DEFAULT_ANDROID_WEBVIEW_VERSION = 60;

--- a/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/CapConfig.java
@@ -70,27 +70,6 @@ public class CapConfig {
     private CapConfig() {}
 
     /**
-     * Get an instance of the Config file object.
-     * @deprecated use {@link #loadDefault(Context)} to load an instance of the Config object
-     * from the capacitor.config.json file, or use the {@link CapConfig.Builder} to construct
-     * a CapConfig for embedded use.
-     *
-     * @param assetManager The AssetManager used to load the config file
-     * @param config JSON describing a configuration to use
-     */
-    @Deprecated
-    public CapConfig(AssetManager assetManager, JSONObject config) {
-        if (config != null) {
-            this.configJSON = config;
-        } else {
-            // Load the capacitor.config.json
-            loadConfigFromAssets(assetManager, null);
-        }
-
-        deserializeConfig(null);
-    }
-
-    /**
      * Constructs a Capacitor Configuration from config.json file.
      *
      * @param context The context.
@@ -427,104 +406,6 @@ public class CapConfig {
         }
 
         return pluginConfig;
-    }
-
-    /**
-     * Get a JSON object value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getObject(String)}  to access plugin config values.
-     * For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @return The value from the config, if exists. Null if not
-     */
-    @Deprecated
-    public JSONObject getObject(String key) {
-        try {
-            return configJSON.getJSONObject(key);
-        } catch (Exception ex) {}
-        return null;
-    }
-
-    /**
-     * Get a string value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getString(String, String)} to access plugin config
-     * values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @return The value from the config, if exists. Null if not
-     */
-    @Deprecated
-    public String getString(String key) {
-        return JSONUtils.getString(configJSON, key, null);
-    }
-
-    /**
-     * Get a string value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getString(String, String)} to access plugin config
-     * values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @param defaultValue A default value to return if the key does not exist in the config
-     * @return The value from the config, if key exists. Default value returned if not
-     */
-    @Deprecated
-    public String getString(String key, String defaultValue) {
-        return JSONUtils.getString(configJSON, key, defaultValue);
-    }
-
-    /**
-     * Get a boolean value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getBoolean(String, boolean)} to access plugin config
-     * values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @param defaultValue A default value to return if the key does not exist in the config
-     * @return The value from the config, if key exists. Default value returned if not
-     */
-    @Deprecated
-    public boolean getBoolean(String key, boolean defaultValue) {
-        return JSONUtils.getBoolean(configJSON, key, defaultValue);
-    }
-
-    /**
-     * Get an integer value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getInt(String, int)}  to access the plugin config
-     * values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @param defaultValue A default value to return if the key does not exist in the config
-     * @return The value from the config, if key exists. Default value returned if not
-     */
-    @Deprecated
-    public int getInt(String key, int defaultValue) {
-        return JSONUtils.getInt(configJSON, key, defaultValue);
-    }
-
-    /**
-     * Get a string array value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getArray(String)}  to access the plugin config
-     * values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @return The value from the config, if exists. Null if not
-     */
-    @Deprecated
-    public String[] getArray(String key) {
-        return JSONUtils.getArray(configJSON, key, null);
-    }
-
-    /**
-     * Get a string array value from the Capacitor config.
-     * @deprecated use {@link PluginConfig#getArray(String, String[])}  to access the plugin
-     * config values. For main Capacitor config values, use the appropriate getter.
-     *
-     * @param key A key to fetch from the config
-     * @param defaultValue A default value to return if the key does not exist in the config
-     * @return The value from the config, if key exists. Default value returned if not
-     */
-    @Deprecated
-    public String[] getArray(String key, String[] defaultValue) {
-        return JSONUtils.getArray(configJSON, key, defaultValue);
     }
 
     private static Map<String, PluginConfig> deserializePluginsConfig(JSONObject pluginsConfig) {

--- a/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/MessageHandler.java
@@ -45,11 +45,6 @@ public class MessageHandler {
         }
     }
 
-    @Deprecated
-    public MessageHandler(Bridge bridge, WebView webView, Object cordovaPluginManager) {
-        this(bridge, webView);
-    }
-
     /**
      * The main message handler that will be called from JavaScript
      * to send a message to the native bridge.

--- a/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Plugin.java
@@ -297,24 +297,6 @@ public class Plugin {
     }
 
     /**
-     * Get the value for a key on the config for this plugin.
-     * @deprecated use {@link #getConfig()} and access config values using the methods available
-     * depending on the type.
-     *
-     * @param key the key for the config value
-     * @return some object containing the value from the config
-     */
-    @Deprecated
-    public Object getConfigValue(String key) {
-        try {
-            PluginConfig pluginConfig = getConfig();
-            return pluginConfig.getConfigJSON().get(key);
-        } catch (JSONException ex) {
-            return null;
-        }
-    }
-
-    /**
      * Check whether any of the given permissions has been defined in the AndroidManifest.xml
      * @deprecated use {@link #isPermissionDeclared(String)}
      *

--- a/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/PluginCall.java
@@ -27,12 +27,6 @@ public class PluginCall {
 
     private boolean keepAlive = false;
 
-    /**
-     * Indicates that this PluginCall was released, and should no longer be used
-     */
-    @Deprecated
-    private boolean isReleased = false;
-
     public PluginCall(MessageHandler msgHandler, String pluginId, String callbackId, String methodName, JSObject data) {
         this.msgHandler = msgHandler;
         this.pluginId = pluginId;
@@ -325,28 +319,6 @@ public class PluginCall {
     }
 
     /**
-     * @param name of the option to check
-     * @return boolean indicating if the plugin call has an option for the provided name.
-     * @deprecated Presence of a key should not be considered significant.
-     * Use typed accessors to check the value instead.
-     */
-    @Deprecated
-    public boolean hasOption(String name) {
-        return this.data.has(name);
-    }
-
-    /**
-     * Indicate that the Bridge should cache this call in order to call
-     * it again later. For example, the addListener system uses this to
-     * continuously call the call's callback (😆).
-     * @deprecated use {@link #setKeepAlive(Boolean)} instead
-     */
-    @Deprecated
-    public void save() {
-        setKeepAlive(true);
-    }
-
-    /**
      * Indicate that the Bridge should cache this call in order to call
      * it again later. For example, the addListener system uses this to
      * continuously call the call's callback.
@@ -360,16 +332,6 @@ public class PluginCall {
     public void release(Bridge bridge) {
         this.keepAlive = false;
         bridge.releaseCall(this);
-        this.isReleased = true;
-    }
-
-    /**
-     * @deprecated use {@link #isKeptAlive()}
-     * @return true if the plugin call is kept alive
-     */
-    @Deprecated
-    public boolean isSaved() {
-        return isKeptAlive();
     }
 
     /**
@@ -378,11 +340,6 @@ public class PluginCall {
      */
     public boolean isKeptAlive() {
         return keepAlive;
-    }
-
-    @Deprecated
-    public boolean isReleased() {
-        return isReleased;
     }
 
     class PluginCallDataTypeException extends Exception {


### PR DESCRIPTION
## Description

Removes the Java APIs marked `@Deprecated` in previous major versions, as part of the Capacitor 9 cleanup (RMET-5304). All of them have direct replacements that have been available since Capacitor 3.

| Removed | Replacement |
| :------ | :---------- |
| `CapConfig(AssetManager, JSONObject)` constructor | `CapConfig.loadDefault(Context)` or `CapConfig.Builder` |
| `CapConfig.getObject(String)`, `getString(...)`, `getBoolean(...)`, `getInt(...)`, `getArray(...)` | Typed getters on `CapConfig` for main config values; `PluginConfig` accessors for plugin config values |
| `PluginCall.save()` | `setKeepAlive(true)` |
| `PluginCall.isSaved()` | `isKeptAlive()` |
| `PluginCall.hasOption(String)` | Typed accessors (`getString(...)`, `getInt(...)`, etc.) |
| `PluginCall.isReleased()` (and the backing `isReleased` flag) | No replacement, released calls are managed by the bridge |
| `Bridge.CAPACITOR_HTTPS_INTERCEPTOR_START` | `CAPACITOR_HTTP_INTERCEPTOR_START` |
| `Plugin.getConfigValue(String)` | `getConfig()` and the typed accessors on `PluginConfig` |
| `MessageHandler(Bridge, WebView, Object)` constructor | `MessageHandler(Bridge, WebView)` |

**Intentionally kept**: the legacy `@NativePlugin` ecosystem (the `NativePlugin` annotation and the deprecated permission/activity-result cluster in `Plugin` and `Bridge`: `saveCall`, `getSavedCall`, `freeSavedCall`, `hasDefinedPermissions`, `hasPermission`, `pluginRequestPermission(s)`, `handleOnActivityResult`, `startActivityForResult(int)`, `getPluginWithRequestCode`, `startActivityForPluginWithResult`). Those are still wired into the legacy permission handling and their removal is being evaluated separately (RMET-5305).

## Change Type
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [x] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Capacitor 9 is a major release, which is the opportunity to drop APIs that have been deprecated for several majors. This reduces the public API surface and makes the remaining deprecation warnings actionable again. It is the Android counterpart of the iOS cleanup in #8551.

## Tests or Reproductions

- `./gradlew :capacitor-android:testDebugUnitTest` passes.
- `prettier` (used by the repository's `npm run lint` for Java) reports no violations on the changed files.
- Built and ran [capacitor-testapp](https://github.com/ionic-team/capacitor-testapp) against this branch on an API 36 emulator: all official plugins compile against the new API surface, the bridge starts, all plugins register and the app renders and responds normally.
- Verified there are no remaining references to the removed symbols across the repository (source and tests).

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments

- None of the removed APIs had internal callers, so this is a pure API-surface removal with no behavior changes.
- A migration guide entry for these removals is in ionic-team/capacitor-docs#581.
