### PR TITLE
fix(android-template): declare app/build.gradle dependency versions explicitly

### DIFF
--- a/android-template/app/build.gradle
+++ b/android-template/app/build.gradle
@@ -1,5 +1,12 @@
 apply plugin: 'com.android.application'
 
+def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion
+def androidxCoordinatorLayoutVersion = rootProject.ext.androidxCoordinatorLayoutVersion
+def coreSplashScreenVersion = rootProject.ext.coreSplashScreenVersion
+def junitVersion = rootProject.ext.junitVersion
+def androidxJunitVersion = rootProject.ext.androidxJunitVersion
+def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
+
 android {
     namespace = "com.getcapacitor.myapp"
     compileSdk = rootProject.ext.compileSdkVersion

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -553,6 +553,23 @@ async function updateAppBuildGradle(filename: string) {
 `,
     '',
   );
+
+  if (!replaced.includes('def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion')) {
+    replaced = replaced.replace(
+      `apply plugin: 'com.android.application'\n\n`,
+      `apply plugin: 'com.android.application'
+
+def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion
+def androidxCoordinatorLayoutVersion = rootProject.ext.androidxCoordinatorLayoutVersion
+def coreSplashScreenVersion = rootProject.ext.coreSplashScreenVersion
+def junitVersion = rootProject.ext.junitVersion
+def androidxJunitVersion = rootProject.ext.androidxJunitVersion
+def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
+
+`,
+    );
+  }
+
   writeFileSync(filename, replaced, 'utf-8');
 }
 

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -553,23 +553,6 @@ async function updateAppBuildGradle(filename: string) {
 `,
     '',
   );
-
-  if (!replaced.includes('def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion')) {
-    replaced = replaced.replace(
-      `apply plugin: 'com.android.application'\n\n`,
-      `apply plugin: 'com.android.application'
-
-def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion
-def androidxCoordinatorLayoutVersion = rootProject.ext.androidxCoordinatorLayoutVersion
-def coreSplashScreenVersion = rootProject.ext.coreSplashScreenVersion
-def junitVersion = rootProject.ext.junitVersion
-def androidxJunitVersion = rootProject.ext.androidxJunitVersion
-def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
-
-`,
-    );
-  }
-
   writeFileSync(filename, replaced, 'utf-8');
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes the "Implicit lookup of properties in parent projects" Gradle 9.6 deprecation in the Android app template.

ref: [RMET-5369](https://outsystemsrd.atlassian.net/browse/RMET-5369)

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
Gradle 9.6 deprecated implicit parent property lookup. This will fail with an error in Gradle 10. Declaring the versions locally removes the implicit lookup and makes the template forward-compatible.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Verified on a fresh Capacitor 9 app (Gradle 9.6.0, `--warning-mode=all`) that the 6 warnings on `app/build.gradle` are gone after the fix, and that running `updateAppBuildGradle` against a Cap 8-style sample inserts the `def` block.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web


[RMET-5369]: https://outsystemsrd.atlassian.net/browse/RMET-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ