### PR TITLE
ci: update to node 24 and update actions versions

### DIFF
--- a/.github/workflows/capacitor-bot.yml
+++ b/.github/workflows/capacitor-bot.yml
@@ -15,7 +15,7 @@ jobs:
     name: ${{ github.event_name }}/${{ github.event.action }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ionic-team/bot@main
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get Latest
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
@@ -104,7 +104,7 @@ jobs:
       - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
       - name: Restore Dependency Cache
         uses: actions/cache@v4
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Get Latest
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
@@ -34,12 +34,12 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
@@ -53,12 +53,12 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
@@ -74,12 +74,12 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
@@ -102,12 +102,12 @@ jobs:
       - run: sudo xcode-select --switch ${{ matrix.xcode }}
       - run: xcrun simctl list > /dev/null
       - run: xcodebuild -downloadPlatform iOS
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}
@@ -123,7 +123,7 @@ jobs:
       - setup
       - lint
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
       - name: set up JDK 21
@@ -131,9 +131,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Restore Dependency Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-dependencies-cache-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: 'main'

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -17,7 +17,7 @@ jobs:
       - run: xcodebuild -downloadPlatform iOS
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -15,10 +15,10 @@ jobs:
       - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - run: xcrun simctl list > /dev/null
       - run: xcodebuild -downloadPlatform iOS
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: 'main'

--- a/.github/workflows/publish-npm-alpha.yml
+++ b/.github/workflows/publish-npm-alpha.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-alpha.yml
+++ b/.github/workflows/publish-npm-alpha.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-beta.yml
+++ b/.github/workflows/publish-npm-beta.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-beta.yml
+++ b/.github/workflows/publish-npm-beta.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-dev.yml
+++ b/.github/workflows/publish-npm-dev.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-dev.yml
+++ b/.github/workflows/publish-npm-dev.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-latest-from-pre.yml
+++ b/.github/workflows/publish-npm-latest-from-pre.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-latest-from-pre.yml
+++ b/.github/workflows/publish-npm-latest-from-pre.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-latest.yml
+++ b/.github/workflows/publish-npm-latest.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-nightly.yml
+++ b/.github/workflows/publish-npm-nightly.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-npm-rc.yml
+++ b/.github/workflows/publish-npm-rc.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
           cache-dependency-path: '**/package.json'

--- a/.github/workflows/publish-npm-rc.yml
+++ b/.github/workflows/publish-npm-rc.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Description

This PR has the following updates to GitHub workflows:

- Use Node 24, which will be required in Capacitor 9
- Update `actions/checkout` from v5 to v7
- Update `actions/setup-node` from v6 to v7
- Update `actions/cache` from v4 to v6

Updates to macos runner and Xcode version are out-of-scope, to be done in other task / PR.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [x] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-4731


