### PR TITLE
fix(cli): remove AGP 9 property shims and jcenter() in cap migrate

### DIFF
--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -69,8 +69,6 @@ const agpMigrationAssistantProperties = [
 ];
 
 const jcenterLine = /^jcenter\(\)\s*(\/\/.*)?$/;
-const mavenCentralLine = /^mavenCentral\(\)\s*(\/\/.*)?$/;
-const repositoriesBlockStart = /(^|\s)repositories\s*\{/;
 
 export async function migrateCommand(config: Config, noprompt: boolean, packagemanager: string): Promise<void> {
   if (config === null) {
@@ -633,79 +631,32 @@ function removeAGPMigrationProperties(txt: string): string {
 }
 
 async function removeJCenter(config: Config): Promise<void> {
-  const gradleFiles = [
-    join(config.android.platformDirAbs, 'build.gradle'),
-    join(config.android.appDirAbs, 'build.gradle'),
-  ];
+  // jcenter() has only ever been in the root build.gradle of our templates, never in app/build.gradle
+  const filename = join(config.android.platformDirAbs, 'build.gradle');
+  const txt = readFile(filename);
+  if (!txt) {
+    return;
+  }
 
-  for (const filename of gradleFiles) {
-    const txt = readFile(filename);
-    if (!txt) {
-      continue;
-    }
-
-    const replaced = removeJCenterFromGradleFile(txt);
-    if (replaced !== txt) {
-      writeFileSync(filename, replaced, 'utf-8');
-    }
+  const replaced = removeJCenterFromGradleFile(txt);
+  if (replaced !== txt) {
+    writeFileSync(filename, replaced, 'utf-8');
   }
 }
 
+// mavenCentral() is not added back: it has been in the template since Capacitor 4 and the
+// 3 to 4 migrator always added it, so every app is assumed to declare it already
 function removeJCenterFromGradleFile(txt: string): string {
-  const lines = txt.split('\n');
-  const result: string[] = [];
-  let index = 0;
-
-  while (index < lines.length) {
-    // A commented out block start would make the brace counting below swallow the rest of the file
-    if (isCommentedOut(lines[index]) || !repositoriesBlockStart.test(lines[index])) {
-      result.push(lines[index]);
-      index++;
-      continue;
-    }
-
-    // Collect the whole block so nested ones (maven, flatDir) don't end it early
-    const block: string[] = [];
-    let depth = 0;
-    do {
-      const line = lines[index];
-      depth += (line.match(/{/g) ?? []).length - (line.match(/}/g) ?? []).length;
-      block.push(line);
-      index++;
-    } while (index < lines.length && depth > 0);
-
-    result.push(...replaceJCenterInRepositories(block));
-  }
-
-  return result.join('\n');
-}
-
-function isCommentedOut(line: string): boolean {
-  return line.trim().startsWith('//');
-}
-
-function replaceJCenterInRepositories(block: string[]): string[] {
-  if (!block.some((line) => jcenterLine.test(line.trim()))) {
-    return block;
-  }
-
-  const hasMavenCentral = block.some((line) => mavenCentralLine.test(line.trim()));
-  const replaced: string[] = [];
-  let mavenCentralAdded = false;
-
-  for (const line of block) {
-    if (!jcenterLine.test(line.trim())) {
-      replaced.push(line);
-    } else if (!hasMavenCentral && !mavenCentralAdded) {
-      replaced.push(line.replace('jcenter()', 'mavenCentral()'));
-      mavenCentralAdded = true;
-      logger.info(`Replaced jcenter() with mavenCentral().`);
-    } else {
+  return txt
+    .split('\n')
+    .filter((line) => {
+      if (!jcenterLine.test(line.trim())) {
+        return true;
+      }
       logger.info(`Removed jcenter().`);
-    }
-  }
-
-  return replaced;
+      return false;
+    })
+    .join('\n');
 }
 
 async function updateFile(

--- a/cli/src/tasks/migrate.ts
+++ b/cli/src/tasks/migrate.ts
@@ -51,6 +51,27 @@ const gradleVersion = '9.5.1';
 const iOSVersion = '16';
 let installFailed = false;
 
+// AGP 9 changed the defaults of these properties and Android Studio's AGP Upgrade Assistant
+// writes them into gradle.properties as compatibility shims. Capacitor apps need none of them,
+// most are deprecated and will be removed in AGP 10, and some (android.builtInKotlin,
+// android.sdk.defaultTargetSdkToCompileSdkIfUnset) break a Capacitor 9 build.
+const agpMigrationAssistantProperties = [
+  'android.builtInKotlin',
+  'android.defaults.buildfeatures.resvalues',
+  'android.dependency.useConstraints',
+  'android.enableAppCompileTimeRClass',
+  'android.newDsl',
+  'android.r8.optimizedResourceShrinking',
+  'android.r8.strictFullModeForKeepRules',
+  'android.sdk.defaultTargetSdkToCompileSdkIfUnset',
+  'android.uniquePackageNames',
+  'android.usesSdkInManifest.disallowed',
+];
+
+const jcenterLine = /^jcenter\(\)\s*(\/\/.*)?$/;
+const mavenCentralLine = /^mavenCentral\(\)\s*(\/\/.*)?$/;
+const repositoriesBlockStart = /(^|\s)repositories\s*\{/;
+
 export async function migrateCommand(config: Config, noprompt: boolean, packagemanager: string): Promise<void> {
   if (config === null) {
     fatal('Config data missing');
@@ -221,6 +242,17 @@ export async function migrateCommand(config: Config, noprompt: boolean, packagem
             );
             writeFileSync(settingsPath, txt, { encoding: 'utf-8' });
           })();
+        });
+
+        // gradle.properties
+        await runTask(`Migrating gradle.properties file.`, () => {
+          return updateGradleProperties(join(config.android.platformDirAbs, 'gradle.properties'));
+        });
+
+        // Gradle 9 removed jcenter(), so it has to go before the wrapper upgrade below or the
+        // wrapper task itself fails at the configuration phase once it runs on Gradle 9
+        await runTask(`Removing jcenter() from gradle files.`, () => {
+          return removeJCenter(config);
         });
 
         // Always run before root build.gradle changes as the AGP update could be incompatible with current gradle
@@ -574,6 +606,108 @@ def androidxEspressoCoreVersion = rootProject.ext.androidxEspressoCoreVersion
   writeFileSync(filename, replaced, 'utf-8');
 }
 
+async function updateGradleProperties(filename: string): Promise<void> {
+  const txt = readFile(filename);
+  if (!txt) {
+    return;
+  }
+
+  const replaced = removeAGPMigrationProperties(txt);
+  if (replaced !== txt) {
+    writeFileSync(filename, replaced, 'utf-8');
+  }
+}
+
+function removeAGPMigrationProperties(txt: string): string {
+  return txt
+    .split('\n')
+    .filter((line) => {
+      const property = line.split('=')[0].trim();
+      if (!agpMigrationAssistantProperties.includes(property)) {
+        return true;
+      }
+      logger.info(`Removed ${property} from gradle.properties.`);
+      return false;
+    })
+    .join('\n');
+}
+
+async function removeJCenter(config: Config): Promise<void> {
+  const gradleFiles = [
+    join(config.android.platformDirAbs, 'build.gradle'),
+    join(config.android.appDirAbs, 'build.gradle'),
+  ];
+
+  for (const filename of gradleFiles) {
+    const txt = readFile(filename);
+    if (!txt) {
+      continue;
+    }
+
+    const replaced = removeJCenterFromGradleFile(txt);
+    if (replaced !== txt) {
+      writeFileSync(filename, replaced, 'utf-8');
+    }
+  }
+}
+
+function removeJCenterFromGradleFile(txt: string): string {
+  const lines = txt.split('\n');
+  const result: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    // A commented out block start would make the brace counting below swallow the rest of the file
+    if (isCommentedOut(lines[index]) || !repositoriesBlockStart.test(lines[index])) {
+      result.push(lines[index]);
+      index++;
+      continue;
+    }
+
+    // Collect the whole block so nested ones (maven, flatDir) don't end it early
+    const block: string[] = [];
+    let depth = 0;
+    do {
+      const line = lines[index];
+      depth += (line.match(/{/g) ?? []).length - (line.match(/}/g) ?? []).length;
+      block.push(line);
+      index++;
+    } while (index < lines.length && depth > 0);
+
+    result.push(...replaceJCenterInRepositories(block));
+  }
+
+  return result.join('\n');
+}
+
+function isCommentedOut(line: string): boolean {
+  return line.trim().startsWith('//');
+}
+
+function replaceJCenterInRepositories(block: string[]): string[] {
+  if (!block.some((line) => jcenterLine.test(line.trim()))) {
+    return block;
+  }
+
+  const hasMavenCentral = block.some((line) => mavenCentralLine.test(line.trim()));
+  const replaced: string[] = [];
+  let mavenCentralAdded = false;
+
+  for (const line of block) {
+    if (!jcenterLine.test(line.trim())) {
+      replaced.push(line);
+    } else if (!hasMavenCentral && !mavenCentralAdded) {
+      replaced.push(line.replace('jcenter()', 'mavenCentral()'));
+      mavenCentralAdded = true;
+      logger.info(`Replaced jcenter() with mavenCentral().`);
+    } else {
+      logger.info(`Removed jcenter().`);
+    }
+  }
+
+  return replaced;
+}
+
 async function updateFile(
   config: Config,
   filename: string,
@@ -684,3 +818,11 @@ async function updateAppDelegate(filename: string) {
     writeFileSync(filename, replaced, 'utf-8');
   }
 }
+
+export const __testables = {
+  agpMigrationAssistantProperties,
+  removeAGPMigrationProperties,
+  removeJCenter,
+  removeJCenterFromGradleFile,
+  updateGradleProperties,
+};

--- a/cli/test/migrate-android-gradle.spec.ts
+++ b/cli/test/migrate-android-gradle.spec.ts
@@ -148,7 +148,7 @@ describe('removeJCenterFromGradleFile', () => {
     jest.restoreAllMocks();
   });
 
-  it('replaces jcenter() with mavenCentral() when the block has no mavenCentral()', () => {
+  it('removes the jcenter() line and leaves the rest of the block alone', () => {
     // Arrange
     const txt = 'buildscript {\n    repositories {\n        google()\n        jcenter()\n    }\n}\n';
 
@@ -156,10 +156,10 @@ describe('removeJCenterFromGradleFile', () => {
     const result = removeJCenterFromGradleFile(txt);
 
     // Assert
-    expect(result).toBe('buildscript {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n');
+    expect(result).toBe('buildscript {\n    repositories {\n        google()\n    }\n}\n');
   });
 
-  it('drops jcenter() without duplicating an existing mavenCentral()', () => {
+  it('removes jcenter() from every repositories block', () => {
     // Arrange
     const txt = ROOT_BUILD_GRADLE_WITH_JCENTER;
 
@@ -168,57 +168,21 @@ describe('removeJCenterFromGradleFile', () => {
 
     // Assert
     expect(result).not.toContain('jcenter()');
-    expect(result.match(/mavenCentral\(\)/g)).toHaveLength(2);
+    expect(result.match(/mavenCentral\(\)/g)).toHaveLength(1);
   });
 
-  it('adds mavenCentral() to the buildscript block that was missing it', () => {
+  it('does not add mavenCentral() to a block that lacks it', () => {
     // Arrange
-    const txt = ROOT_BUILD_GRADLE_WITH_JCENTER;
+    const txt = 'buildscript {\n    repositories {\n        google()\n        jcenter()\n    }\n}\n';
 
     // Act
     const result = removeJCenterFromGradleFile(txt);
 
     // Assert
-    expect(result).toContain('buildscript {\n    repositories {\n        google()\n        mavenCentral()\n    }');
+    expect(result).not.toContain('mavenCentral()');
   });
 
-  it('keeps nested blocks intact when removing jcenter()', () => {
-    // Arrange
-    const txt = APP_BUILD_GRADLE_WITH_FLATDIR;
-
-    // Act
-    const result = removeJCenterFromGradleFile(txt);
-
-    // Assert
-    expect(result).not.toContain('jcenter()');
-    expect(result).toContain("        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'");
-    expect(result).toContain('    flatDir{');
-    expect(result).toContain('    mavenCentral()');
-  });
-
-  it('does not add mavenCentral() to repositories blocks that never had jcenter()', () => {
-    // Arrange
-    const txt = "repositories {\n    flatDir{\n        dirs 'libs'\n    }\n}\n";
-
-    // Act
-    const result = removeJCenterFromGradleFile(txt);
-
-    // Assert
-    expect(result).toBe(txt);
-  });
-
-  it('preserves the indentation of the line it replaces', () => {
-    // Arrange
-    const txt = 'repositories {\n\t\tjcenter()\n}\n';
-
-    // Act
-    const result = removeJCenterFromGradleFile(txt);
-
-    // Assert
-    expect(result).toBe('repositories {\n\t\tmavenCentral()\n}\n');
-  });
-
-  it('keeps a trailing comment on the replaced line', () => {
+  it('removes a jcenter() line that carries a trailing comment', () => {
     // Arrange
     const txt = 'repositories {\n    jcenter() // legacy artifacts\n}\n';
 
@@ -226,10 +190,10 @@ describe('removeJCenterFromGradleFile', () => {
     const result = removeJCenterFromGradleFile(txt);
 
     // Assert
-    expect(result).toBe('repositories {\n    mavenCentral() // legacy artifacts\n}\n');
+    expect(result).toBe('repositories {\n}\n');
   });
 
-  it('ignores jcenter() outside of a repositories block', () => {
+  it('leaves a commented out jcenter() alone', () => {
     // Arrange
     const txt =
       '// jcenter() was removed in Gradle 9\ntask clean(type: Delete) {\n    delete rootProject.buildDir\n}\n';
@@ -239,19 +203,6 @@ describe('removeJCenterFromGradleFile', () => {
 
     // Assert
     expect(result).toBe(txt);
-  });
-
-  it('does not treat a commented out block start as a repositories block', () => {
-    // Arrange
-    const txt = '// repositories {\nallprojects {\n    repositories {\n        google()\n        jcenter()\n    }\n}\n';
-
-    // Act
-    const result = removeJCenterFromGradleFile(txt);
-
-    // Assert
-    expect(result).toBe(
-      '// repositories {\nallprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n',
-    );
   });
 
   it('returns the file unchanged when there is no jcenter()', () => {
@@ -312,7 +263,19 @@ describe('android gradle migration against a project on disk', () => {
     }
   });
 
-  it('removes jcenter() from both the root and the app build.gradle', async () => {
+  it('removes jcenter() from the root build.gradle', async () => {
+    // Arrange
+    const rootPath = join(platformDir, 'build.gradle');
+    writeFileSync(rootPath, ROOT_BUILD_GRADLE_WITH_JCENTER, 'utf-8');
+
+    // Act
+    await removeJCenter(makeConfig());
+
+    // Assert
+    expect(read(rootPath)).not.toContain('jcenter()');
+  });
+
+  it('leaves the app build.gradle alone', async () => {
     // Arrange
     const rootPath = join(platformDir, 'build.gradle');
     const appPath = join(appDir, 'build.gradle');
@@ -323,9 +286,7 @@ describe('android gradle migration against a project on disk', () => {
     await removeJCenter(makeConfig());
 
     // Assert
-    expect(read(rootPath)).not.toContain('jcenter()');
-    expect(read(appPath)).not.toContain('jcenter()');
-    expect(read(appPath)).toContain('    mavenCentral()');
+    expect(read(appPath)).toBe(APP_BUILD_GRADLE_WITH_FLATDIR);
   });
 
   it('leaves a clean project untouched', async () => {
@@ -339,17 +300,5 @@ describe('android gradle migration against a project on disk', () => {
 
     // Assert
     expect(read(rootPath)).toBe(clean);
-  });
-
-  it('does not fail when the app build.gradle is missing', async () => {
-    // Arrange
-    const rootPath = join(platformDir, 'build.gradle');
-    writeFileSync(rootPath, ROOT_BUILD_GRADLE_WITH_JCENTER, 'utf-8');
-
-    // Act
-    await removeJCenter(makeConfig());
-
-    // Assert
-    expect(read(rootPath)).not.toContain('jcenter()');
   });
 });

--- a/cli/test/migrate-android-gradle.spec.ts
+++ b/cli/test/migrate-android-gradle.spec.ts
@@ -1,0 +1,355 @@
+import { mkdirp, readFileSync, writeFileSync } from 'fs-extra';
+import { join } from 'path';
+
+import type { Config } from '../src/definitions';
+import { logger } from '../src/log';
+import { __testables } from '../src/tasks/migrate';
+
+import { mktmp } from './util';
+
+const {
+  agpMigrationAssistantProperties,
+  removeAGPMigrationProperties,
+  removeJCenter,
+  removeJCenterFromGradleFile,
+  updateGradleProperties,
+} = __testables;
+
+// gradle.properties of a Capacitor 8 app after running the AGP 9 Upgrade Assistant
+const ASSISTANT_MIGRATED_PROPERTIES = `# Project-wide Gradle settings.
+
+org.gradle.jvmargs=-Xmx1536m
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false
+`;
+
+const ROOT_BUILD_GRADLE_WITH_JCENTER = `buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.13.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+    }
+}
+`;
+
+// Capacitor 8 app/build.gradle, whose only repositories block wraps a nested flatDir block
+const APP_BUILD_GRADLE_WITH_FLATDIR = `apply plugin: 'com.android.application'
+
+repositories {
+    flatDir{
+        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
+    }
+    jcenter()
+}
+
+dependencies {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+}
+`;
+
+describe('removeAGPMigrationProperties', () => {
+  beforeEach(() => {
+    jest.spyOn(logger, 'info').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('removes every property injected by the AGP 9 Upgrade Assistant', () => {
+    // Arrange
+    const txt = ASSISTANT_MIGRATED_PROPERTIES;
+
+    // Act
+    const result = removeAGPMigrationProperties(txt);
+
+    // Assert
+    for (const property of agpMigrationAssistantProperties) {
+      expect(result).not.toContain(property);
+    }
+  });
+
+  it('keeps properties a Capacitor app still needs', () => {
+    // Arrange
+    const txt = ASSISTANT_MIGRATED_PROPERTIES;
+
+    // Act
+    const result = removeAGPMigrationProperties(txt);
+
+    // Assert
+    expect(result).toContain('android.useAndroidX=true');
+    expect(result).toContain('org.gradle.jvmargs=-Xmx1536m');
+    expect(result).toContain('# Project-wide Gradle settings.');
+  });
+
+  it('removes properties written with spaces around the separator', () => {
+    // Arrange
+    const txt = 'android.newDsl = false\nandroid.useAndroidX=true\n';
+
+    // Act
+    const result = removeAGPMigrationProperties(txt);
+
+    // Assert
+    expect(result).toBe('android.useAndroidX=true\n');
+  });
+
+  it('leaves commented out properties alone', () => {
+    // Arrange
+    const txt = '#android.newDsl=false\n# android.builtInKotlin=false\n';
+
+    // Act
+    const result = removeAGPMigrationProperties(txt);
+
+    // Assert
+    expect(result).toBe(txt);
+  });
+
+  it('returns the file unchanged when no property was injected', () => {
+    // Arrange
+    const txt = 'org.gradle.jvmargs=-Xmx1536m\nandroid.useAndroidX=true\n';
+
+    // Act
+    const result = removeAGPMigrationProperties(txt);
+
+    // Assert
+    expect(result).toBe(txt);
+  });
+});
+
+describe('removeJCenterFromGradleFile', () => {
+  beforeEach(() => {
+    jest.spyOn(logger, 'info').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('replaces jcenter() with mavenCentral() when the block has no mavenCentral()', () => {
+    // Arrange
+    const txt = 'buildscript {\n    repositories {\n        google()\n        jcenter()\n    }\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe('buildscript {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n');
+  });
+
+  it('drops jcenter() without duplicating an existing mavenCentral()', () => {
+    // Arrange
+    const txt = ROOT_BUILD_GRADLE_WITH_JCENTER;
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).not.toContain('jcenter()');
+    expect(result.match(/mavenCentral\(\)/g)).toHaveLength(2);
+  });
+
+  it('adds mavenCentral() to the buildscript block that was missing it', () => {
+    // Arrange
+    const txt = ROOT_BUILD_GRADLE_WITH_JCENTER;
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toContain('buildscript {\n    repositories {\n        google()\n        mavenCentral()\n    }');
+  });
+
+  it('keeps nested blocks intact when removing jcenter()', () => {
+    // Arrange
+    const txt = APP_BUILD_GRADLE_WITH_FLATDIR;
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).not.toContain('jcenter()');
+    expect(result).toContain("        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'");
+    expect(result).toContain('    flatDir{');
+    expect(result).toContain('    mavenCentral()');
+  });
+
+  it('does not add mavenCentral() to repositories blocks that never had jcenter()', () => {
+    // Arrange
+    const txt = "repositories {\n    flatDir{\n        dirs 'libs'\n    }\n}\n";
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe(txt);
+  });
+
+  it('preserves the indentation of the line it replaces', () => {
+    // Arrange
+    const txt = 'repositories {\n\t\tjcenter()\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe('repositories {\n\t\tmavenCentral()\n}\n');
+  });
+
+  it('keeps a trailing comment on the replaced line', () => {
+    // Arrange
+    const txt = 'repositories {\n    jcenter() // legacy artifacts\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe('repositories {\n    mavenCentral() // legacy artifacts\n}\n');
+  });
+
+  it('ignores jcenter() outside of a repositories block', () => {
+    // Arrange
+    const txt =
+      '// jcenter() was removed in Gradle 9\ntask clean(type: Delete) {\n    delete rootProject.buildDir\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe(txt);
+  });
+
+  it('does not treat a commented out block start as a repositories block', () => {
+    // Arrange
+    const txt = '// repositories {\nallprojects {\n    repositories {\n        google()\n        jcenter()\n    }\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe(
+      '// repositories {\nallprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n',
+    );
+  });
+
+  it('returns the file unchanged when there is no jcenter()', () => {
+    // Arrange
+    const txt = 'allprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n';
+
+    // Act
+    const result = removeJCenterFromGradleFile(txt);
+
+    // Assert
+    expect(result).toBe(txt);
+  });
+});
+
+describe('android gradle migration against a project on disk', () => {
+  let tmpDir: any;
+  let platformDir: string;
+  let appDir: string;
+
+  beforeEach(async () => {
+    jest.spyOn(logger, 'info').mockImplementation();
+    jest.spyOn(logger, 'error').mockImplementation();
+
+    tmpDir = await mktmp();
+    platformDir = join(tmpDir.path, 'android');
+    appDir = join(platformDir, 'app');
+    await mkdirp(appDir);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    tmpDir.cleanupCallback();
+  });
+
+  function makeConfig(): Config {
+    return {
+      android: { platformDirAbs: platformDir, appDirAbs: appDir },
+    } as unknown as Config;
+  }
+
+  function read(filename: string): string {
+    return readFileSync(filename, 'utf-8');
+  }
+
+  it('rewrites gradle.properties in place', async () => {
+    // Arrange
+    const propertiesPath = join(platformDir, 'gradle.properties');
+    writeFileSync(propertiesPath, ASSISTANT_MIGRATED_PROPERTIES, 'utf-8');
+
+    // Act
+    await updateGradleProperties(propertiesPath);
+
+    // Assert
+    const result = read(propertiesPath);
+    expect(result).toContain('android.useAndroidX=true');
+    for (const property of agpMigrationAssistantProperties) {
+      expect(result).not.toContain(property);
+    }
+  });
+
+  it('removes jcenter() from both the root and the app build.gradle', async () => {
+    // Arrange
+    const rootPath = join(platformDir, 'build.gradle');
+    const appPath = join(appDir, 'build.gradle');
+    writeFileSync(rootPath, ROOT_BUILD_GRADLE_WITH_JCENTER, 'utf-8');
+    writeFileSync(appPath, APP_BUILD_GRADLE_WITH_FLATDIR, 'utf-8');
+
+    // Act
+    await removeJCenter(makeConfig());
+
+    // Assert
+    expect(read(rootPath)).not.toContain('jcenter()');
+    expect(read(appPath)).not.toContain('jcenter()');
+    expect(read(appPath)).toContain('    mavenCentral()');
+  });
+
+  it('leaves a clean project untouched', async () => {
+    // Arrange
+    const rootPath = join(platformDir, 'build.gradle');
+    const clean = 'allprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}\n';
+    writeFileSync(rootPath, clean, 'utf-8');
+
+    // Act
+    await removeJCenter(makeConfig());
+
+    // Assert
+    expect(read(rootPath)).toBe(clean);
+  });
+
+  it('does not fail when the app build.gradle is missing', async () => {
+    // Arrange
+    const rootPath = join(platformDir, 'build.gradle');
+    writeFileSync(rootPath, ROOT_BUILD_GRADLE_WITH_JCENTER, 'utf-8');
+
+    // Act
+    await removeJCenter(makeConfig());
+
+    // Assert
+    expect(read(rootPath)).not.toContain('jcenter()');
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Extends `cap migrate` with two Android cleanup steps that Gradle 9 / AGP 9 make necessary:

1. **`gradle.properties`**: removes the 10 compatibility flags that Android Studio's AGP Upgrade Assistant writes to preserve the AGP 8 defaults. `android.useAndroidX=true` is kept.
2. **`jcenter()`**: removes it from `android/build.gradle`.

Both steps run **before** the gradle wrapper upgrade. The wrapper task runs on Gradle 9.5.1 the second time around, so a leftover `jcenter()` would fail it at the configuration phase and the wrapper upgrade would be lost.

`mavenCentral()` is not added back, and `android/app/build.gradle` is not scanned, per review feedback: the 3 -> 4 migrator always added `mavenCentral()` regardless of the opt-in `jcenter()` removal, it has been in the template since Capacitor 4, and `jcenter()` has only ever been in the root `build.gradle` of the templates.

Adds `cli/test/migrate-android-gradle.spec.ts`: 15 tests covering the transformations and a block that runs them against a project on disk.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
Users have been running the AGP 9 migration in Android Studio while still on Capacitor 8. The Assistant injects flags that a Capacitor app does not need: most are deprecated and will be removed in AGP 10, and a couple break a Capacitor 9 build (`android.builtInKotlin=false` disables the Kotlin support AGP 9 now bundles, `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` stops AGP from inferring `targetSdkVersion`).

`RepositoryHandler.jcenter()` was removed in Gradle 9.0. Any `build.gradle` that still calls it fails immediately at the configuration phase with `Could not find method jcenter()`.

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web