### PR TITLE
fix(cli): reject apksigner for Android App Bundles

### DIFF
--- a/cli/src/android/build.ts
+++ b/cli/src/android/build.ts
@@ -10,6 +10,12 @@ import { runCommand } from '../util/subprocess';
 export async function buildAndroid(config: Config, buildOptions: BuildCommandOptions): Promise<void> {
   const releaseType = buildOptions.androidreleasetype ?? 'AAB';
   const releaseTypeIsAAB = releaseType === 'AAB';
+  const signingType = buildOptions.signingtype ?? 'jarsigner';
+
+  if (releaseTypeIsAAB && signingType === 'apksigner') {
+    throw 'apksigner cannot sign Android App Bundles. Use jarsigner by setting android.buildOptions.signingType to "jarsigner" or passing "--signing-type jarsigner". Alternatively, build an APK by setting android.buildOptions.releaseType to "APK" or passing "--androidreleasetype APK".';
+  }
+
   const flavor = buildOptions.flavor ?? '';
   const arg = releaseTypeIsAAB ? `:app:bundle${flavor}Release` : `assemble${flavor}Release`;
   const gradleArgs = [arg];
@@ -55,7 +61,7 @@ export async function buildAndroid(config: Config, buildOptions: BuildCommandOpt
     `-release-signed.${releaseType.toLowerCase()}`,
   );
 
-  if (buildOptions.signingtype == 'jarsigner') {
+  if (signingType === 'jarsigner') {
     await signWithJarSigner(config, buildOptions, releasePath, signedReleaseName, unsignedReleaseName);
   } else {
     await signWithApkSigner(config, buildOptions, releasePath, signedReleaseName, unsignedReleaseName);

--- a/cli/test/build.android.spec.ts
+++ b/cli/test/build.android.spec.ts
@@ -1,0 +1,100 @@
+import { buildAndroid } from '../src/android/build';
+import type { AndroidConfig, Config } from '../src/definitions';
+import type { BuildCommandOptions } from '../src/tasks/build';
+import { runCommand } from '../src/util/subprocess';
+
+jest.mock('../src/util/subprocess', () => ({
+  runCommand: jest.fn(),
+}));
+
+const mockedRunCommand = runCommand as jest.MockedFunction<typeof runCommand>;
+
+function makeConfig(android: Partial<AndroidConfig>): Config {
+  return { android } as unknown as Config;
+}
+
+const config = makeConfig({
+  platformDirAbs: '/tmp/app/android',
+  appDirAbs: '/tmp/app/android/app',
+});
+
+const signingOptions: BuildCommandOptions = {
+  keystorepath: '/tmp/release.keystore',
+  keystorepass: 'store-password',
+  keystorealias: 'release',
+  keystorealiaspass: 'key-password',
+  configuration: 'Release',
+};
+
+describe('buildAndroid', () => {
+  beforeEach(() => {
+    mockedRunCommand.mockReset();
+  });
+
+  it('rejects apksigner for AAB before running external commands', async () => {
+    await expect(
+      buildAndroid(config, {
+        ...signingOptions,
+        signingtype: 'apksigner',
+      }),
+    ).rejects.toBe(
+      'apksigner cannot sign Android App Bundles. Use jarsigner by setting android.buildOptions.signingType to "jarsigner" or passing "--signing-type jarsigner". Alternatively, build an APK by setting android.buildOptions.releaseType to "APK" or passing "--androidreleasetype APK".',
+    );
+    expect(mockedRunCommand).not.toHaveBeenCalled();
+  });
+
+  it.each<{
+    name: string;
+    options: Partial<BuildCommandOptions>;
+    gradleTask: string;
+    signingTool: 'apksigner' | 'jarsigner';
+    unsignedArtifact: string;
+    signedArtifact: string;
+  }>([
+    {
+      name: 'uses jarsigner for the default AAB build',
+      options: {},
+      gradleTask: ':app:bundleRelease',
+      signingTool: 'jarsigner',
+      unsignedArtifact: '/tmp/app/android/app/build/outputs/bundle/release/app-release.aab',
+      signedArtifact: '/tmp/app/android/app/build/outputs/bundle/release/app-release-signed.aab',
+    },
+    {
+      name: 'uses jarsigner for an explicit AAB build',
+      options: { androidreleasetype: 'AAB', signingtype: 'jarsigner' },
+      gradleTask: ':app:bundleRelease',
+      signingTool: 'jarsigner',
+      unsignedArtifact: '/tmp/app/android/app/build/outputs/bundle/release/app-release.aab',
+      signedArtifact: '/tmp/app/android/app/build/outputs/bundle/release/app-release-signed.aab',
+    },
+    {
+      name: 'uses apksigner for an APK build when requested',
+      options: { androidreleasetype: 'APK', signingtype: 'apksigner' },
+      gradleTask: 'assembleRelease',
+      signingTool: 'apksigner',
+      unsignedArtifact: '/tmp/app/android/app/build/outputs/apk/release/app-release-unsigned.apk',
+      signedArtifact: '/tmp/app/android/app/build/outputs/apk/release/app-release-signed.apk',
+    },
+    {
+      name: 'uses jarsigner for an APK build when requested',
+      options: { androidreleasetype: 'APK', signingtype: 'jarsigner' },
+      gradleTask: 'assembleRelease',
+      signingTool: 'jarsigner',
+      unsignedArtifact: '/tmp/app/android/app/build/outputs/apk/release/app-release-unsigned.apk',
+      signedArtifact: '/tmp/app/android/app/build/outputs/apk/release/app-release-signed.apk',
+    },
+  ])('$name', async ({ options, gradleTask, signingTool, unsignedArtifact, signedArtifact }) => {
+    await expect(buildAndroid(config, { ...signingOptions, ...options })).resolves.toBeUndefined();
+
+    expect(mockedRunCommand).toHaveBeenCalledTimes(2);
+    expect(mockedRunCommand).toHaveBeenNthCalledWith(1, './gradlew', [gradleTask], {
+      cwd: '/tmp/app/android',
+    });
+    expect(mockedRunCommand).toHaveBeenNthCalledWith(
+      2,
+      signingTool,
+      expect.arrayContaining([unsignedArtifact, signedArtifact]),
+      { cwd: '/tmp/app/android' },
+    );
+  });
+});


### PR DESCRIPTION
## Description

Reject Android App Bundle builds configured with `apksigner` before Gradle or signing commands run. The CLI keeps `jarsigner` as its default and uses the same resolved signing tool for validation and dispatch.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

`apksigner` only supports APK files. Passing an AAB to it currently produces a misleading `MinSdkVersionException` / missing manifest error after the bundle has been built. The new validation explains how to select `jarsigner` or build an APK instead.

Fixes #8428

## Tests or Reproductions

- `npm test -- --runTestsByPath test/build.android.spec.ts` (5 tests passed)
- `npm test --workspace @capacitor/cli` (89 tests passed)
- `npm run build --workspace @capacitor/cli`
- `npm run lint`

The regression tests cover the rejected AAB/apksigner combination and the valid default AAB, explicit AAB/jarsigner, APK/apksigner, and APK/jarsigner paths. External commands are mocked at the `runCommand` process boundary. A real Android SDK and keystore signing run was not performed.

## Screenshots / Media

Not applicable.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments

SwiftLint was skipped by `node-swiftlint` because validation ran on Linux; the TypeScript and formatting portions of the official lint command passed.
