### PR TITLE
fix(cli): declare app/build.gradle dependency versions in cap migrate

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -553,6 +553,23 @@ async function updateAppBuildGradle(filename: string) {
 `,
     '',
   );
+
+  if (!replaced.includes('def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion')) {
+    replaced = replaced.replace(
+      `apply plugin: 'com.android.application'\n\n`,
+      `apply plugin: 'com.android.application'
+
+def androidxAppCompatVersion = rootProject.ext.androidxAppCompatVersion
+def androidxCoordinatorLayoutVersion = rootProject.ext.androidxCoordinatorLayoutVersion
+def coreSplashScreenVersion = rootProject.ext.coreSplashScreenVersion
+def junitVersion = rootProject.ext.junitVersion
+def androidxJunitVersion = rootProject.ext.androidxJunitVersion
+def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
+
+`,
+    );
+  }
+
   writeFileSync(filename, replaced, 'utf-8');
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Extends `cap migrate` to insert the 6 dependency version `def` declarations in `app/build.gradle`, matching the template fix from #8567.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
Gradle 9.6 deprecated implicit parent property lookup. This will fail with an error in Gradle 10.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web
