### PR TITLE
fix(android): reject JS promise when plugin invoke fails with PluginLoadException or InvalidPluginMethodException

### DIFF
--- a/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
+++ b/android/capacitor/src/main/java/com/getcapacitor/Bridge.java
@@ -845,6 +845,7 @@ public class Bridge {
                     }
                 } catch (PluginLoadException | InvalidPluginMethodException ex) {
                     Logger.error("Unable to execute plugin method", ex);
+                    call.errorCallback(ex.getMessage());
                 } catch (Exception ex) {
                     Logger.error("Serious error executing plugin", ex);
                     throw new RuntimeException(ex);

--- a/android/capacitor/src/test/java/com/getcapacitor/BridgeCallPluginMethodTest.java
+++ b/android/capacitor/src/test/java/com/getcapacitor/BridgeCallPluginMethodTest.java
@@ -1,0 +1,98 @@
+package com.getcapacitor;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.os.Handler;
+import java.lang.reflect.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * C-006: InvalidPluginMethodException / PluginLoadException during invoke must reject the JS call.
+ */
+public class BridgeCallPluginMethodTest {
+
+    // android.util.Log is not available in the JVM mockable jar; silence Logger
+    private MockedStatic<Logger> loggerMock;
+
+    @Before
+    public void setUp() {
+        loggerMock = org.mockito.Mockito.mockStatic(Logger.class);
+    }
+
+    @After
+    public void tearDown() {
+        loggerMock.close();
+    }
+
+    @Test
+    public void invalidPluginMethodCallsErrorCallback() throws Exception {
+        MessageHandler msgHandler = mock(MessageHandler.class);
+        PluginCall call = spy(new PluginCall(msgHandler, "TestPlugin", "cb1", "typoMethod", new JSObject()));
+
+        PluginHandle pluginHandle = mock(PluginHandle.class);
+        String errorMessage = "No method typoMethod found for plugin com.example.TestPlugin";
+        doThrow(new InvalidPluginMethodException(errorMessage)).when(pluginHandle).invoke(eq("typoMethod"), eq(call));
+
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getPlugin("TestPlugin")).thenReturn(pluginHandle);
+        setSyncTaskHandler(bridge);
+
+        doCallRealMethod().when(bridge).callPluginMethod("TestPlugin", "typoMethod", call);
+
+        bridge.callPluginMethod("TestPlugin", "typoMethod", call);
+
+        ArgumentCaptor<String> msg = ArgumentCaptor.forClass(String.class);
+        verify(call).errorCallback(msg.capture());
+        assertTrue(msg.getValue().contains("typoMethod"));
+    }
+
+    @Test
+    public void pluginLoadExceptionCallsErrorCallback() throws Exception {
+        MessageHandler msgHandler = mock(MessageHandler.class);
+        PluginCall call = spy(new PluginCall(msgHandler, "TestPlugin", "cb2", "getInfo", new JSObject()));
+
+        PluginHandle pluginHandle = mock(PluginHandle.class);
+        String errorMessage = "Unable to load plugin instance";
+        doThrow(new PluginLoadException(errorMessage)).when(pluginHandle).invoke(eq("getInfo"), eq(call));
+
+        Bridge bridge = mock(Bridge.class);
+        when(bridge.getPlugin("TestPlugin")).thenReturn(pluginHandle);
+        setSyncTaskHandler(bridge);
+
+        doCallRealMethod().when(bridge).callPluginMethod("TestPlugin", "getInfo", call);
+
+        bridge.callPluginMethod("TestPlugin", "getInfo", call);
+
+        ArgumentCaptor<String> msg = ArgumentCaptor.forClass(String.class);
+        verify(call).errorCallback(msg.capture());
+        assertTrue(msg.getValue().contains("Unable to load plugin instance"));
+    }
+
+    private static void setSyncTaskHandler(Bridge bridge) throws Exception {
+        Handler syncHandler = mock(Handler.class);
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return true;
+        })
+            .when(syncHandler)
+            .post(any(Runnable.class));
+
+        Field taskHandlerField = Bridge.class.getDeclaredField("taskHandler");
+        taskHandlerField.setAccessible(true);
+        taskHandlerField.set(bridge, syncHandler);
+    }
+}


### PR DESCRIPTION
## Problem

When `PluginHandle.invoke()` throws `PluginLoadException` or `InvalidPluginMethodException` inside the `taskHandler` runnable in `Bridge.callPluginMethod()`, the catch block only calls `Logger.error(...)` and never calls `call.errorCallback(...)`:

```java
} catch (PluginLoadException | InvalidPluginMethodException ex) {
    Logger.error("Unable to execute plugin method", ex);
    // call.errorCallback() was never invoked
}
```

As a result, the JS-side promise returned by `Capacitor.Plugins.*.method()` never settles — the caller `await`s forever with no error. A typical trigger is a typo'd method name on an existing plugin (e.g. `await Plugins.App.getInfoTypo()`), which throws `InvalidPluginMethodException` natively but leaves the JS promise pending forever.

The two neighboring error paths already reject the JS call:

- plugin id not found → `call.errorCallback(...)` (`Bridge.java` ~L822)
- outer `catch (Exception ex)` → `call.errorCallback(ex.toString())` (~L858)

Only the two invoke exceptions inside the runnable were missing the callback, so the promise hung instead of rejecting.

## Fix

Call `call.errorCallback(ex.getMessage())` in the `PluginLoadException | InvalidPluginMethodException` catch block, aligning it with the existing error paths. The error message now propagates to JS and the promise rejects.

## Testing

Added `BridgeCallPluginMethodTest` (JUnit 4, Mockito) covering both exception types:

- `invalidPluginMethodCallsErrorCallback` — plugin exists, method name is invalid → verifies `errorCallback` is invoked with a message containing the method name
- `pluginLoadExceptionCallsErrorCallback` — plugin fails to load → verifies `errorCallback` is invoked with the load-failure message

Full unit suite passes (`./gradlew -b capacitor/build.gradle testDebugUnitTest`, 50/50, including the new tests).

```js
// before fix: never settles
await Capacitor.Plugins.App.typoMethod(); // hangs forever

// after fix: rejects with the native error message
await Capacitor.Plugins.App.typoMethod(); // rejects: "No method typoMethod found for plugin com.example.App"
```
