### PR TITLE
chore(cli)!: require node >= 24

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "cross platform"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "main": "dist/index.js",
   "types": "dist/declarations.d.ts",


### PR DESCRIPTION
## Description

Updates Capacitor CLI's required Node version from 22 to 24.

This is a breaking change (to be included in Capacitor 9)  because it requires developers to update their Node version.

https://github.com/ionic-team/capacitor/pull/8557 should be merged before this one so CI passes.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Breaking Change
- [ ] Documentation
- [x] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Per https://nodejs.org/en/about/previous-releases, Node 22 will leave maintenance mode around mid-2027, time at which Capacitor 9 would still be active, so we should require Node 24 for it.

Internal Jira Reference: https://outsystemsrd.atlassian.net/browse/RMET-4731

Equivalent PR for Node 22 and Cap 8 last year: https://github.com/ionic-team/capacitor/pull/8198

## Tests or Reproductions

I have tested Cap CLI and a few other assets on Node 24, found no issues or fixes needed.