### PR TITLE
fix(cli): run gradle wrapper before root build.gradle migration

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -202,10 +202,6 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
           join(config.android.platformDirAbs, 'gradle', 'wrapper', 'gradle-wrapper.properties'),
         );
 
-        await runTask(`Migrating root build.gradle file.`, () => {
-          return updateBuildGradle(join(config.android.platformDirAbs, 'build.gradle'), variablesAndClasspaths);
-        });
-
         await runTask(`Migrating app build.gradle file.`, () => {
           return updateAppBuildGradle(join(config.android.appDirAbs, 'build.gradle'));
         });
@@ -227,6 +223,7 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
           })();
         });
 
+        // Always run before root build.gradle changes as the AGP update could be incompatible with current gradle
         if (!installFailed && gte(gradleVersion, gradleWrapperVersion)) {
           try {
             await runTask(`Upgrading gradle wrapper`, () => {
@@ -252,6 +249,10 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
         } else {
           logger.warn('Skipped upgrading gradle wrapper files');
         }
+
+        await runTask(`Migrating root build.gradle file.`, () => {
+          return updateBuildGradle(join(config.android.platformDirAbs, 'build.gradle'), variablesAndClasspaths);
+        });
 
         // Variables gradle
         await runTask(`Migrating variables.gradle file.`, () => {


### PR DESCRIPTION
In https://github.com/ionic-team/capacitor/pull/8543 the order of updating files was changed to edit settings.gradle and app/build.gradle before updating gradle files as it could cause issues, but the root build.gradle was also moved to run before updating the wrapper files.
The wrapper files need to be updated before updating the root build.gradle as if the AGP version is not compatible with current gradle it will fail to update the wrapper files, it doesn't happen with current versions, but could break in the future, in example if we update to AGP 9.4.0.

Added a comment as it's not the first time the wrapper files update was moved after the root build.gradle update and broke in a following update.

