### PR TITLE
fix(core): make registerPlugin proxy non-thenable to prevent silent await hangs

### DIFF
--- a/core/src/runtime.ts
+++ b/core/src/runtime.ts
@@ -167,6 +167,18 @@ export const createCapacitor = (win: WindowCapacitor): CapacitorInstance => {
             // https://github.com/facebook/react/issues/20030
             case '$$typeof':
               return undefined;
+            // https://tc39.es/ecma262/#sec-promiseresolvethenablejob
+            // The runtime probes `.then` on any value it adopts into a Promise
+            // (e.g. a plugin proxy returned from an async function). Returning
+            // a callable wrapper here would make the proxy look like a
+            // thenable, and `proxy.then(resolve, reject)` would dispatch a
+            // `then()` call to the native side that never settles — silently
+            // hanging the outer `await`. A plugin is not a Promise, so these
+            // must not be callable.
+            case 'then':
+            case 'catch':
+            case 'finally':
+              return undefined;
             case 'toJSON':
               return () => ({});
             case 'addListener':

--- a/core/src/tests/runtime.spec.ts
+++ b/core/src/tests/runtime.spec.ts
@@ -74,4 +74,24 @@ describe('runtime', () => {
     cap = createCapacitor(win);
     expect(cap.getServerUrl()).toBe('');
   });
+
+  it('registerPlugin proxy is not thenable', async () => {
+    cap = createCapacitor(win);
+    const plugin = cap.registerPlugin('Awesome');
+
+    // then/catch/finally must not produce callable method wrappers,
+    // otherwise the engine treats the proxy as a thenable
+    expect((plugin as any).then).toBeUndefined();
+    expect((plugin as any).catch).toBeUndefined();
+    expect((plugin as any).finally).toBeUndefined();
+
+    // a plugin proxy returned from an async function must not hang the await
+    await expect((async () => plugin)()).resolves.toBe(plugin);
+    await expect(Promise.resolve(plugin)).resolves.toBe(plugin);
+
+    // regular methods are unaffected
+    expect(typeof (plugin as any).someMethod).toBe('function');
+    expect((plugin as any).$$typeof).toBeUndefined();
+    expect((plugin as any).toJSON()).toEqual({});
+  });
 });


### PR DESCRIPTION
## Problem

The plugin `Proxy` in `registerPlugin()` ([`core/src/runtime.ts`](https://github.com/ionic-team/capacitor/blob/main/core/src/runtime.ts)) returns a callable method wrapper for **every** property name that isn't in its allowlist. The allowlist already special-cases `$$typeof` (facebook/react#20030) so React doesn't misclassify a plugin as a Lazy/Promise — but it doesn't cover the **language-level** thenable probe.

When any value is adopted into a Promise — most commonly a plugin proxy returned from an `async` function — the engine runs [`PromiseResolveThenableJob`](https://tc39.es/ecma262/#sec-promiseresolvethenablejob), which accesses `.then` and, if callable, invokes `proxy.then(resolve, reject)`.

For the plugin proxy:

1. `proxy.then` hits the `get` trap's `default` branch and returns a method wrapper.
2. The engine classifies the proxy as a thenable and calls `proxy.then(resolve, reject)`.
3. That dispatches a `then()` method call across the bridge. Plugins don't implement `then`, so the call never settles — the outer `await` **hangs forever**, and the `try/catch` at the call site can never reach the failure.

```js
// hangs forever with no error at the call site:
async function getPlugin() {
  return Capacitor.Plugins.PushNotifications;
}
const plugin = await getPlugin(); // never resolves
```

This is the same class of issue the `$$typeof` special case already fixed, but triggered by the language's own thenable adoption machinery instead of React's userland check.

## Fix

Return `undefined` for `then`, `catch`, and `finally` in the `get` trap, mirroring the existing `$$typeof` handling: a Capacitor plugin is not a Promise, so these names must not produce callables.

```diff
 case '$$typeof':
   return undefined;
+// https://tc39.es/ecma262/#sec-promiseresolvethenablejob
+// ...
+case 'then':
+case 'catch':
+case 'finally':
+  return undefined;
```

Why this is safe:

- `then` is probed by the language on every value adopted into a Promise; returning `undefined` makes the proxy a plain non-thenable, so `await` resolves to the proxy itself — same semantics as a plain object.
- `.then(...)` on **real promises returned by plugin methods** is unaffected — that's a Promise method, not a proxy `get`.
- No official or community plugin exposes methods named `then`/`catch`/`finally`; such names would already be hostile to Promise-using callers.

## Testing

Added a regression test to `core/src/tests/runtime.spec.ts` (verified it fails on `main` without the patch):

```js
it('registerPlugin proxy is not thenable', async () => {
  const plugin = cap.registerPlugin('Awesome');

  expect(plugin.then).toBeUndefined();
  expect(plugin.catch).toBeUndefined();
  expect(plugin.finally).toBeUndefined();

  // a plugin proxy returned from an async function must not hang the await
  await expect((async () => plugin)()).resolves.toBe(plugin);
  await expect(Promise.resolve(plugin)).resolves.toBe(plugin);

  // regular methods are unaffected
  expect(typeof plugin.someMethod).toBe('function');
  expect(plugin.$$typeof).toBeUndefined();
  expect(plugin.toJSON()).toEqual({});
});
```

Full suite passes: `cd core && npm run build && npm test` — 52/52 (was 51, +1).

Fixes #8469
Closes #8472
