### PR TITLE
fix(cli): replace usesCleartextTraffic with network-security-config

### DIFF
--- a/cli/src/cordova.ts
+++ b/cli/src/cordova.ts
@@ -867,14 +867,30 @@ export async function writeCordovaAndroidManifest(
     });
   });
   const cleartextString = 'android:usesCleartextTraffic="true"';
-  const cleartextValue =
-    (cleartext || config.app.extConfig.server?.cleartext) && !applicationXMLAttributes.includes(cleartextString)
-      ? cleartextString
+  const networkSecurityConfigValue =
+    cleartext || config.app.extConfig.server?.cleartext || applicationXMLAttributes.includes(cleartextString)
+      ? 'android:networkSecurityConfig="@xml/network_security_config"'
       : '';
+  const networkSecurityConfigDir = join(config.android.cordovaPluginsDirAbs, 'src', 'main', 'res', 'xml');
+  const networkSecurityConfigPath = join(networkSecurityConfigDir, 'network_security_config.xml');
+  if (networkSecurityConfigValue) {
+    await ensureDir(networkSecurityConfigDir);
+    await writeFile(
+      networkSecurityConfigPath,
+      `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>
+`,
+    );
+  } else if (await pathExists(networkSecurityConfigPath)) {
+    await remove(networkSecurityConfigPath);
+  }
+
   let content = `<?xml version='1.0' encoding='utf-8'?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:amazon="http://schemas.amazon.com/apk/res/android">
-<application ${applicationXMLAttributes.join('\n')} ${cleartextValue}>
+<application ${applicationXMLAttributes.filter((attr) => !attr.includes('android:usesCleartextTraffic')).join('\n')} ${networkSecurityConfigValue}>
 ${applicationXMLEntries.join('\n')}
 </application>
 ${rootXMLEntries.join('\n')}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Migrates `usesCleartextTraffic opt-in in the generated `capacitor-cordova-android-plugins` module from the deprecated `android:usesCleartextTraffic` attribute to `network-security-config.xml` with `cleartextTrafficPermitted="true"`. Any legacy `usesCleartextTraffic` attribute injected by Cordova plugins via `edit-config` is filtered out, so the final manifest is free of the deprecated attribute. The `android:networkSecurityConfig` reference is set on the library module's manifest and propagated to the app's final manifest at build time.

The three existing triggers still work: `server.cleartext=true` in the Capacitor config, live-reload, and Cordova plugins declaring `usesCleartextTraffic="true"` via `edit-config`. When none apply, the `network-security-config.xml` file is removed.

ref: [RMET-5243](https://outsystemsrd.atlassian.net/browse/RMET-5243)

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
`android:usesCleartextTraffic` is [deprecated in a future Android version](https://developer.android.com/about/versions/17/behavior-changes-all#uses-clear-traffic-deprecation) and will eventually be removed.
The recommended replacement is `network-security-config` with `cleartextTrafficPermitted`.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->
Verified (inspecting the generated manifest + `network-security-config.xml` file) and in runtime on a Samsung SM-S721B using the `@capacitor/inappbrowser` example app pointed at `http://httpforever.com` and `https://outsystems.com`:

- Default (no cleartext trigger): HTTP blocked, HTTPS loads.
- `server.cleartext=true`: HTTP loads, HTTPS loads.
- Cordova plugin `edit-config` with `usesCleartextTraffic="true"` (and `server.cleartext=false`): HTTP loads, HTTPS loads. Legacy attribute filtered out of the final manifest.
- live-reload: HTTP loads, HTTPS loads.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

[RMET-5243]: https://outsystemsrd.atlassian.net/browse/RMET-5243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ